### PR TITLE
test(linting): update mock scoping to target LintingHelpers module

### DIFF
--- a/scripts/tests/linting/Invoke-PSScriptAnalyzer.Tests.ps1
+++ b/scripts/tests/linting/Invoke-PSScriptAnalyzer.Tests.ps1
@@ -31,12 +31,12 @@ Describe 'Invoke-PSScriptAnalyzer Parameter Validation' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Get-ChangedFilesFromGit { @('script.ps1') }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers { @('script.ps1') }
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Accepts ChangedFilesOnly switch' {
@@ -52,11 +52,11 @@ Describe 'Invoke-PSScriptAnalyzer Parameter Validation' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Uses default config path when not specified' {
@@ -74,11 +74,11 @@ Describe 'Invoke-PSScriptAnalyzer Parameter Validation' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Accepts custom output path' {
@@ -110,11 +110,11 @@ Describe 'PSScriptAnalyzer Module Availability' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Proceeds when module available' {
@@ -132,14 +132,14 @@ Describe 'File Discovery' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Uses Get-FilesRecursive for all files' {
-            Mock Get-FilesRecursive {
+            Mock Get-FilesRecursive -ModuleName LintingHelpers {
                 return @('script1.ps1', 'script2.ps1')
             }
 
@@ -152,15 +152,15 @@ Describe 'File Discovery' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
             Mock Invoke-ScriptAnalyzer { @() }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Uses Get-ChangedFilesFromGit when ChangedFilesOnly specified' {
-            Mock Get-ChangedFilesFromGit {
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers {
                 return @('changed.ps1')
             }
 
@@ -169,7 +169,7 @@ Describe 'File Discovery' -Tag 'Unit' {
         }
 
         It 'Passes BaseBranch to Get-ChangedFilesFromGit' {
-            Mock Get-ChangedFilesFromGit {
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers {
                 return @('changed.ps1')
             }
 
@@ -189,11 +189,11 @@ Describe 'GitHub Actions Integration' -Tag 'Unit' {
     Context 'Write-GitHubAnnotation calls' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
-            Mock Get-FilesRecursive { @('test.ps1') }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @('test.ps1') }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Calls Write-GitHubAnnotation for each issue' {
@@ -242,11 +242,11 @@ Describe 'Output Generation' -Tag 'Unit' {
     Context 'JSON output file' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
-            Mock Get-FilesRecursive { @('test.ps1') }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @('test.ps1') }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
 
             Mock Invoke-ScriptAnalyzer {
                 return @(
@@ -284,11 +284,11 @@ Describe 'Exit Code Handling' -Tag 'Unit' {
     Context 'No issues found' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
-            Mock Get-FilesRecursive { @() }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @() }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
             Mock Invoke-ScriptAnalyzer { @() }
         }
 
@@ -300,11 +300,11 @@ Describe 'Exit Code Handling' -Tag 'Unit' {
     Context 'Issues found' {
         BeforeEach {
             Mock Get-Module { $true } -ParameterFilter { $Name -eq 'PSScriptAnalyzer' }
-            Mock Get-FilesRecursive { @('test.ps1') }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Get-FilesRecursive -ModuleName LintingHelpers { @('test.ps1') }
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
 
             Mock Invoke-ScriptAnalyzer {
                 return @(

--- a/scripts/tests/linting/Invoke-YamlLint.Tests.ps1
+++ b/scripts/tests/linting/Invoke-YamlLint.Tests.ps1
@@ -37,12 +37,12 @@ Describe 'Invoke-YamlLint Parameter Validation' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock actionlint { '[]' }
-            Mock Get-ChangedFilesFromGit { @() }
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers { @() }
             Mock Test-Path { $false } -ParameterFilter { $Path -eq '.github/workflows' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Accepts ChangedFilesOnly switch' {
@@ -59,10 +59,10 @@ Describe 'Invoke-YamlLint Parameter Validation' -Tag 'Unit' {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock actionlint { '[]' }
             Mock Test-Path { $false } -ParameterFilter { $Path -eq '.github/workflows' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Accepts custom output path' {
@@ -101,10 +101,10 @@ Describe 'actionlint Tool Availability' -Tag 'Unit' {
             Mock Get-Command { [PSCustomObject]@{ Source = 'C:\tools\actionlint.exe' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock actionlint { '[]' }
             Mock Test-Path { $false } -ParameterFilter { $Path -eq '.github/workflows' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Proceeds when actionlint available' {
@@ -122,10 +122,10 @@ Describe 'File Discovery' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock actionlint { '[]' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Uses Get-ChildItem when workflows directory exists' {
@@ -168,21 +168,21 @@ Describe 'File Discovery' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock actionlint { '[]' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Uses Get-ChangedFilesFromGit when ChangedFilesOnly specified' {
-            Mock Get-ChangedFilesFromGit { @('.github/workflows/ci.yml') }
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers { @('.github/workflows/ci.yml') }
 
             & $script:ScriptPath -ChangedFilesOnly
             Should -Invoke Get-ChangedFilesFromGit -Times 1
         }
 
         It 'Passes BaseBranch to Get-ChangedFilesFromGit' {
-            Mock Get-ChangedFilesFromGit { @() }
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers { @() }
 
             & $script:ScriptPath -ChangedFilesOnly -BaseBranch 'develop'
             Should -Invoke Get-ChangedFilesFromGit -Times 1 -ParameterFilter {
@@ -191,7 +191,7 @@ Describe 'File Discovery' -Tag 'Unit' {
         }
 
         It 'Filters changed files to workflows directory only' {
-            Mock Get-ChangedFilesFromGit {
+            Mock Get-ChangedFilesFromGit -ModuleName LintingHelpers {
                 @(
                     '.github/workflows/ci.yml',
                     'scripts/test.yml',
@@ -209,10 +209,10 @@ Describe 'File Discovery' -Tag 'Unit' {
         BeforeEach {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
             Mock Test-Path { $false } -ParameterFilter { $Path -eq '.github/workflows' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Sets count and issues to 0 when no files found' {
@@ -238,10 +238,10 @@ Describe 'actionlint Output Parsing' -Tag 'Unit' {
         Mock Get-ChildItem {
             @([PSCustomObject]@{ FullName = '.github/workflows/ci.yml'; Extension = '.yml' })
         } -ParameterFilter { $Path -eq '.github/workflows' }
-        Mock Set-GitHubOutput {}
-        Mock Set-GitHubEnv {}
-        Mock Write-GitHubStepSummary {}
-        Mock Write-GitHubAnnotation {}
+        Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+        Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+        Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+        Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         Mock New-Item {}
         Mock Out-File {}
     }
@@ -316,10 +316,10 @@ Describe 'Issue Processing' -Tag 'Unit' {
         Mock Get-ChildItem {
             @([PSCustomObject]@{ FullName = '.github/workflows/ci.yml'; Extension = '.yml' })
         } -ParameterFilter { $Path -eq '.github/workflows' }
-        Mock Set-GitHubOutput {}
-        Mock Set-GitHubEnv {}
-        Mock Write-GitHubStepSummary {}
-        Mock Write-GitHubAnnotation {}
+        Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+        Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+        Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+        Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         Mock New-Item {}
         Mock Out-File {}
     }
@@ -388,10 +388,10 @@ Describe 'Output Generation' -Tag 'Unit' {
                 @([PSCustomObject]@{ FullName = '.github/workflows/ci.yml'; Extension = '.yml' })
             } -ParameterFilter { $Path -eq '.github/workflows' }
             Mock actionlint { '[]' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
 
             $script:OutputFile = Join-Path $script:TempDir 'yaml-lint-results.json'
         }
@@ -416,10 +416,10 @@ Describe 'Output Generation' -Tag 'Unit' {
                 @([PSCustomObject]@{ FullName = '.github/workflows/ci.yml'; Extension = '.yml' })
             } -ParameterFilter { $Path -eq '.github/workflows' }
             Mock actionlint { '[]' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Creates logs directory if missing' {
@@ -443,10 +443,10 @@ Describe 'GitHub Actions Integration' -Tag 'Unit' {
         Mock Get-ChildItem {
             @([PSCustomObject]@{ FullName = '.github/workflows/ci.yml'; Extension = '.yml' })
         } -ParameterFilter { $Path -eq '.github/workflows' }
-        Mock Set-GitHubOutput {}
-        Mock Set-GitHubEnv {}
-        Mock Write-GitHubStepSummary {}
-        Mock Write-GitHubAnnotation {}
+        Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+        Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+        Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+        Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         Mock New-Item {}
         Mock Out-File {}
     }
@@ -523,10 +523,10 @@ Describe 'Exit Code Handling' -Tag 'Unit' {
     Context 'Success scenarios (exit 0)' {
         BeforeEach {
             Mock Get-Command { [PSCustomObject]@{ Source = 'actionlint' } } -ParameterFilter { $Name -eq 'actionlint' }
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
             Mock New-Item {}
             Mock Out-File {}
         }
@@ -550,10 +550,10 @@ Describe 'Exit Code Handling' -Tag 'Unit' {
 
     Context 'Failure scenarios (exit 1)' {
         BeforeEach {
-            Mock Set-GitHubOutput {}
-            Mock Set-GitHubEnv {}
-            Mock Write-GitHubStepSummary {}
-            Mock Write-GitHubAnnotation {}
+            Mock Set-GitHubOutput -ModuleName LintingHelpers {}
+            Mock Set-GitHubEnv -ModuleName LintingHelpers {}
+            Mock Write-GitHubStepSummary -ModuleName LintingHelpers {}
+            Mock Write-GitHubAnnotation -ModuleName LintingHelpers {}
         }
 
         It 'Exits with error when actionlint not installed' {


### PR DESCRIPTION
## Description

This PR updates mock scoping in linting tests following the refactoring in #379 where shared boilerplate functions were extracted into `LintingHelpers.psm1`.

Without specifying `-ModuleName LintingHelpers`, mocks may not target the correct function scope, potentially causing test failures.

## Changes

- Added `-ModuleName LintingHelpers` parameter to all mocks of functions from the LintingHelpers module:
  - `Get-ChangedFilesFromGit`
  - `Get-FilesRecursive`
  - `Write-GitHubAnnotation`
  - `Set-GitHubOutput`
  - `Set-GitHubEnv`
  - `Write-GitHubStepSummary`

## Files Modified

- `scripts/tests/linting/Invoke-PSScriptAnalyzer.Tests.ps1`
- `scripts/tests/linting/Invoke-YamlLint.Tests.ps1`

## Testing

- Verified all mock calls now include the correct module scope
- No functional changes to test logic

Fixes #396