### PR TITLE
fix(ci): exclude extension/README.md from frontmatter validation

### DIFF
--- a/.github/workflows/frontmatter-validation.yml
+++ b/.github/workflows/frontmatter-validation.yml
@@ -77,7 +77,8 @@ jobs:
           }
           
           # Exclude test fixture files (intentionally invalid frontmatter for testing)
-          $params['ExcludePaths'] = @('scripts/tests/Fixtures/**')
+          # and extension/README.md (uses VS Code marketplace format, not repo docs standards)
+          $params['ExcludePaths'] = @('scripts/tests/Fixtures/**', 'extension/README.md')
           
           & scripts/linting/Validate-MarkdownFrontmatter.ps1 @params
         continue-on-error: true


### PR DESCRIPTION
## Summary

Fixes #361

The `extension/README.md` uses VS Code marketplace README format which doesn't require YAML frontmatter. This file should be excluded from frontmatter validation to prevent false positive CI failures.

## Changes

- Added `extension/README.md` to the `ExcludePaths` array in `.github/workflows/frontmatter-validation.yml`

## Testing

- The frontmatter validation workflow will now skip `extension/README.md`
- Other markdown files will continue to be validated normally