### PR TITLE
fix(scripts): add GHSA word and logs/ exclusion to cspell config

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,7 +21,8 @@
     "package-lock.json",
     "**/package-lock.json",
     "Cargo.lock",
-    "**/Cargo.lock"
+    "**/Cargo.lock",
+    "logs/**"
   ],
   "ignoreRegExpList": [
     "/#.*/g",
@@ -59,10 +60,12 @@
   ],
   "words": [
     "ˈpræksɪs",
+    "autobuild",
     "behaviour",
     "Chronograf",
     "edgeai",
     "GHCP",
+    "GHSA",
     "Kapacitor",
     "kata",
     "katas",


### PR DESCRIPTION
# Pull Request

## Description

Adds missing cspell configuration to fix spell-check failures in CI pipelines.

- Added `logs/**` to `ignorePaths` to exclude generated output files from spell checking
- Added `GHSA` to `words` for GitHub Security Advisory IDs appearing in CHANGELOG.md
- Added `autobuild` to `words` for CodeQL action names in generated logs

## Related Issue(s)

Fixes #213

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [x] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Verified `npm run spell-check` passes locally with 0 issues
- Verified `npm run lint:md` passes locally with 0 errors

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

This fix unblocks the release-please PR #212 for v1.2.0 which was failing spell-check due to GHSA references in CHANGELOG.md.

🔧 - Generated by Copilot