### PR TITLE
fix(workflows): correct JSON output formatting in plugin discovery step

### DIFF
--- a/.github/workflows/plugin-package.yml
+++ b/.github/workflows/plugin-package.yml
@@ -37,7 +37,7 @@ jobs:
                   matrix_json=$(find collections -name '*.collection.yml' -type f | sort | while IFS= read -r file; do
                     id=$(basename "$file" .collection.yml)
                     echo "{\"id\":\"$id\"}"
-                  done | jq -s '{include: .}')
+                  done | jq -sc '{include: .}')
 
                   echo "matrix=$matrix_json" >> "$GITHUB_OUTPUT"
                   echo "Discovered plugin collections:"


### PR DESCRIPTION
# fix(workflows): correct JSON output formatting in plugin discovery step

## Description

Fixed the plugin collection discovery step in the `plugin-package.yml` workflow by adding the compact output flag (`-c`) to the `jq` command. Without compact output, `jq -s` produced multi-line pretty-printed JSON that broke the `$GITHUB_OUTPUT` mechanism in GitHub Actions, preventing the matrix strategy from parsing the discovered plugin collections correctly.

- fix(workflows): Added `-c` (compact) flag to `jq -s` in the plugin discovery step, changing `jq -s '{include: .}'` to `jq -sc '{include: .}'` to produce single-line JSON output compatible with `$GITHUB_OUTPUT`.

## Related Issue(s)

N/A

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Verified that `jq -sc '{include: .}'` produces single-line JSON suitable for GitHub Actions matrix output.
- Confirmed the workflow YAML syntax is valid after the change.

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

The `jq -s` (slurp) flag correctly aggregates JSON objects into an array, but its default pretty-printed output spans multiple lines. GitHub Actions `$GITHUB_OUTPUT` requires values to be on a single line. The `-c` (compact) flag resolves this by ensuring the JSON is emitted as a single line.

🔧 Generated by Copilot
