### PR TITLE
fix(workflows): replace draft release config with post-creation draft conversion

### DIFF
--- a/.github/workflows/extension-publish-prerelease.yml
+++ b/.github/workflows/extension-publish-prerelease.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'ODD minor version (e.g., 1.1.0, 1.3.0). Must use ODD minor number.'
-        required: true
+        description: 'ODD minor version (e.g., 1.1.0). Leave empty to auto-detect from latest release.'
+        required: false
         type: string
+        default: ''
       dry-run:
         description: 'Dry run (package only, do not publish)'
         required: false
@@ -25,27 +26,47 @@ jobs:
     steps:
       - name: Validate ODD minor version
         id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ inputs.version }}"
           # Strip leading 'v' if present
           VERSION="${VERSION#v}"
-          
+
+          # Auto-detect from latest release tag when no version specified
+          if [ -z "$VERSION" ]; then
+            TAG=$(gh release view --json tagName -q '.tagName' -R "${{ github.repository }}")
+            VERSION="${TAG#hve-core-v}"
+
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+            # Derive ODD minor: if even, bump minor by 1 and reset patch
+            if (( MINOR % 2 == 0 )); then
+              MINOR=$((MINOR + 1))
+              PATCH=0
+            fi
+            VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            echo "📦 Auto-derived pre-release version from latest release: $VERSION"
+          fi
+
           # Validate format
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid version format: $VERSION. Expected semantic version (e.g., 1.1.0)"
             exit 1
           fi
-          
+
           # Extract minor version
           MINOR=$(echo "$VERSION" | cut -d. -f2)
-          
+
           # Check if ODD (pre-release channel uses ODD minor versions)
           if (( MINOR % 2 == 0 )); then
             echo "::error::Pre-release requires ODD minor version. Got: $VERSION (minor=$MINOR is EVEN)"
             echo "::error::Use version like 1.1.0, 1.3.0, 2.1.0 for pre-release channel"
             exit 1
           fi
-          
+
           echo "✅ Valid pre-release version: $VERSION (minor=$MINOR is ODD)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (leave empty to use package.json version)'
+        description: 'Version to publish (leave empty to auto-detect from latest release)'
         required: false
         type: string
         default: ''
@@ -63,14 +63,25 @@ jobs:
     steps:
       - name: Normalize version string
         id: normalize
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
             VERSION="${{ github.event.release.tag_name }}"
           else
             VERSION="${{ inputs.version }}"
           fi
-          # Strip leading 'v' if present
+          # Strip leading 'v' and component prefix if present
           VERSION="${VERSION#v}"
+          VERSION="${VERSION#hve-core-v}"
+
+          # Auto-detect from latest release tag when no version specified
+          if [ -z "$VERSION" ]; then
+            TAG=$(gh release view --json tagName -q '.tagName' -R "${{ github.repository }}")
+            VERSION="${TAG#hve-core-v}"
+            echo "📦 Auto-detected version from latest release: $VERSION"
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   package:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,33 +96,17 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Bridge: GitHub does not create git tags for draft releases, but
-      # release-please needs the tag to anchor version calculations for
-      # subsequent release PRs. Without it, release-please scans the full
-      # commit history, may find an old breaking change, and proposes a
-      # wrong major bump. The force-tag-creation config option (release-please
-      # v17.2.0+) would handle this natively, but v4.4.0 of the action
-      # bundles v17.1.3. Remove this step once the action upgrades past
-      # v17.2.0. See: https://github.com/googleapis/release-please/pull/2423
-      - name: Create git tag for draft release
+      # Bridge: release-please creates a published release so it can
+      # anchor version calculations in the same run. Convert to draft
+      # immediately so assets can be uploaded to a mutable release.
+      # The publish-release job converts back to published after upload.
+      - name: Convert release to draft for asset upload
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          TAG="${{ steps.release.outputs.tag_name }}"
-          echo "Creating tag $TAG at ${{ github.sha }}"
-          if ! OUTPUT=$(gh api "repos/${{ github.repository }}/git/refs" \
-            --method POST \
-            -f ref="refs/tags/$TAG" \
-            -f sha="${{ github.sha }}" 2>&1); then
-            if echo "$OUTPUT" | grep -qi "Reference already exists"; then
-              echo "::warning::Tag $TAG already exists, skipping"
-            else
-              echo "::error::Failed to create tag $TAG"
-              echo "$OUTPUT" >&2
-              exit 1
-            fi
-          fi
+          gh release edit "${{ steps.release.outputs.tag_name }}" \
+            --draft=true -R "${{ github.repository }}"
 
   extension-package-release:
     name: Package VS Code Extensions (Release)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "draft": true,
   "release-search-depth": 800,
   "commit-search-depth": 1000,
