### PR TITLE
feat(agents): add hve-core-installer agent to extension package

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -62,6 +62,11 @@
         "description": "Interactive GitHub issue management with conversational workflows for filing, navigating, and searching issues"
       },
       {
+        "name": "hve-core-installer",
+        "path": "./.github/agents/hve-core-installer.agent.md",
+        "description": "Decision-driven installer for HVE-Core with 6 installation methods for local, devcontainer, and Codespaces environments - Brought to you by microsoft/hve-core"
+      },
+      {
         "name": "memory",
         "path": "./.github/agents/memory.agent.md",
         "description": "Conversation memory persistence for session continuity - Brought to you by microsoft/hve-core"

--- a/scripts/extension/Prepare-Extension.ps1
+++ b/scripts/extension/Prepare-Extension.ps1
@@ -521,14 +521,14 @@ try {
 
     Write-Host "   Using version: $version" -ForegroundColor Green
 
-    # Discover chat agents (excluding hve-core-installer which is for manual installation only)
+    # Discover chat agents
     Write-Host ""
     Write-Host "🔍 Discovering chat agents..." -ForegroundColor Yellow
     $agentsDir = Join-Path $GitHubDir "agents"
     $chatAgents = @()
 
     # Agents to exclude from extension packaging
-    $excludedAgents = @('hve-core-installer')
+    $excludedAgents = @()
 
     if (Test-Path $agentsDir) {
         $agentFiles = Get-ChildItem -Path $agentsDir -Filter "*.agent.md" | Sort-Object Name


### PR DESCRIPTION
# feat(agents): add hve-core-installer agent to extension package

## Description

Added the `hve-core-installer` agent to the VS Code extension package. The agent was previously excluded from extension packaging but is now stable and ready for distribution.

- feat(extension): include `hve-core-installer` agent in extension package.json
- refactor(scripts): remove `hve-core-installer` from the excluded agents list in `Prepare-Extension.ps1`

## Related Issue(s)

N/A

## Type of Change

Select all that apply:

**Code & Documentation:**

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [x] Copilot agent (`.github/agents/*.agent.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [x] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

> "Help me install HVE-Core agents, prompts, and instructions in my project"

**Execution Flow:**

1. Agent detects environment (local, devcontainer, Codespaces)
2. Presents installation path choice (Extension quick install vs Clone-based)
3. For clone-based: guides through method selection based on environment and team needs
4. Executes installation and validates success
5. Configures gitignore and offers MCP server setup

**Output Artifacts:**

- Updated `.vscode/settings.json` with HVE-Core paths
- For clone methods: cloned HVE-Core repository at appropriate location
- For extension method: installed VS Code extension

**Success Indicators:**

- Agent appears in VS Code Copilot Chat agent picker dropdown
- HVE-Core agents, prompts, and instructions are accessible

## Testing

- Ran `Prepare-Extension.ps1` to verify agent discovery includes `hve-core-installer`
- Confirmed `extension/package.json` includes the new agent entry with correct path and description

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The `.vscode/mcp.json` changes in this branch are local workspace configuration and not intended for merge. Only the `extension/package.json` and `scripts/extension/Prepare-Extension.ps1` changes are relevant to this feature.

🚀 - Generated by Copilot
