### PR TITLE
fix(build): resolve scorecard badge and workflow security issues

### DIFF
--- a/.github/workflows/extension-publish-prerelease.yml
+++ b/.github/workflows/extension-publish-prerelease.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: '20'
 
       - name: Install VSCE
-        run: npm install -g @vscode/vsce
+        run: npm install -g @vscode/vsce@3.7.1
 
       - name: Setup PowerShell
         shell: pwsh
@@ -126,7 +126,7 @@ jobs:
           node-version: '20'
 
       - name: Install VSCE
-        run: npm install -g @vscode/vsce
+        run: npm install -g @vscode/vsce@3.7.1
 
       - name: Download VSIX artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -19,6 +19,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   pester:
     name: PowerShell Tests

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,14 +44,3 @@ jobs:
           name: scorecard-results
           path: results.sarif
           retention-days: 90
-
-      - name: Add job summary
-        if: always()
-        run: |
-          {
-            echo "## OpenSSF Scorecard Analysis Complete"
-            echo ""
-            echo "📊 View results in the Security tab under Code Scanning"
-            echo ""
-            echo "🏆 [View Scorecard Badge](https://scorecard.dev/viewer/?uri=github.com/microsoft/hve-core)"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   codeql:


### PR DESCRIPTION
## Description

This PR fixes the broken OpenSSF Scorecard badge by removing a `run:` step from the scorecard workflow that violated ossf/scorecard-action restrictions. Additionally, it addresses workflow security configurations by adding explicit permission blocks and pinning npm dependencies to specific versions.

- Removed job summary step from scorecard.yml that used `run:` commands, which caused workflow verification failures and prevented the Scorecard API from accepting results
- Added explicit `permissions: contents: read` block to pester-tests.yml to satisfy scorecard token permissions requirements
- Removed redundant `security-events: write` from security-scan.yml top-level permissions (already declared at job level)
- Pinned `@vscode/vsce@3.7.1` in extension-publish-prerelease.yml (two locations) to address npm dependency pinning requirements

## Related Issue(s)

Closes #300
Closes #292
Closes #291

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [x] Security configuration
- [ ] DevContainer configuration
- [x] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Ran `npm run lint:yaml` to validate all 21 workflow files pass YAML/actionlint checks
- Verified workflow syntax is valid for all modified files

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

N/A - No AI artifacts in this PR.

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The root cause of the broken scorecard badge was the `run:` step in scorecard.yml. The ossf/scorecard-action explicitly restricts workflows containing arbitrary shell commands to prevent supply chain attacks, which caused all workflow runs to fail verification and return empty results to the Scorecard API.

🔧 Generated by Copilot