### PR TITLE
fix(build): use hashtable splatting for named parameters

### DIFF
--- a/.github/workflows/extension-package.yml
+++ b/.github/workflows/extension-package.yml
@@ -76,21 +76,18 @@ jobs:
           
           Write-Host "📦 Packaging extension..."
           
-          $arguments = @()
+          $arguments = @{}
           
           if ($version) {
-            $arguments += '-Version'
-            $arguments += $version
+            $arguments['Version'] = $version
           }
           
           if ($devPatch) {
-            $arguments += '-DevPatchNumber'
-            $arguments += $devPatch
+            $arguments['DevPatchNumber'] = $devPatch
           }
           
           if (Test-Path "./CHANGELOG.md") {
-            $arguments += '-ChangelogPath'
-            $arguments += "./CHANGELOG.md"
+            $arguments['ChangelogPath'] = "./CHANGELOG.md"
           }
           
           ./scripts/extension/Package-Extension.ps1 @arguments


### PR DESCRIPTION
# fix(build): use hashtable splatting for named parameters

## Description

Fixed PowerShell splatting issue in the extension packaging workflow where array splatting passed values as positional parameters instead of named parameters. The CI failure occurred because `Package-Extension.ps1` expects named parameters (`-Version`, `-DevPatchNumber`, `-ChangelogPath`), but array splatting (`@()`) incorrectly passed them positionally.

- **fix**(_workflows_): Converted array splatting to hashtable splatting in `Package-Extension.ps1` call
  - Changed `$arguments = @()` with `+=` to `$arguments = @{}` with key assignments
  - Hashtable splatting correctly maps keys to named parameters

## Related Issue(s)

Closes #163

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` chatmode and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot chatmode (`.github/chatmodes/*.chatmode.md`)

> **Note for AI Artifact Contributors**:
>
> - **Chatmodes**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation chatmodes likely already exist. Review `.github/chatmodes/` before creating new ones.
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Chatmodes Not Accepted](../docs/contributing/chatmodes.md#chatmodes-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing
<!-- Describe how you tested these changes -->

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### AI Artifact Contributions
<!-- If contributing a chatmode, prompt, or instruction, complete these checks -->
- [ ] Used `prompt-builder` chatmode to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Root cause: PowerShell array splatting (`@()`) passes elements as positional arguments in order, which fails when the target script expects named parameters. Hashtable splatting (`@{}`) correctly maps keys to parameter names.

🔧 - Generated by Copilot