### PR TITLE
fix(workflows): package pre-release VSIX artifacts correctly

### DIFF
--- a/.github/workflows/extension-package.yml
+++ b/.github/workflows/extension-package.yml
@@ -169,12 +169,18 @@ jobs:
         run: |
           $version = "${{ inputs.version }}".Trim()
           $devPatch = "${{ inputs.dev-patch-number }}".Trim()
+          $channel = "${{ inputs.channel }}".Trim()
+          if (-not $channel) { $channel = 'Stable' }
           $collection = "${{ matrix.manifest }}"
 
-          Write-Host "📦 Packaging extension (collection: ${{ matrix.id }})..."
+          Write-Host "📦 Packaging extension for $channel channel (collection: ${{ matrix.id }})..."
 
           $arguments = @{
             Collection = $collection
+          }
+
+          if ($channel -ieq 'PreRelease') {
+            $arguments['PreRelease'] = $true
           }
 
           if ($version) {


### PR DESCRIPTION
# fix(workflows): package pre-release VSIX artifacts correctly

## Description
This PR fixed the pre-release extension packaging path so generated VSIX artifacts are correctly marked for pre-release publishing.

- Updated `.github/workflows/extension-package.yml` to resolve the effective `channel` in the package step.
- Set the `PreRelease` argument when the channel is `PreRelease`, which forwards the pre-release mode into `Package-Extension.ps1` packaging.
- Updated packaging log output to include the active channel for clearer workflow diagnostics.

## Related Issue(s)
None.

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing
- Verified generated diff content from `.copilot-tracking/pr/pr-reference.xml` and confirmed the workflow change is scoped to pre-release packaging argument flow.
- Validated the edited workflow file has no editor-reported errors.

## Checklist

### Required Checks

- [ ] Documentation is updated (if applicable)
- [ ] Files follow existing naming conventions
- [ ] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions
- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations
- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [ ] Security-related scripts follow the principle of least privilege
