### PR TITLE
fix(linting): use cross-platform path separators in gitignore pattern matching

### DIFF
--- a/scripts/linting/Modules/LintingHelpers.psm1
+++ b/scripts/linting/Modules/LintingHelpers.psm1
@@ -145,7 +145,7 @@ function Get-GitIgnorePatterns {
     Path to .gitignore file.
 
     .OUTPUTS
-    Array of wildcard patterns.
+    Array of wildcard patterns using platform-appropriate separators.
     #>
     [CmdletBinding()]
     param(
@@ -157,19 +157,24 @@ function Get-GitIgnorePatterns {
         return @()
     }
 
+    $sep = [System.IO.Path]::DirectorySeparatorChar
+
     $patterns = Get-Content $GitIgnorePath | Where-Object {
         $_ -and -not $_.StartsWith('#') -and $_.Trim() -ne ''
     } | ForEach-Object {
         $pattern = $_.Trim()
         
+        # Normalize to platform separator
+        $normalizedPattern = $pattern.Replace('/', $sep).Replace('\', $sep)
+        
         if ($pattern.EndsWith('/')) {
-            "*\$($pattern.TrimEnd('/'))\*"
+            "*$sep$($normalizedPattern.TrimEnd($sep))$sep*"
         }
-        elseif ($pattern.Contains('/')) {
-            "*\$($pattern.Replace('/', '\'))*"
+        elseif ($pattern.Contains('/') -or $pattern.Contains('\')) {
+            "*$sep$normalizedPattern*"
         }
         else {
-            "*\$pattern\*"
+            "*$sep$normalizedPattern$sep*"
         }
     }
 

--- a/scripts/linting/Validate-MarkdownFrontmatter.ps1
+++ b/scripts/linting/Validate-MarkdownFrontmatter.ps1
@@ -501,31 +501,9 @@ function Test-FrontmatterValidation {
         }
     }
     
-    # Parse .gitignore patterns
-    $gitignorePatterns = @()
+    # Parse .gitignore patterns using shared helper function
     $gitignorePath = Join-Path $repoRoot ".gitignore"
-    if (Test-Path $gitignorePath) {
-        $gitignorePatterns = Get-Content $gitignorePath | Where-Object {
-            $_ -and 
-            -not $_.StartsWith('#') -and 
-            $_.Trim() -ne ''
-        } | ForEach-Object {
-            $pattern = $_.Trim()
-            # Convert gitignore patterns to PowerShell wildcard patterns
-            if ($pattern.EndsWith('/')) {
-                # Directory pattern
-                "*\$($pattern.TrimEnd('/'))\*"
-            }
-            elseif ($pattern.Contains('/')) {
-                # Path pattern
-                "*\$($pattern.Replace('/', '\'))*"
-            }
-            else {
-                # Simple pattern
-                "*\$pattern\*"
-            }
-        }
-    }
+    $gitignorePatterns = Get-GitIgnorePatterns -GitIgnorePath $gitignorePath
     
     Write-Host "🔍 Validating frontmatter across markdown files..." -ForegroundColor Cyan
     


### PR DESCRIPTION
## Description

Updated the PowerShell linting helpers to use platform-appropriate path separators, enabling proper gitignore exclusion behavior in Linux-based dev container environments.

- **fix**(_linting_): Updated `Get-GitIgnorePatterns` function to use `[System.IO.Path]::DirectorySeparatorChar` instead of hardcoded backslashes
  - Normalizes input patterns by replacing both `/` and `\` with the platform separator
  - Wildcard patterns now correctly match on both Windows and Unix systems

- **refactor**(_linting_): Replaced inline gitignore parsing in `Validate-MarkdownFrontmatter.ps1` with call to shared `Get-GitIgnorePatterns` helper
  - Removed 24 lines of duplicate code
  - Ensures consistent gitignore behavior across all linting scripts

## Related Issue(s)

Fixes #120

## Type of Change

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [x] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**Other:**

- [x] Script/automation (`.ps1`, `.sh`, `.py`)

## Testing

- Validated with PSScriptAnalyzer (exit code 0, no issues)
- Cross-platform path separator logic verified using `[System.IO.Path]::DirectorySeparatorChar`

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [x] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

This fix addresses an issue where gitignore patterns using hardcoded Windows backslashes (`\`) failed to match paths on Linux systems in the dev container. The solution uses .NET's `DirectorySeparatorChar` for platform detection and normalizes patterns accordingly.

🐛 - Generated by Copilot