### PR TITLE
build(build): add Pester code coverage to main branch CI

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -71,6 +71,7 @@
     "katas",
     "learning",
     "pullrequest",
+    "rhysd",
     "SARIF",
     "Segoe",
     "streamlit",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,17 @@ jobs:
       upload-sarif: true
       upload-artifact: true
 
+  pester-tests:
+    name: PowerShell Tests
+    uses: ./.github/workflows/pester-tests.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      soft-fail: false
+      changed-files-only: false
+      code-coverage: true
+
   extension-package:
     name: Package VS Code Extension
     needs:
@@ -54,6 +65,7 @@ jobs:
       - markdown-lint
       - table-format
       - dependency-pinning-scan
+      - pester-tests
     uses: ./.github/workflows/extension-package.yml
     with:
       dev-patch-number: ${{ github.run_number }}
@@ -68,6 +80,7 @@ jobs:
       - table-format
       - dependency-pinning-scan
       - extension-package
+      - pester-tests
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+ignore:
+  - "scripts/tests/**"
+  - "logs/**"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+
+flags:
+  pester:
+    paths:
+      - "scripts/**"
+    carryforward: true


### PR DESCRIPTION
## Description

Adds Pester code coverage generation to main branch pushes, establishing baseline coverage for Codecov PR comparisons. Also introduces a `codecov.yml` configuration with status thresholds, carryforward flags, and ignore paths.

**Changes:**

- Added `pester-tests` job to `main.yml` with OIDC permissions (`id-token: write`) and `code-coverage: true`
- Created `codecov.yml` with project status (`target: auto`, 1% threshold), informational patch status (80% target), carryforward flags for pester, and ignore paths for test code and logs
- Added "rhysd" to `.cspell.json` dictionary for actionlint checksum references

## Related Issue(s)

Fixes #249

## Type of Change

Select all that apply:

**Code & Documentation:**

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

N/A - This PR does not include AI artifacts.

## Testing

- [x] YAML lint validation passes (`pwsh -File scripts/linting/Invoke-YamlLint.ps1`)
- [x] Spell check passes (`npm run spell-check`)
- [x] Frontmatter validation passes (`npm run lint:frontmatter`)
- [x] Markdown lint passes (`npm run lint:md`)

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

### AI Artifact Contributions

N/A

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The `codecov.yml` configuration was added based on research of Codecov best practices:

| Setting | Value | Rationale |
|---------|-------|-----------|
| `coverage.status.project.target` | `auto` | Automatically uses base branch coverage for comparison |
| `coverage.status.project.threshold` | `1%` | Allows minor fluctuation without failing the check |
| `coverage.status.patch.informational` | `true` | Reports patch coverage without blocking PRs |
| `flags.pester.carryforward` | `true` | Preserves coverage when pester tests don't run on a commit |
| `ignore` | `scripts/tests/**`, `logs/**` | Excludes test code and logs from metrics |

📊 - Generated by Copilot