### PR TITLE
fix(build): pin npm commands for OpenSSF Scorecard compliance

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 main() {
   echo "Installing NPM dependencies..."
-  npm install
+  npm ci
   echo "NPM dependencies installed successfully"
 }
 

--- a/.github/workflows/extension-package.yml
+++ b/.github/workflows/extension-package.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm install -g @vscode/vsce
+        run: npm install -g @vscode/vsce@3.7.1
 
       - name: Setup PowerShell
         shell: pwsh

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -124,7 +124,7 @@ jobs:
           node-version: '20'
 
       - name: Install VSCE
-        run: npm install -g @vscode/vsce
+        run: npm install -g @vscode/vsce@3.7.1
 
       - name: Download VSIX artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
# fix(build): pin npm commands for OpenSSF Scorecard compliance

## Description

Resolved npm command pinning warnings identified by OpenSSF Scorecard analysis. Replaced non-deterministic `npm install` with `npm ci` in the DevContainer post-create script and pinned `@vscode/vsce` to version 3.7.1 in GitHub Actions workflows to prevent supply chain vulnerabilities from unpinned global package installations.

- **fix**(_scripts_): Replaced `npm install` with `npm ci` in `.devcontainer/scripts/post-create.sh` for deterministic dependency installation using lockfile
- **fix**(_build_): Pinned `@vscode/vsce` to version 3.7.1 in `.github/workflows/extension-package.yml`
- **fix**(_build_): Pinned `@vscode/vsce` to version 3.7.1 in `.github/workflows/extension-publish.yml`

## Related Issue(s)

Fixes #180

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [x] Security configuration
- [x] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` chatmode and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot chatmode (`.github/chatmodes/*.chatmode.md`)

> **Note for AI Artifact Contributors**:
>
> - **Chatmodes**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation chatmodes likely already exist. Review `.github/chatmodes/` before creating new ones.
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Chatmodes Not Accepted](../docs/contributing/chatmodes.md#chatmodes-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [x] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- Not applicable - this PR does not include AI artifacts -->

## Testing

- Verified file changes produce valid YAML syntax in GitHub Actions workflows
- Confirmed shell script syntax is valid with `npm ci` command
- Changes align with npm best practices for CI/CD environments

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### AI Artifact Contributions

<!-- Not applicable - this PR does not include AI artifacts -->

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

This change addresses OpenSSF Scorecard npm command pinning warnings:

- `npm ci` uses the lockfile (`package-lock.json`) for deterministic, reproducible builds
- Pinning `@vscode/vsce@3.7.1` prevents supply chain attacks from compromised latest versions
- Both changes improve the repository's OpenSSF Scorecard security score

🔒 - Generated by Copilot
