### PR TITLE
fix(build): use GitHub App token for release-please

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.0.0
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
# fix(build): use GitHub App token for release-please

## Description

Replace `GITHUB_TOKEN` with a GitHub App installation token for the release-please workflow to bypass the organization-level restriction that prevents `GITHUB_TOKEN` from creating pull requests. The organization policy "Allow GitHub Actions to create and approve pull requests" is disabled at the enterprise level and cannot be changed at the repository level.

- **fix**(_workflows_): Add `actions/create-github-app-token@v2` step to generate installation token from GitHub App
- **fix**(_workflows_): Replace `token: ${{ secrets.GITHUB_TOKEN }}` with `token: ${{ steps.app-token.outputs.token }}`
- **refactor**(_workflows_): Reduce job permissions from `contents: write, pull-requests: write, issues: write` to `contents: read` since the app token provides necessary write access

## Related Issue(s)

Fixes #165

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` chatmode and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot chatmode (`.github/chatmodes/*.chatmode.md`)

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Workflow will be tested on merge when release-please attempts to create/update a release PR
- Requires GitHub App installation approval from org admins
- Requires `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret to be configured

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [x] Link validation: `npm run lint:md-links`
- [x] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

**Prerequisites before merging:**
1. GitHub App installation must be approved by org admins (App ID: 2646666)
2. Store `RELEASE_APP_ID` as a repository variable with value `2646666`
3. Store `RELEASE_APP_PRIVATE_KEY` as a repository secret with the PEM file contents

**Why this approach:**
- GitHub App tokens are treated differently than `GITHUB_TOKEN` by GitHub's permission system
- App tokens bypass the org-level restriction that blocks `GITHUB_TOKEN` from creating PRs
- App tokens auto-renew (1-hour lifetime, refreshed automatically) unlike PATs which expire

🤖 - Generated by Copilot