-  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "node",
@@ -19,7 +17,6 @@
       ],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Description

Fixes a race condition where release-please `"draft": true` configuration caused draft releases that are excluded from the GitHub Releases API "latest" query, making them invisible to release-please's own version anchoring within the same workflow invocation. Because the draft release is invisible, release-please scans the full commit history, finds an old breaking change (PR #277), and proposes erroneous v3.0.0 major version bumps. Also added auto-detection of version from the latest GitHub release tag in both extension publish workflows, removing the requirement for manual version input on every dispatch.

**Proof the race condition fires in production:** after v2.3.4 merged, release-please created the v2.3.4 release as draft at 22:05:23 UTC. At 22:08:14 UTC — while v2.3.4 was still draft — release-please opened PR #547 proposing v3.0.0. The v2.3.4 release was not published until 22:10:08 UTC, confirming that release-please computed the next version while v2.3.4 was invisible to its own Releases API query.

Additionally, v2.3.2 remains stuck in draft state, demonstrating that the `publish-release` job's `gh release edit --draft=false` is unreliable when it depends on upstream jobs that may not always run.

### Changes

- fix(workflows): removed `"draft": true` from root and package level in `release-please-config.json` so release-please creates published releases that are immediately visible to the Releases API for version anchoring
- fix(workflows): removed `"force-tag-creation": true` from `release-please-config.json` since it requires release-please v17.2.0+ and was silently ignored by the bundled v17.1.3
- fix(workflows): replaced 20-line tag bridge step in `main.yml` with a `gh release edit --draft=true` post-creation conversion, allowing assets to be uploaded to a mutable draft release while preserving release visibility for version anchoring
- feat(workflows): added auto-detection of version from latest GitHub release tag in `extension-publish-prerelease.yml` when version input is empty, with ODD minor derivation for the pre-release channel
- feat(workflows): added auto-detection of version from latest GitHub release tag in `extension-publish.yml` when version input is empty, with `hve-core-v` prefix stripping
- fix(workflows): updated `extension-publish.yml` input description to match new auto-detect behavior (was incorrectly referencing `package.json`)

## Related Issue(s)

Fixes #543

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Validated YAML linting passes via `npm run lint:yaml` — all 25 workflow files passed
- Verified `release-please-config.json` is valid JSON with no schema errors
- Confirmed the `publish-release` job already contains `gh release edit --draft=false` to finalize releases after asset upload
- Confirmed `gh release view --json tagName` correctly returns the latest release tag format (`hve-core-v2.3.4`)

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The release lifecycle after this change follows a four-phase sequence: release-please creates a **published** release (tag created, visible to Releases API) → post-creation step converts to **draft** (mutable for asset upload) → package/attest/upload jobs attach assets → `publish-release` job converts back to **published**. This preserves the original HTTP 422 fix from PR #538 while eliminating the version anchoring race condition that caused PRs #530, #532, #534, #539, #540, #542, and #547.

### Why the tag bridge didn't work

The tag bridge step from PR #538 manually created git tags after draft release creation. However, release-please anchors its version calculation on the GitHub **Releases** API (not the Tags API). Even though tag `hve-core-v2.3.4` existed at commit `9a72f2b`, release-please's query for the latest release excluded the draft, causing it to scan the full commit history and hit the old breaking change from PR #277.