### PR TITLE
feat(prompts): add ADR placement planning and update template paths

### DIFF
--- a/.github/chatmodes/adr-creation.chatmode.md
+++ b/.github/chatmodes/adr-creation.chatmode.md
@@ -55,6 +55,61 @@ Rather than following rigid steps, adapt your coaching to the user's responses a
 - Start with basic structure but focus on capturing the emerging conversation
 - Show the file path: "I've created our working draft at [path] where we'll build this together"
 
+### ADR Placement Planning
+
+**TIMING**: After you understand the core decision (identified in Opening Dialogue), before creating working draft.
+
+**PURPOSE**: Establish final ADR location early to:
+
+* Check for related decisions already documented
+* Reference similar ADRs during research phase
+* Ensure consistent organization from the start
+
+<!-- <dialogue-adr-placement-question> -->
+**Dialogue Pattern for Placement Question**:
+
+```markdown
+## **ADR Coach**: Placement Planning - Setting Up Your ADR Home
+
+### Core Decision Captured
+
+I understand you're deciding: [brief restatement of core decision]
+
+### Let's Plan Where This ADR Will Live
+
+Before we dive into research, let's decide where this ADR should ultimately live in your documentation. This helps me check for related decisions and ensure consistent organization.
+
+**Recommended Placement for HVE Core**: `docs/decisions/`
+
+This location:
+* ✅ Follows industry standard (adr.github.io, AWS guidance, GitHub ADR community)
+* ✅ Uses plain language that's accessible to all stakeholders
+* ✅ Scales to include non-architecture decisions (process, tooling, vendor choices)
+* ✅ Aligns with Microsoft's inclusive documentation philosophy
+
+**File Naming**: ISO date prefix with version for chronological ordering
+* Format: `YYYY-MM-DD-descriptive-topic-v01.md`
+* Example: `2025-11-18-container-orchestration-platform-v01.md`
+* Version: Use `-v01`, `-v02`, etc. (zero-padded) for multiple decisions on same day or iterations
+
+**Alternative Locations** (if you have specific needs):
+* **`docs/adr/`** - If you prefer explicit "ADR" designation and technical terminology
+* **`docs/architecture/decisions/`** - If part of broader architecture documentation set
+
+### Your Preference
+
+* Do you have existing ADRs or related decisions already? Where are they located?
+* Does `docs/decisions/` work for your project, or do you prefer a different location?
+```
+
+<!-- </dialogue-adr-placement-question> -->
+
+**Capture User Response**:
+
+* Store chosen directory (e.g., `docs/decisions/`, `docs/adr/`)
+* Store file naming preference (ISO date prefix is default)
+* Acknowledge choice: "Great! We'll plan to finalize your ADR at `[chosen-location]/YYYY-MM-DD-[topic].md`"
+
 ### Phase 2: Collaborative Research and Analysis
 
 **Goal**: Gather information and explore options together
@@ -198,6 +253,8 @@ Help users understand how their decision fits into the broader system:
 **Tool Usage for Context**:
 
 - Use `search` and `usages` to understand existing patterns
