### PR TITLE
fix(build): seed CHANGELOG.md with version entry for release-please frontmatter preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** This file is automatically maintained by [release-please](https://github.com/googleapis/release-please). Do not edit manually.
 
-<!-- Releases will be automatically added by release-please -->
+## 0.0.0 (Initial)
+
+- Initial placeholder for release-please compatibility


### PR DESCRIPTION
## Summary

Fixes #169

Seeds CHANGELOG.md with a placeholder version entry so release-please preserves YAML frontmatter during changelog updates.

## Problem

PR #168 fails markdown linting because CHANGELOG.md had no version entry. When release-please's `updateContent()` method runs without a matching version header (`'\n###? v?[0-9[]'`), it takes the "no version found" code path which:

1. Prepends `# Changelog\n` header
2. Adds the new changelog entry  
3. Calls `adjustHeaders()` on **all** existing content (including frontmatter)
4. Appends adjusted content at the **end** of the file

This mangles the YAML frontmatter, causing MD003, MD012, MD013, and MD022 lint failures.

## Solution

Add `## 0.0.0 (Initial)` placeholder version entry. This triggers release-please's "version found" path:

```typescript
const lastEntryIndex = content.search(versionHeaderRegex);
const before = content.slice(0, lastEntryIndex);   // Frontmatter preserved
const after = content.slice(lastEntryIndex);       // Only versions processed

return `${before}\n${this.changelogEntry}\n${adjustHeaders(after)}`;
```

The frontmatter stays in the protected `before` slice and is preserved exactly as-is.

## Changes

- [CHANGELOG.md](CHANGELOG.md) - Added `## 0.0.0 (Initial)` placeholder version entry

## Testing

- ✅ `npx markdownlint-cli2 CHANGELOG.md` passes with 0 errors

## Next Steps

After merging this PR:
1. Close PR #168
2. Release-please will regenerate with the corrected algorithm

## References

- [release-please changelog.ts](https://github.com/googleapis/release-please/blob/main/src/updaters/changelog.ts) - `updateContent()` algorithm