### PR TITLE
feat(prompts): add github-add-issue prompt and github-issue-manager chatmode with delegation pattern

### DIFF
--- a/.github/chatmodes/github-issue-manager.chatmode.md
+++ b/.github/chatmodes/github-issue-manager.chatmode.md
@@ -19,6 +19,24 @@ You are an interactive GitHub issue management assistant that helps users file i
 
 Follow markdown styling from #file:../instructions/markdown.instructions.md
 
+## Configuration
+
+### Artifact Base Path
+
+All artifacts stored in: `.copilot-tracking/github-issues/`
+
+### File Naming Conventions
+
+* Issue creation: `issue-{number}.md`
+* Navigation sessions: `issues-list-{timestamp}.md`
+* Search sessions: `search-{timestamp}.md`
+* Session state: `session-state.md`
+* Working drafts: `draft-issue.md`, `current-filters.md`
+
+### Timestamp Format
+
+Use ISO 8601 format: `YYYYMMDD-HHMMSS`
+
 ## Workflow Modes
 
 ### Issue Creation Workflow
@@ -96,28 +114,6 @@ Maintain session context:
 
 Use this context to offer shortcuts: "Would you like to see the bug reports again, or switch to feature requests?"
 
-#### Artifact Logging
-
-Log navigation sessions to `.copilot-tracking/github-issues/issues-list.md`:
-
-```markdown
-# Issue Navigation Session
-
-**Timestamp**: {timestamp}
-**Filters Applied**: state=open, labels=bug,triage
-
-## Results ({count} issues)
-
-* #42: [Bug]: Login button broken
-* #41: [Bug]: Search not working
-* #38: [Bug]: Profile page crashes
-
-## Actions Taken
-
-* Viewed details for #42
-* Added comment to #41
-```
-
 ### Issue Search Workflow
 
 Help users find issues using natural language queries.
@@ -171,7 +167,7 @@ After presenting search results:
 
 Enable smooth transitions between workflows.
 
-#### Artifact Logging
+#### Search Logging
 
 Log searches to `.copilot-tracking/github-issues/search-{timestamp}.md`:
 
@@ -208,7 +204,82 @@ Maintain session-level state to provide contextual, efficient assistance:
 
 ### Session State Persistence
 
-Store session state in `.copilot-tracking/github-issues/session-state.md`:
+Store session state using the configured file naming conventions (see Configuration section).
+
+> **Note**: Session state is designed for single-user local development environments. For multi-user scenarios, consider using separate workspace clones or user-specific directories to prevent session state conflicts.
+
+Use session state to:
+
+* Resume interrupted workflows
+* Suggest next actions based on patterns
+* Provide contextual shortcuts
+
+## Artifact Management
+
+### Artifact Types and Purposes
+
+* **Issue Creation Logs**: Document issue creation process and final results
+* **Navigation Sessions**: Track issue browsing and filtering activities
+* **Search Sessions**: Record search queries, results, and refinements
+* **Session State**: Maintain workflow context across interactions
+* **Working Files**: Temporary files for active workflows
+
+### Artifact Content Standards
+
+All artifact files must follow markdown standards (see Instructions Reference):
+
+* Start with level-1 heading as title
+* Use ATX-style headings (`#`, `##`, `###`)
+* Use `*` for unordered lists
+* Specify language for all code blocks
+* One blank line around headings, lists, code blocks
+* No trailing spaces
+* Files end with single newline
+
+### Logging Examples
+
+#### Issue Navigation Session
+
+```markdown
+# Issue Navigation Session
+
+**Timestamp**: {timestamp}
+**Filters Applied**: state=open, labels=bug,triage
+
+## Results ({count} issues)
+
+* #42: [Bug]: Login button broken
+* #41: [Bug]: Search not working
+* #38: [Bug]: Profile page crashes
+
+## Actions Taken
+
+* Viewed details for #42
+* Added comment to #41
+```
+
+#### Search Session
+
+```markdown
+# Issue Search Session
+
+**Timestamp**: {timestamp}
+**Query**: "bugs assigned to John"
+**GitHub Query**: `is:issue label:bug assignee:john`
+
+## Results ({count} issues)
+
+* #42: [Bug]: Login button broken (score: 0.95)
+* #38: [Bug]: Profile page crashes (score: 0.88)
+
+## Refinements
+
+1. Initial query: bugs
+2. Added filter: assignee:john
+3. Final query: is:issue label:bug assignee:john
+```
+
+#### Session State
 
 ```markdown
 # GitHub Issue Manager Session State
@@ -234,51 +305,9 @@ Store session state in `.copilot-tracking/github-issues/session-state.md`:
 * Typical assignee: john
 ```
 
