### PR TITLE
fix(build): disable MD012 lint rule in CHANGELOG for release-please compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ title: Changelog
 description: Automatically generated changelog tracking all notable changes to the HVE Core project using semantic versioning
 ---
 
+<!-- markdownlint-disable MD012 -->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -12,4 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.0.0 (Initial)
 
-- Initial placeholder for release-please compatibility
+* Initial placeholder for release-please compatibility


### PR DESCRIPTION
## Summary

Fixes markdown lint failures caused by release-please's generated CHANGELOG content by disabling the MD012 rule (multiple consecutive blank lines) and converting the existing dash list marker to an asterisk.

## Changes

- Add \<!-- markdownlint-disable MD012 -->\ after frontmatter to allow multiple blank lines
- Change \- Initial placeholder\ to \* Initial placeholder\ for MD004 compliance

## Why This Approach

Release-please uses \conventional-changelog-writer\ with hardcoded templates that generate multiple consecutive blank lines between sections. Rather than post-processing the CHANGELOG on every release, we disable the specific lint rule that conflicts with the generated output.

## Testing

- Ran \
px markdownlint-cli2 CHANGELOG.md\ - 0 errors

Closes #172