### PR TITLE
fix(build): remove draft flag that prevents release tag creation

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "draft": true,
   "release-search-depth": 800,
   "commit-search-depth": 1000,
   "packages": {


### PR DESCRIPTION
## Description

Removed the `"draft": true` setting from `release-please-config.json`. Draft GitHub releases do not create git tags, which broke release-please's version anchoring. Without the prior version tag, release-please rescanned the full commit history, found an old breaking change, and incorrectly bumped from 2.3.0 to 3.0.0 instead of computing the next patch or minor version.

- Removed `"draft": true` from the top-level config object in `release-please-config.json`
- Future releases will be published immediately, creating the git tag that release-please uses to anchor subsequent version calculations

## Related Issue(s)

<!-- No issue references found in commits or branch name -->

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Validated JSON syntax of `release-please-config.json` after edit
- Verified diff contains only the intended single-line removal of `"draft": true,`

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [ ] Files follow existing naming conventions
- [ ] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

Two manual follow-up actions are required after this PR merges:

1. **Publish the v2.3.0 draft release** on GitHub to create the missing `hve-core-v2.3.0` git tag that anchors future release-please runs
2. **Close PR #532** (the incorrect 3.0.0 release PR) and delete its branch `release-please--branches--main--components--hve-core`

Without publishing the draft release, release-please will still fail to find the v2.3.0 version anchor even after this config fix lands on main.

🔧 - Generated by Copilot