### PR TITLE
fix(workflows): add manual tag creation for draft releases until release-please-action updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       minor: ${{ steps.release.outputs.minor }}
       patch: ${{ steps.release.outputs.patch }}
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -95,6 +95,34 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Bridge: GitHub does not create git tags for draft releases, but
+      # release-please needs the tag to anchor version calculations for
+      # subsequent release PRs. Without it, release-please scans the full
+      # commit history, may find an old breaking change, and proposes a
+      # wrong major bump. The force-tag-creation config option (release-please
+      # v17.2.0+) would handle this natively, but v4.4.0 of the action
+      # bundles v17.1.3. Remove this step once the action upgrades past
+      # v17.2.0. See: https://github.com/googleapis/release-please/pull/2423
+      - name: Create git tag for draft release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          TAG="${{ steps.release.outputs.tag_name }}"
+          echo "Creating tag $TAG at ${{ github.sha }}"
+          if ! OUTPUT=$(gh api "repos/${{ github.repository }}/git/refs" \
+            --method POST \
+            -f ref="refs/tags/$TAG" \
+            -f sha="${{ github.sha }}" 2>&1); then
+            if echo "$OUTPUT" | grep -qi "Reference already exists"; then
+              echo "::warning::Tag $TAG already exists, skipping"
+            else
+              echo "::error::Failed to create tag $TAG"
+              echo "$OUTPUT" >&2
+              exit 1
+            fi
+          fi
 
   extension-package-release:
     name: Package VS Code Extensions (Release)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "markdownlint-cli2": "^0.20.0"
   },
   "overrides": {
+    "markdown-it": "14.1.1",
     "undici": "7.18.2"
   },
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "draft": true,
   "release-search-depth": 800,
   "commit-search-depth": 1000,
   "force-tag-creation": true,


### PR DESCRIPTION
# fix(workflows): add draft release with manual tag bridge + markdown-it ReDoS patch

## Description

### Draft Release with Manual Tag Bridge

GitHub does not create git tags for draft releases, but `release-please` needs the tag to anchor version calculations for subsequent release PRs. Without it, `release-please` scans the full commit history, may find an old breaking change, and proposes a wrong major bump (evidenced by bogus v3.0.0 PRs #530, #532, #534, #539).

The `release-please-action` v4.4.0 bundles `release-please` v17.1.3, which does not support `force-tag-creation` (introduced in v17.2.0). This PR adds a temporary bridge step that creates the tag via the GitHub API immediately after a draft release is created.

**Changes:**

- Set `draft: true` in `release-please-config.json` so releases are mutable (fixes HTTP 422 on asset upload)
- Add manual tag creation step to `.github/workflows/main.yml` using `gh api` to push a lightweight tag
- Add robust error handling: detects duplicate tags specifically, fails on other errors
- Add `contents: write` permission for the tag creation API call

**Remove the manual tag-creation step once `release-please-action` ships with `release-please >= 17.2.0` and supports `force-tag-creation` natively.** See: https://github.com/googleapis/release-please/pull/2423

### markdown-it ReDoS Remediation (GHSA-38c4-r59v-3vqw)

`markdownlint-cli2@0.20.0` depends on `markdown-it@14.1.0`, which has a moderate ReDoS vulnerability (CVE-2026-2327) in the linkify regex. No upstream fix is available yet.

**Changes:**

- Add `markdown-it: 14.1.1` to `overrides` in `package.json` (follows existing `undici` override pattern)
- Patch-level bump with a single regex fix — no API surface changes

**Validation:** `npm audit` reports 0 vulnerabilities, `npm run lint:md` passes with 0 errors on all 153 files.

## Related Issue(s)

- Upstream tag creation: https://github.com/googleapis/release-please/pull/2423
- markdown-it advisory: https://github.com/advisories/GHSA-38c4-r59v-3vqw

## Type of Change

Select all that apply:

**Code &amp; Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure &amp; Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [x] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- `npm audit` — 0 vulnerabilities
- `npm run lint:md` — 0 errors, 153 files linted
- Tag creation step tested via CI on prior runs

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

Two independent fixes in this PR:

1. **Draft release bridge** — temporary workaround until `release-please-action` upgrades past v17.2.0
2. **markdown-it override** — temporary until `markdownlint-cli2` bumps its `markdown-it` dependency to >=14.1.1

🔧 - Generated by Copilot