### PR TITLE
fix(workflows): use draft-first release flow to avoid immutability errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,28 +96,28 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # Bridge: release-please creates a published (immutable) release,
-      # ensuring version anchoring succeeds. Published releases cannot
-      # be edited or have assets uploaded (HTTP 422). Delete the
-      # immutable release and recreate as a mutable draft so downstream
-      # jobs can upload assets. The tag persists across the delete/create
-      # cycle. The publish-release job deletes the draft and recreates as published.
-      - name: Recreate release as draft for asset upload
+      # Workaround: release-please with "draft": true uses lazy tag
+      # creation — the git tag is not materialized until the release is
+      # published. Without the tag, release-please cannot find the draft
+      # on subsequent runs, breaking version anchoring. Create the tag
+      # explicitly via API. Replace with "force-tag-creation": true in
+      # release-please-config.json once release-please-action ships a
+      # version that includes googleapis/release-please#2627.
+      - name: Create git tag for draft release
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           TAG="${{ steps.release.outputs.tag_name }}"
           REPO="${{ github.repository }}"
-          # Capture release metadata before deletion
-          RELEASE_JSON=$(gh release view "$TAG" --json name,body -R "$REPO")
-          NAME=$(echo "$RELEASE_JSON" | jq -r '.name')
-          echo "$RELEASE_JSON" | jq -r '.body' > /tmp/release-body.md
-          # Delete immutable published release; tag is preserved
-          gh release delete "$TAG" --yes -R "$REPO"
-          # Recreate as mutable draft for asset upload
-          gh release create "$TAG" --draft --verify-tag \
-            --title "$NAME" --notes-file /tmp/release-body.md -R "$REPO"
+          if ! gh api "/repos/$REPO/git/refs/tags/$TAG" --silent 2>/dev/null; then
+            gh api "/repos/$REPO/git/refs" \
+              -f "ref=refs/tags/$TAG" \
+              -f "sha=${{ github.sha }}"
+            echo "Created git tag $TAG -> ${{ github.sha }}"
+          else
+            echo "Git tag $TAG already exists"
+          fi
 
   extension-package-release:
     name: Package VS Code Extensions (Release)
@@ -216,11 +216,6 @@ jobs:
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
           REPO="${{ github.repository }}"
-          # Capture draft release metadata
-          RELEASE_JSON=$(gh release view "$TAG" --json name,body -R "$REPO")
-          NAME=$(echo "$RELEASE_JSON" | jq -r '.name')
-          echo "$RELEASE_JSON" | jq -r '.body' > /tmp/release-body.md
-          # Delete mutable draft; recreate as published
-          gh release delete "$TAG" --yes -R "$REPO"
-          gh release create "$TAG" --verify-tag \
-            --title "$NAME" --notes-file /tmp/release-body.md -R "$REPO"
+          # Promote draft to published. The release becomes immutable
+          # after publish with all assets already attached.
+          gh release edit "$TAG" --draft=false -R "$REPO"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     ".": {
       "release-type": "node",
       "package-name": "hve-core",
+      "draft": true,
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [


### PR DESCRIPTION
# Pull Request

## Description

Fixes the persistent `HTTP 422: tag_name was used by an immutable release` error in the `publish-release` job. This is the **fifth iteration** (PRs #538 → #545 → #550 → #552) — all previous approaches failed because they attempted to delete and recreate releases or tags after publication, which GitHub's immutability model permanently forbids.

### Root Cause

GitHub's [immutable releases documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#about-immutable-releases) states:

> *"Git tags cannot be moved or deleted"* for immutable releases. *"Even if you delete a repository and create a new one with the same name, you cannot reuse tags that were associated with immutable releases."*

The tag name is **permanently tainted** at GitHub's infrastructure level once a release is published with immutability enabled. Every delete/recreate approach was fundamentally doomed:

| PR | Approach | Failure Mode |
|----|----------|-------------|
| #538 | `"draft": true` in config | Race condition — release-please can't find draft releases (lazy tag) |
| #545 | `gh release edit --draft=true` | Can't edit published immutable release |
| #550 | Delete published, recreate as draft | Worked for upload, but publish step failed |
| #552 | Delete draft, recreate as published | HTTP 422 — tag name permanently reserved |

### Solution: Draft-First Flow

Follow [GitHub's recommended workflow](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#creating-immutable-releases):

1. **release-please creates release as draft** (`"draft": true` in config)
2. **Explicit git tag creation** via API (workaround for release-please's lazy tag behavior)
3. **Upload assets to the mutable draft** (existing `attest-and-upload` and `upload-plugin-packages` jobs)
4. **Publish**: `gh release edit --draft=false` — release becomes immutable with all assets already attached

### Draft Race Condition Workaround

release-please with `"draft": true` uses lazy tag creation — the git tag isn't materialized until publish. Without the tag, release-please's GraphQL query returns null for `tag` and `tagCommit`, causing it to skip the draft and propose a bogus version bump.

This was fixed upstream in [googleapis/release-please#2627](https://github.com/googleapis/release-please/pull/2627) (`force-tag-creation` option), but the fix is **not yet released** in release-please-action (latest: v4.4.0 → release-please 17.1.3). We work around this by explicitly creating the git tag via API after draft creation.

When a new release-please-action ships with PR #2627, replace the manual tag creation step with `"force-tag-creation": true` in `release-please-config.json`.

## Related Issue(s)

Supersedes PRs #538, #545, #550, #552

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow

## Testing

- Verified YAML and JSON syntax (no lint errors)
- Logic validated against [GitHub REST API docs](https://docs.github.com/en/rest/releases/releases), [immutable releases concept](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#about-immutable-releases), and [release-please issue #1650](https://github.com/googleapis/release-please/issues/1650)  
- The draft-first approach avoids all immutability enforcement because assets are uploaded to mutable drafts, and publish is a single `--draft=false` edit (not a delete/create)

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [x] Any new dependencies have been reviewed for security issues

## Additional Notes

- **v2.3.7 remediation**: The v2.3.7 tag is permanently tainted. A manual release may be needed if v2.3.7 assets need to be published. The next release-please cycle (v2.3.8+) will use the draft-first flow and should succeed cleanly.
- **Future upgrade**: Once `release-please-action` includes `force-tag-creation` support, the manual tag creation step can be replaced with a single config line. This is documented in a code comment referencing googleapis/release-please#2627.
