### PR TITLE
fix(workflows): delete and recreate immutable release as draft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,17 +96,27 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Bridge: release-please creates a published release so it can
-      # anchor version calculations in the same run. Convert to draft
-      # immediately so assets can be uploaded to a mutable release.
-      # The publish-release job converts back to published after upload.
-      - name: Convert release to draft for asset upload
+      # Bridge: release-please creates a published (immutable) release,
+      # ensuring version anchoring succeeds. Published releases cannot
+      # be edited or have assets uploaded (HTTP 422). Delete the
+      # immutable release and recreate as a mutable draft so downstream
+      # jobs can upload assets. The tag persists across the delete/create
+      # cycle. The publish-release job converts the draft back to published.
+      - name: Recreate release as draft for asset upload
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh release edit "${{ steps.release.outputs.tag_name }}" \
-            --draft=true -R "${{ github.repository }}"
+          TAG="${{ steps.release.outputs.tag_name }}"
+          REPO="${{ github.repository }}"
+          # Capture release metadata before deletion
+          gh release view "$TAG" --json body -q '.body' -R "$REPO" > /tmp/release-body.md
+          NAME=$(gh release view "$TAG" --json name -q '.name' -R "$REPO")
+          # Delete immutable published release; tag is preserved
+          gh release delete "$TAG" --yes -R "$REPO"
+          # Recreate as mutable draft for asset upload
+          gh release create "$TAG" --draft --verify-tag \
+            --title "$NAME" --notes-file /tmp/release-body.md -R "$REPO"
 
   extension-package-release:
     name: Package VS Code Extensions (Release)


### PR DESCRIPTION
## Description

Published releases on this repository are immutable — the `gh release edit --draft=true` step introduced in PR #545 fails with `HTTP 422: state cannot be changed when release is immutable`. This PR replaces the edit approach with a delete-and-recreate cycle: capture the release metadata, delete the immutable published release, and recreate it as a mutable draft so downstream jobs can upload assets. The git tag persists across the delete/create cycle, and the `publish-release` job converts the draft back to published after upload completes.

**Why prior approaches failed:**

- PR #538 (`"draft": true` in config) — release-please cannot find draft releases via the Releases API, causing it to scan full history and propose a bogus v3.0.0
- PR #545 (`gh release edit --draft=true`) — published releases are immutable on this repo (HTTP 422)

## Related Issue(s)

Fixes #543

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- Validated YAML syntax of `main.yml` with `yamllint`
- Confirmed `gh release delete` preserves the git tag (documented GitHub CLI behavior)
- Confirmed `gh release create --draft --verify-tag` recreates a mutable draft tied to the existing tag
- Verified `--notes-file` approach safely handles release body content with special characters

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The delete-and-recreate approach is safe because:

1. **Tag preservation** — `gh release delete` only removes the release object; the git tag remains intact
2. **Timing** — release-please has already completed version anchoring before this step runs, so the brief absence of the release object has no effect
3. **Metadata fidelity** — release title and body are captured before deletion and reapplied to the new draft via `--notes-file` (avoids shell interpolation issues)
4. **Downstream compatibility** — all subsequent jobs reference `steps.release.outputs.tag_name`, which is unaffected by the recreate