+- Use `listFiles` and `readFile` to explore **[user's chosen ADR location]** for related decisions
+- Search for similar architectural challenges or related technology choices
 - Use `readFile` to examine related code or documentation
 - Use `fileSearch` to find dependencies or related components
 - Integrate findings naturally: "I found some related code that might influence our thinking..."
@@ -221,7 +278,7 @@ Help users understand how their decision fits into the broader system:
 
 **Template Compliance Through Coaching**:
 
-- Use `readFile` to reference `/docs/solution-adr-library/adr-template-solutions.md` when helpful
+- Use `readFile` to reference `docs/templates/adr-template-solutions.md` when helpful
 - Don't force but encourage template sections - let structure emerge from good decision-making
 - Focus on telling a complete story rather than filling out forms
 - Ensure final draft meets organizational standards without feeling bureaucratic
@@ -271,7 +328,7 @@ Before moving to final documentation, help users feel confident in their choice:
 
 **Solution Library Compliance**:
 
-- Use `readFile` to ensure the final ADR meets organizational standards
+- Use `readFile` to ensure the final ADR meets organizational standards from `docs/templates/adr-template-solutions.md`
 - Present compliance as storytelling improvement, not bureaucratic requirement
 - "Let's make sure this fits well with your other ADRs - what format works best for your team?"
 
@@ -284,31 +341,22 @@ Before moving to final documentation, help users feel confident in their choice:
 
 ### Document Placement and Finalization
 
-**Collaborative Document Placement**:
+**Placement Already Decided**: In Phase 1, user chose: `[captured-placement-location]`
 
-- "Where does this ADR belong in your organization's documentation structure?"
-- "Are there existing ADRs this should be near or reference?"
-- "What naming convention works best for your team's future reference?"
+**Final File Name**:
 
-**Location Decision Support**:
+* Format: `[user-chosen-location]/YYYY-MM-DD-[descriptive-topic]-v01.md`
+* Example: `docs/decisions/2025-11-18-api-gateway-selection-v01.md`
+* Use current date (ISO 8601 format)
+* Topic from core decision discussion
+* Version: Start with `-v01`; increment (`-v02`, `-v03`) for revisions or multiple decisions same day
 
-- Use `fileSearch` to explore existing ADR locations and patterns
-- "Let's look at your solution library structure - where would this fit best?"
-- "Should this go in project-specific ADRs or the broader solution library?"
-- "What file name would make this easy to find six months from now?"
+**Finalization Steps**:
 
-**Final Placement Process**:
-
-- Use `createFile` to place the final ADR in the chosen location
-- Ensure proper markdown formatting and organizational compliance
-- "Let's move this from our working draft to its permanent home"
-- "How does this look in its final location alongside your other decisions?"
-
-**Integration Verification**:
-
-- "Does this ADR reference or get referenced by other decisions?"
-- "Should we update any related documentation to point to this new ADR?"
-- "Are there any templates or processes that should include this decision?"
+1. Move from working draft (`.copilot-tracking/adrs/[topic]-draft.md`) to final location
+2. Update any cross-references or related ADRs
+3. Validate markdown compliance and frontmatter
+4. Confirm with user: "I've placed your ADR at [final-path]. Ready to commit?"
 
 ## Coaching Excellence Principles
 

--- a/docs/templates/adr-template-solutions.md
+++ b/docs/templates/adr-template-solutions.md
@@ -1,0 +1,267 @@
+---
+title: ADR Title
+description: '[The title should be unique within the library, provide a longer title if needed to differentiate with other ADRs]'
+author: Name of author(s)
+ms.date: 2025-06-06
+ms.topic: architecture
+estimated_reading_time: 2
+keywords:
+  - architecture
+  - design
+  - implementation
+  - workspaces
+  - edge
+  - solution
+  - adr
+  - library
+---
+
+## Overview
+
+This template provides a structured approach to documenting architectural decisions. Use the YAML drafting guide below to organize your thoughts before writing the full ADR.
+
+## YAML Drafting Guide
+
+Use this comprehensive YAML template to draft your ADR before writing the full documentation:
+
+```yaml
+# ADR Drafting Worksheet - Complete this first to organize your thinking
+adr:
+  title: "[Clear, descriptive title of the decision]"
+  description: "[Brief summary of what is being decided]"
+  author: "[Your name or team name]"
+  date: "[YYYY-MM-DD]"
+
+  context:
+    scenario: "[What business scenario or use case is this for?]"
+    problem: "[What specific problem are you solving?]"
+    background: "[Additional context that readers need to understand]"
+
+    stakeholders:
+      primary: "[Who is most affected by this decision?]"
+      secondary: "[Who else needs to know about this decision?]"
+
+    constraints:
+      technical:
+        - "[Platform limitations]"
+        - "[Integration requirements]"
+        - "[Performance requirements]"
+      business:
+        - "[Budget constraints]"
+        - "[Timeline requirements]"
+        - "[Regulatory compliance]"
+      organizational:
+        - "[Team expertise]"
+        - "[Operational capabilities]"
+        - "[Strategic direction]"
+
+    success_criteria:
+      quantitative:
+        - "[Measurable performance target]"
+        - "[Cost target]"
+        - "[Timeline goal]"
+      qualitative:
+        - "[Maintainability goal]"
+        - "[Security posture]"
+        - "[Developer experience]"
+
+  decision:
+    summary: "[One clear sentence stating what was decided]"
+    rationale: "[Why this decision was made - key reasoning]"
+    implementation_approach: "[High-level approach to implementing this decision]"
+
+  decision_drivers:
+    - name: "[Driver 1 - e.g., Performance Requirements]"
+      description: "[Why this factor influenced the decision]"
+      weight: "[High/Medium/Low priority]"
+    - name: "[Driver 2 - e.g., Cost Optimization]"
+      description: "[Why this factor influenced the decision]"
+      weight: "[High/Medium/Low priority]"
+    - name: "[Driver 3 - e.g., Team Expertise]"
+      description: "[Why this factor influenced the decision]"
+      weight: "[High/Medium/Low priority]"
+
+  considered_options:
+    - name: "[Option 1 - e.g., Technology A]"
+      description: "[Brief description of what this option entails]"
+
+      technical_details:
+        - "[Architecture approach]"
+        - "[Key components]"
+        - "[Integration requirements]"
+
+      pros:
+        - "[Specific advantage 1]"
+        - "[Specific advantage 2]"
+        - "[Quantifiable benefit]"
+
+      cons:
+        - "[Specific disadvantage 1]"
+        - "[Specific disadvantage 2]"
+        - "[Quantifiable limitation]"
+
+      risks:
+        - risk: "[Risk description]"
+          probability: "[High/Medium/Low]"
+          impact: "[High/Medium/Low]"
+          mitigation: "[How to address this risk]"
+
+      dependencies:
+        - "[External dependency]"
+        - "[Internal capability requirement]"
+        - "[Timeline dependency]"
+
+      costs:
+        initial: "[Implementation cost]"
+        ongoing: "[Operational cost]"
+        effort: "[Development effort required]"
+
+    - name: "[Option 2 - e.g., Technology B]"
+      description: "[Brief description]"
+      technical_details: ["[Key technical aspects]"]
+      pros: ["[Advantages]"]
+      cons: ["[Disadvantages]"]
+      risks:
+        - risk: "[Risk]"
+          probability: "[Level]"
+          impact: "[Level]"
+          mitigation: "[Mitigation strategy]"
+      dependencies: ["[Dependencies]"]
+      costs:
+        initial: "[Cost]"
+        ongoing: "[Cost]"
+        effort: "[Effort]"
+
+  comparison_matrix:
+    criteria:
+      - name: "[Evaluation criteria 1]"
+        weight: "[High/Medium/Low]"
+        option_1_score: "[Score/Rating]"
+        option_2_score: "[Score/Rating]"
+      - name: "[Evaluation criteria 2]"
+        weight: "[High/Medium/Low]"
+        option_1_score: "[Score/Rating]"
+        option_2_score: "[Score/Rating]"
+
+  consequences:
+    positive:
+      - "[Positive outcome 1]"
+      - "[Positive outcome 2]"
+    negative:
+      - "[Negative impact 1]"
+      - "[Negative impact 2]"
+    neutral:
+      - "[Neutral change 1]"
+      - "[Neutral change 2]"
+    risks:
+      - "[Risk that remains after decision]"
+      - "[Monitoring requirement]"
+
+  implementation:
+    phases:
+      - "[Phase 1 description]"
+      - "[Phase 2 description]"
+    timeline: "[Expected timeline]"
+    resources_required: "[Team/budget/tools needed]"
+    success_metrics: "[How to measure success]"
+
+  future_considerations:
+    monitoring:
+      - "[What to watch for]"
+      - "[When to re-evaluate]"
+    evolution:
+      - "[Future technology to consider]"
+      - "[Upcoming decisions that may affect this]"
+    triggers_for_review:
+      - "[Condition that would trigger re-evaluation]"
+      - "[Timeline for regular review]"
+```
+
+---
+
+## ADR Document Structure
+
+After completing the YAML drafting guide above, use this structure for your final ADR:
+
+### Status
+
+[Mark the most applicable status for tracking purposes]
+
+- [ ] Draft
+- [ ] Proposed
+- [ ] Accepted
+- [ ] Deprecated
+
+### Context
+
+**Scenario Context**: [Describe the business scenario or use case]
+
+**Problem Statement**: [Clearly articulate the problem being solved]
+
+**Constraints and Requirements**: [Document technical, business, and organizational boundaries]
+
+**Success Criteria**: [Define measurable outcomes for success]
+
+### Decision
+
+**Decision Statement**: [Clear, single sentence stating what was decided]
+
+**Decision Rationale**: [Explain the reasoning behind this decision]
+
+**Implementation Approach**: [Outline how this decision will be implemented]
+
+### Decision Drivers (optional)
+
+List the key factors that influenced this decision:
+
+- [Driver 1]
+- [Driver 2]
+- [Driver 3]
+
+### Considered Options (optional)
+
+**Option Evaluation Framework**: [For each option considered, provide:]
+
+#### Option [Number]: [Option Name]
+
+**Description**: [What this option entails]
+
+**Technical Details**: [Architecture, components, requirements]
+
+**Pros**: [Specific advantages with supporting detail]
+
+**Cons**: [Specific disadvantages with impact assessment]
+
+**Risks and Mitigation**: [Risks with probability, impact, and mitigation strategies]
+
+**Dependencies**: [External dependencies and prerequisites]
+
+**Cost Analysis**: [Implementation and operational costs]
+
+### Comparison Matrix (optional)
+
+| Criteria     | Option 1 | Option 2 | Option 3 | Weight  |
+|--------------|----------|----------|----------|---------|
+| [Criteria 1] | [Score]  | [Score]  | [Score]  | [H/M/L] |
+| [Criteria 2] | [Score]  | [Score]  | [Score]  | [H/M/L] |
+
+### Consequences
+
+**Positive Consequences**: [Benefits and positive outcomes]
+
+**Negative Consequences**: [Risks and negative impacts]
+
+**Neutral Consequences**: [Other changes or considerations]
+
+### Future Considerations (optional)
+
+**Monitoring and Evolution**: [What to watch for and when to re-evaluate]
+
+**Review Triggers**: [Conditions that would require re-evaluation of this decision]
+
+---
+
+<!-- markdownlint-disable MD036 -->
+*🤖 Crafted with precision by ✨Copilot following brilliant human instruction,
+then carefully refined by our team of discerning human reviewers.*
+<!-- markdownlint-enable MD036 -->


### PR DESCRIPTION
Enhanced the ADR creation chatmode to streamline workflow by introducing early placement planning, updating template references to local repository paths, and implementing version-aware file naming conventions for better organization and decision tracking.

- **feat**(_prompts_): added ADR template file to `docs/templates/` directory, providing local reference for solution ADR structure with comprehensive YAML drafting guide and document format

- **feat**(_prompts_): added ADR Placement Planning subsection to Phase 1 Discovery that establishes final ADR location before drafting, includes dialogue pattern with recommended `docs/decisions/` location, ISO date prefix file naming with version numbering (`-v01`, `-v02` format), and captures user's chosen directory for consistent organization

- **feat**(_prompts_): updated template path references from `/docs/solution-adr-library/` to `docs/templates/` in Phase 2 Research Integration and Phase 4 Solution Library Compliance sections

- **feat**(_prompts_): updated Repository and Project Context Analysis to reference user's chosen ADR location for discovering related decisions and similar architectural challenges

- **refactor**(_prompts_): simplified Document Placement and Finalization section to reference Phase 1 placement decision, reducing redundant location questioning while preserving file naming format and finalization steps

## Notes

- Version numbering uses zero-padded two-digit format (`-v01`, `-v02`, `-v03`) for tracking iterations and multiple decisions on the same day
- The placement planning dialogue recommends `docs/decisions/` as industry standard location following adr.github.io and AWS guidance
- Early placement planning enables checking for related decisions during research phase rather than after drafting

Closes #68

📝 - Generated by Copilot