### PR TITLE
fix(workflows): delete and recreate draft release to publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       # be edited or have assets uploaded (HTTP 422). Delete the
       # immutable release and recreate as a mutable draft so downstream
       # jobs can upload assets. The tag persists across the delete/create
-      # cycle. The publish-release job converts the draft back to published.
+      # cycle. The publish-release job deletes the draft and recreates as published.
       - name: Recreate release as draft for asset upload
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
@@ -110,8 +110,9 @@ jobs:
           TAG="${{ steps.release.outputs.tag_name }}"
           REPO="${{ github.repository }}"
           # Capture release metadata before deletion
-          gh release view "$TAG" --json body -q '.body' -R "$REPO" > /tmp/release-body.md
-          NAME=$(gh release view "$TAG" --json name -q '.name' -R "$REPO")
+          RELEASE_JSON=$(gh release view "$TAG" --json name,body -R "$REPO")
+          NAME=$(echo "$RELEASE_JSON" | jq -r '.name')
+          echo "$RELEASE_JSON" | jq -r '.body' > /tmp/release-body.md
           # Delete immutable published release; tag is preserved
           gh release delete "$TAG" --yes -R "$REPO"
           # Recreate as mutable draft for asset upload
@@ -213,4 +214,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release edit "${{ needs.release-please.outputs.tag_name }}" --draft=false -R "${{ github.repository }}"
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          REPO="${{ github.repository }}"
+          # Capture draft release metadata
+          RELEASE_JSON=$(gh release view "$TAG" --json name,body -R "$REPO")
+          NAME=$(echo "$RELEASE_JSON" | jq -r '.name')
+          echo "$RELEASE_JSON" | jq -r '.body' > /tmp/release-body.md
+          # Delete mutable draft; recreate as published
+          gh release delete "$TAG" --yes -R "$REPO"
+          gh release create "$TAG" --verify-tag \
+            --title "$NAME" --notes-file /tmp/release-body.md -R "$REPO"


### PR DESCRIPTION
## Description

The `publish-release` job at the end of the release pipeline uses `gh release edit --draft=false` to publish the draft release after asset uploads complete. This fails with `HTTP 422: tag_name was used by an immutable release` — GitHub enforces immutability at the tag level, so any release using a tag that was previously associated with an immutable release cannot be edited via `gh release edit`.

This applies the same delete-and-recreate pattern from PR #550 to the `publish-release` job: capture the draft's metadata, delete it, and recreate as a published release.

Also consolidates both recreate steps (draft and publish) to use a single `gh release view --json name,body` API call with `jq` instead of two separate queries.

## Related Issue(s)

Fixes #543

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Testing

- v2.3.6 release confirmed that asset uploads succeeded with the draft recreate from PR #550
- The only failure was the `publish-release` job's `gh release edit --draft=false` — this PR fixes that final step

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

- [ ] Markdown linting: `npm run lint:md`
- [ ] Spell checking: `npm run spell-check`
- [ ] Frontmatter validation: `npm run lint:frontmatter`
- [ ] Link validation: `npm run lint:md-links`
- [ ] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

After this change, the full release lifecycle is: release-please creates published (immutable) release → delete and recreate as draft (mutable) → package/attest/upload assets → delete draft and recreate as published. No `gh release edit` calls remain in the pipeline.