### PR TITLE
fix(tools): correct Method 5 path resolution in hve-core-installer

### DIFF
--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -1352,6 +1352,7 @@ keepbackup
 checkpointed
 parameterless
 notnull
+notmatch
 gettype
 lockfiles
 workitem
@@ -1379,6 +1380,8 @@ typeparam
 colcon
 pathlib
 popen
+popd
+pushd
 expanduser
 reqwest
 pyyaml
@@ -1392,6 +1395,7 @@ cloudevents
 datasize
 mult
 reqs
+toplevel
 
 # Video & Image Processing
 drawtext

--- a/.github/agents/hve-core-installer.agent.md
+++ b/.github/agents/hve-core-installer.agent.md
@@ -617,6 +617,8 @@ if (Test-Path $mountedPath) {
 $ErrorActionPreference = 'Stop'
 
 # Create multi-root workspace file
+# IMPORTANT: Do NOT use folder display names as path prefixes (e.g., "HVE-Core Library/.github").
+# VS Code does not resolve display names. Use actual relative paths from the workspace file location.
 $workspaceContent = @'
 {
   "folders": [
@@ -625,16 +627,16 @@ $workspaceContent = @'
   ],
   "settings": {
     "chat.modeFilesLocations": {
-      "HVE-Core Library/.github/chatmodes": true,
-      "My Project/.github/chatmodes": true
+      ".github/chatmodes": true,
+      "../hve-core/.github/chatmodes": true
     },
     "chat.promptFilesLocations": {
-      "HVE-Core Library/.github/prompts": true,
-      "My Project/.github/prompts": true
+      ".github/prompts": true,
+      "../hve-core/.github/prompts": true
     },
     "chat.instructionsFilesLocations": {
-      "HVE-Core Library/.github/instructions": true,
-      "My Project/.github/instructions": true
+      ".github/instructions": true,
+      "../hve-core/.github/instructions": true
     }
   },
   "extensions": {
@@ -652,6 +654,8 @@ Write-Host "✅ Created hve-core.code-workspace"
 #!/usr/bin/env bash
 set -euo pipefail
 
+# IMPORTANT: Do NOT use folder display names as path prefixes (e.g., "HVE-Core Library/.github").
+# VS Code does not resolve display names. Use actual relative paths from the workspace file location.
 cat > hve-core.code-workspace << 'EOF'
 {
   "folders": [
@@ -660,16 +664,16 @@ cat > hve-core.code-workspace << 'EOF'
   ],
   "settings": {
     "chat.modeFilesLocations": {
-      "HVE-Core Library/.github/chatmodes": true,
-      "My Project/.github/chatmodes": true
+      ".github/chatmodes": true,
+      "../hve-core/.github/chatmodes": true
     },
     "chat.promptFilesLocations": {
-      "HVE-Core Library/.github/prompts": true,
-      "My Project/.github/prompts": true
+      ".github/prompts": true,
+      "../hve-core/.github/prompts": true
     },
     "chat.instructionsFilesLocations": {
-      "HVE-Core Library/.github/instructions": true,
-      "My Project/.github/instructions": true
+      ".github/instructions": true,
+      "../hve-core/.github/instructions": true
     }
   },
   "extensions": {


### PR DESCRIPTION
# Pull Request

## Description

Fixed a path resolution bug in the hve-core-installer agent where Method 5 (Multi-Root Workspace) used folder display names as path prefixes in VS Code settings. VS Code does not resolve display names in path settings, causing chatmodes, prompts, and instructions to fail to load.

**Changes:**
- Replaced folder display name prefixes with explicit relative paths in Method 5 workspace configuration
- Changed `HVE-Core Library/.github/chatmodes` to `.github/chatmodes` and `../hve-core/.github/chatmodes`
- Applied same pattern to `chat.promptFilesLocations` and `chat.instructionsFilesLocations` settings
- Updated both PowerShell and Bash installation examples
- Added comments explaining VS Code path resolution behavior
- Added missing technical terms (`notmatch`, `popd`, `pushd`, `toplevel`) to cspell dictionary

## Related Issue(s)

Fixes #128

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` chatmode and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot chatmode (`.github/chatmodes/*.chatmode.md`)

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Verified markdown linting passes
- Verified frontmatter validation passes
- Verified spell check passes with added technical terms

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

🐞 - Generated by Copilot