### PR TITLE
ci(workflows): skip PR creation on release commits to prevent bogus major-version PRs

### DIFF
--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -269,6 +269,37 @@ All workflows MUST pass the following validation checks:
     fi
 ```
 
+## YAML Expression Quoting
+
+GitHub Actions expression single quotes (`'...'`) inside `${{ }}` are NOT YAML quotes. The YAML parser treats them as literal characters in a plain scalar. If the expression text contains a colon followed by whitespace (`:`&nbsp;), the YAML parser interprets it as a mapping value indicator and fails with `mapping values are not allowed in this context`.
+
+**Problem pattern:**
+
+```yaml
+# FAILS: ': release' contains colon-space, YAML parser chokes
+with:
+  my-input: ${{ startsWith(value, 'prefix: release') }}
+```
+
+**Acceptable solutions (in preference order):**
+
+1. **Shorten the literal to avoid colon-space.** Use a prefix that does not contain a colon followed by whitespace when the specificity tradeoff is acceptable.
+
+    ```yaml
+    with:
+      my-input: ${{ startsWith(value, 'prefix') }}
+    ```
+
+2. **Double-quote the entire expression.** This makes the value a YAML quoted scalar, preventing the parser from interpreting internal colon-space as structure. Add a comment explaining why quotes are required.
+
+    ```yaml
+    with:
+      # Quotes required: expression literal contains ': ' which breaks YAML plain scalars
+      my-input: "${{ startsWith(value, 'prefix: release') }}"
+    ```
+
+Avoid `format()` workarounds or environment variable indirection when the simpler options above apply.
+
 ## Enforcement Statement
 
 The following scripts enforce compliance:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,12 +95,20 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # On release commits, skip PR creation to prevent bogus PRs
+          # from draft release lazy tag timing. Release commits have zero
+          # unreleased changes so skipping loses nothing. The tag is
+          # created in the next step, ensuring subsequent runs find it.
+          skip-github-pull-request: ${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main)') }}
 
       # Workaround: release-please with "draft": true uses lazy tag
-      # creation — the git tag is not materialized until the release is
+      # creation. The git tag is not materialized until the release is
       # published. Without the tag, release-please cannot find the draft
-      # on subsequent runs, breaking version anchoring. Create the tag
-      # explicitly via API. Replace with "force-tag-creation": true in
+      # on subsequent runs, breaking version anchoring and causing bogus
+      # major-version PRs. The skip-github-pull-request conditional above
+      # prevents PR creation on release commits (zero unreleased changes),
+      # and this step creates the tag so subsequent runs find the release.
+      # Replace both workarounds with "force-tag-creation": true in
       # release-please-config.json once release-please-action ships a
       # version that includes googleapis/release-please#2627.
       - name: Create git tag for draft release


### PR DESCRIPTION
## Description

Prevents release-please from creating bogus v3.0.0 PRs when it runs on release commits. The root cause is a timing issue with `"draft": true` in the release-please config: draft releases use lazy tag creation, so the git tag is not materialized until the release is published. Without the tag, release-please cannot locate the draft on subsequent runs, version anchoring fails, and the manifest falls back to scanning all commits — picking up an old `BREAKING CHANGE` footer and proposing un-warranted major bumps.

The fix adds `skip-github-pull-request` to the release-please action step, conditioned on `startsWith(github.event.head_commit.message, 'chore(main)')`. Release commits carry zero unreleased changes, so skipping PR creation loses nothing. The existing manual tag-creation step ensures subsequent runs find the tag regardless.

- ci(workflows): added `skip-github-pull-request` conditional to `main.yml` release-please step, gated on release-commit prefix detection
- ci(workflows): updated the workaround comment block to reference both the skip conditional and the manual tag creation as a paired mitigation
- docs(instructions): added "YAML Expression Quoting" section to `workflows.instructions.md` documenting the colon-space plain scalar parsing issue and two acceptable solutions in preference order

### YAML Expression Quoting Investigation

During implementation, `actionlint` rejected the bare expression `${{ startsWith(value, 'chore(main): release') }}` because the GitHub Actions single-quoted literal `': release'` contains a colon followed by whitespace. The YAML parser interprets that as a mapping value indicator inside a plain scalar, which is invalid. Seven alternatives were tested:

| # | Expression | YAML Quoting | actionlint | Notes |
|---|-----------|--------------|------------|-------|
| 1 | `startsWith(msg, 'chore(main): release')` | bare | FAIL | `': release'` has `: ` |
| 2 | `startsWith(msg, 'chore(main): release')` | `"${{ }}"` | PASS | Only double-quoted `with:` input in repo |
| 3 | `startsWith(msg, 'chore(main)')` | bare | PASS | **Selected** — shorter prefix, no colon-space |
| 4 | `format('{0}: release', 'chore(main)')` | bare | FAIL | `': release'` still has `: ` |
| 5 | `format('{0}{1}{2}', 'chore(main)', ':', ' release')` | bare | PASS | Over-engineered |
| 6 | `startsWith(msg, 'chore(main):')` | bare | PASS | Colon without space is fine |
| 7 | `env.RELEASE_PREFIX` + `startsWith(msg, env.RELEASE_PREFIX)` | bare | PASS | Adds indirection |

Option 3 was selected: the shorter prefix `'chore(main)'` avoids colon-space entirely, enabling bare `${{ }}` which matches every other `with:` input in the repo. The specificity tradeoff is acceptable since all `chore(main)` commits are release-please-generated.

## Related Issue(s)

Fixes #559

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [x] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [x] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- Not applicable — the instructions addition documents a YAML parsing edge case for workflow authors -->

## Testing

- `actionlint` passed on `main.yml` with the final expression form
- `npm run lint:all` passed (all 8 validation stages: markdown, spell-check, frontmatter, link validation, PowerShell analysis, YAML linting, copyright headers, action version pinning)
- Seven YAML expression quoting alternatives were systematically tested with `actionlint` to identify the root cause and select the cleanest fix (see investigation table above)

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [x] Link validation: `npm run lint:md-links`
- [x] PowerShell analysis: `npm run lint:ps`

## Security Considerations

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues
- [x] Security-related scripts follow the principle of least privilege

## Additional Notes

**Upstream references:**

- [googleapis/release-please#2627](https://github.com/googleapis/release-please/issues/2627) — `force-tag-creation` feature request that would eliminate both workarounds
- [googleapis/release-please-action#962](https://github.com/googleapis/release-please-action/issues/962) — draft release tag timing discussion
- [googleapis/release-please-action#906](https://github.com/googleapis/release-please-action/issues/906) — related version anchoring issue

**Follow-up:** Once release-please-action ships a version containing `force-tag-creation` support (release-please#2627), both the `skip-github-pull-request` conditional and the manual tag-creation step can be replaced with `"force-tag-creation": true` in `release-please-config.json`.

🛡️ - Generated by Copilot