-Use this state to:
+### Working Files Management
 
-* Resume interrupted workflows
-* Suggest next actions based on patterns
-* Provide contextual shortcuts
-
-## Output Requirements
-
-### Artifact Files
-
-All artifacts are stored in `.copilot-tracking/github-issues/`:
-
-* `issue-{number}.md`: Individual issue creation logs
-* `issues-list.md`: Navigation session logs
-* `search-{timestamp}.md`: Search session logs
-* `session-state.md`: Current session state
-
-### Artifact Naming Conventions
-
-* Use issue number in filenames when available
-* Use ISO 8601 timestamps for time-based logs (YYYYMMDD-HHMMSS)
-* Use kebab-case for descriptive elements
-
-### Markdown Formatting
-
-All artifact files must follow the markdown standards from markdown.instructions.md:
-
-* Start with level-1 heading as title
-* Use ATX-style headings (`#`, `##`, `###`)
-* Use `*` for unordered lists
-* Specify language for all code blocks
-* One blank line around headings, lists, code blocks
-* No trailing spaces
-* Files end with single newline
-
-## File Management
-
-### Working Files
-
-During active workflows, maintain working files:
-
-* `.copilot-tracking/github-issues/draft-issue.md`: Issue being composed
-* `.copilot-tracking/github-issues/current-filters.md`: Active filter state
-
-### Cleanup
+During active workflows, maintain working files as defined in Configuration section.
 
 After workflow completion:
 

--- a/.github/prompts/github-add-issue.prompt.md
+++ b/.github/prompts/github-add-issue.prompt.md
@@ -137,8 +137,14 @@ You WILL collect all required and optional field values from the user.
    * Accept empty values for optional fields
 4. Apply template defaults:
    * Use template's default title pattern if user didn't override
-   * Merge template's default labels with user-provided labels
-   * Merge template's default assignees with user-provided assignees
+   * Merge template's default labels with user-provided labels:
+     * Remove duplicates (case-insensitive comparison)
+     * Order: template labels first, then user-provided labels
+     * Normalize to lowercase for consistency
+   * Merge template's default assignees with user-provided assignees:
+     * Remove duplicates (case-insensitive comparison)
+     * Order: template assignees first, then user-provided assignees
+     * Normalize to lowercase for consistency
 5. Build final issue data structure
 
 **Conversation Flow Example**:
@@ -174,7 +180,11 @@ You WILL create the GitHub issue using MCP tools.
 
 1. Use `mcp_github_create_issue` tool with collected data:
    * `title`: Final issue title
-   * `body`: Formatted issue body with all field values
+   * `body`: Formatted issue body with all field values using markdown structure:
+     * **Field Name**: Value (for each collected field)
+     * Blank line between each field for readability
+     * Preserve original field formatting and line breaks
+     * Example: "**Description**: User's issue description\n\n**Priority**: High"
    * `labels`: Array of label strings
    * `assignees`: Array of assignee usernames
 2. Handle tool response:


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a new GitHub issue creation prompt and chatmode using a delegation pattern. The chatmode orchestrates issue creation by invoking the `github-add-issue.prompt.md` as a subagent, while the prompt contains the complete implementation logic for template discovery, field collection, and issue creation.

- **feat**(_prompts_): added github-add-issue.prompt.md with directive "You WILL" language style, numbered protocol sections for template discovery, selection, field collection, issue creation, and artifact logging

- **feat**(_prompts_): added github-issue-manager.chatmode.md with Issue Creation Workflow that delegates to github-add-issue prompt, plus Navigation and Search workflows for browsing and finding issues

- **feat**(_prompts_): implemented delegation protocol with parameter passing for templateName, title, labels, and assignees, plus post-creation actions for workflow orchestration

## Related Issue(s)

Closes #53
Closes #54

## Type of Change

- [x] New prompt template
- [x] New chat mode/agent

## Testing

- Verified prompt file follows ADO prompt patterns with directive language and numbered sections
- Verified chatmode delegation protocol correctly references the prompt file
- Confirmed both files pass linter checks (note: linter warning about chatmode→agent migration is informational)
- Updated Issue #53 description to reflect delegation architecture

## Checklist

### Required Checks
- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### Future Automated Checks
- [x] All linting checks pass
- [x] Tables are properly formatted

## Security Considerations

- [x] This PR does not contain any sensitive information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

- The chatmode file shows a linter warning about chatmodes being renamed to agents and suggesting migration to `.github/agents/` directory with `.agent.md` extension - this is a future migration task
- Both files created as new additions to the repository with comprehensive issue management capabilities
- Issue #53 was updated to reflect the new delegation architecture

🔄 - Generated by Copilot