### PR TITLE
Repro: CodeQL does not run on PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -356,6 +356,7 @@ jobs:
         uses: actions/upload-artifact@<sha>  # v4
 ```
 
+
 ### Artifact Handling
 
 * **Retention**: 30 days for all artifacts


### PR DESCRIPTION
Repro PR for #280. This PR is only to confirm CodeQL doesn’t run on PRs with the current workflow triggers.