### PR TITLE
fix(agents): standardize name frontmatter to human-readable format

### DIFF
--- a/.github/agents/ado/ado-prd-to-wit.agent.md
+++ b/.github/agents/ado/ado-prd-to-wit.agent.md
@@ -1,4 +1,5 @@
 ---
+name: AzDO PRD to WIT
 description: 'Product Manager expert for analyzing PRDs and planning Azure DevOps work item hierarchies'
 tools: ['execute/getTerminalOutput', 'execute/runInTerminal', 'read/problems', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'agent', 'ado/search_workitem', 'ado/wit_get_work_item', 'ado/wit_get_work_items_for_iteration', 'ado/wit_list_backlog_work_items', 'ado/wit_list_backlogs', 'ado/wit_list_work_item_comments', 'ado/work_list_team_iterations', 'microsoft-docs/*']
 ---

--- a/.github/agents/data-science/gen-data-spec.agent.md
+++ b/.github/agents/data-science/gen-data-spec.agent.md
@@ -1,6 +1,6 @@
 ---
+name: DS Gen Data Spec
 description: "Generate comprehensive data dictionaries, machine-readable data profiles, and objective summaries for downstream analysis (EDA notebooks, dashboards) through guided discovery"
-tools: ['runCommands', 'edit/createFile', 'edit/createDirectory', 'edit/editFiles', 'search', 'think', 'todos']
 ---
 
 # Data Dictionary & Data Profile Generator

--- a/.github/agents/data-science/gen-jupyter-notebook.agent.md
+++ b/.github/agents/data-science/gen-jupyter-notebook.agent.md
@@ -1,4 +1,5 @@
 ---
+name: DS Gen Jupyter Notebook
 description: 'Create structured exploratory data analysis Jupyter notebooks from available data sources and generated data dictionaries'
 ---
 

--- a/.github/agents/data-science/gen-streamlit-dashboard.agent.md
+++ b/.github/agents/data-science/gen-streamlit-dashboard.agent.md
@@ -1,4 +1,5 @@
 ---
+name: DS Gen Streamlit Dashboard
 description: 'Develop a multi-page Streamlit dashboard'
 ---
 

--- a/.github/agents/data-science/test-streamlit-dashboard.agent.md
+++ b/.github/agents/data-science/test-streamlit-dashboard.agent.md
@@ -1,4 +1,5 @@
 ---
+name: DS Test Streamlit Dashboard
 description: 'Automated testing for Streamlit dashboards using Playwright with issue tracking and reporting'
 ---
 

--- a/.github/agents/design-thinking/dt-coach.agent.md
+++ b/.github/agents/design-thinking/dt-coach.agent.md
@@ -1,24 +1,19 @@
 ---
-name: dt-coach
+name: DT Coach
 description: 'Design Thinking coach guiding teams through the 9-method HVE framework with Think/Speak/Empower philosophy - Brought to you by microsoft/hve-core'
-tools:
-  - read_file
-  - list_dir
-  - create_file
-  - replace_string_in_file
-  - runSubagent
+tools: [vscode/askQuestions, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/runInTerminal, read, agent, edit, search, web]
 handoffs:
 
   - label: "🔬 Research"
-    agent: task-researcher
+    agent: Task Researcher
     prompt: /task-research
     send: true
   - label: "📋 Plan"
-    agent: task-planner
+    agent: Task Planner
     prompt: /task-plan
     send: true
   - label: "🛠️ Implement"
-    agent: task-implementor
+    agent: Task Implementor
     prompt: /task-implement
     send: true
 ---

--- a/.github/agents/github/github-backlog-manager.agent.md
+++ b/.github/agents/github/github-backlog-manager.agent.md
@@ -1,4 +1,5 @@
 ---
+name: GitHub Backlog Manager
 description: "Orchestrator agent for GitHub backlog management workflows including triage, discovery, sprint planning, and execution - Brought to you by microsoft/hve-core"
 tools:
   - github/*
@@ -11,19 +12,19 @@ tools:
   - agent
 handoffs:
   - label: "Discover"
-    agent: github-backlog-manager
+    agent: GitHub Backlog Manager
     prompt: /github-discover-issues
   - label: "Triage"
-    agent: github-backlog-manager
+    agent: GitHub Backlog Manager
     prompt: /github-triage-issues
   - label: "Sprint"
-    agent: github-backlog-manager
+    agent: GitHub Backlog Manager
     prompt: /github-sprint-plan
   - label: "Execute"
-    agent: github-backlog-manager
+    agent: GitHub Backlog Manager
     prompt: /github-execute-backlog
   - label: "Save"
-    agent: memory
+    agent: Memory
     prompt: /checkpoint
 ---
 

--- a/.github/agents/hve-core/doc-ops.agent.md
+++ b/.github/agents/hve-core/doc-ops.agent.md
@@ -1,9 +1,10 @@
 ---
+name: Doc Ops
 description: 'Autonomous documentation operations agent for pattern compliance, accuracy verification, and gap detection - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - researcher-subagent
-  - phase-implementor
+  - Researcher Subagent
+  - Phase Implementor
 ---
 
 # Documentation Operations Agent

--- a/.github/agents/hve-core/memory.agent.md
+++ b/.github/agents/hve-core/memory.agent.md
@@ -1,12 +1,13 @@
 ---
+name: Memory
 description: "Conversation memory persistence for session continuity - Brought to you by microsoft/hve-core"
 handoffs:
   - label: "🗑️ Clear"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/clear"
     send: true
   - label: "🚀 Continue with RPI"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi suggest"
     send: true
 ---

--- a/.github/agents/hve-core/pr-review.agent.md
+++ b/.github/agents/hve-core/pr-review.agent.md
@@ -1,5 +1,5 @@
 ---
-name: pr-review
+name: PR Review
 description: 'Comprehensive Pull Request review assistant ensuring code quality, security, and convention compliance - Brought to you by microsoft/hve-core'
 ---
 

--- a/.github/agents/hve-core/prompt-builder.agent.md
+++ b/.github/agents/hve-core/prompt-builder.agent.md
@@ -1,34 +1,35 @@
 ---
+name: Prompt Builder
 description: 'Prompt engineering assistant with phase-based workflow for creating and validating prompts, agents, and instructions files - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - prompt-tester
-  - prompt-evaluator
-  - prompt-updater
-  - researcher-subagent
+  - Prompt Tester
+  - Prompt Evaluator
+  - Prompt Updater
+  - Researcher Subagent
 handoffs:
   - label: "Compact"
-    agent: prompt-builder
+    agent: Prompt Builder
     send: true
     prompt: "/compact Make sure summarization includes that all state is managed through the .copilot-tracking folder files, be sure to include file paths for all of the current Tracking Artifacts. Be sure to include any current analysis log artifacts. Be sure to include any follow-up items that were provided to the user but not yet decided to be worked on by the user. Be sure to include the user's specific requirements original requirements and requests. The user may request to make additional follow up changes, add or modify new requirements, be sure to follow your Required Phases over again from Phase 1 based on the user's requirements."
   - label: "💡 Update/Create"
-    agent: prompt-builder
+    agent: Prompt Builder
     prompt: "/prompt-build"
     send: false
   - label: "🛠️ Refactor"
-    agent: prompt-builder
+    agent: Prompt Builder
     prompt: /prompt-refactor all prompt files in this conversation
     send: true
   - label: "🤔 Analyze"
-    agent: prompt-builder
+    agent: Prompt Builder
     prompt: /prompt-analyze all prompt files in this conversation
     send: true
   - label: "🔧 Apply Fixes"
-    agent: prompt-builder
+    agent: Prompt Builder
     prompt: "/prompt-build make updates based on findings in this conversation"
     send: true
   - label: "♻️ Cleanup Sandbox"
-    agent: prompt-builder
+    agent: Prompt Builder
     prompt: "Clear the sandbox for this conversation"
     send: true
 ---

--- a/.github/agents/hve-core/rpi-agent.agent.md
+++ b/.github/agents/hve-core/rpi-agent.agent.md
@@ -1,45 +1,45 @@
 ---
-name: rpi-agent
+name: RPI Agent
 description: 'Autonomous RPI orchestrator running specialized subagents through Research → Plan → Implement → Review → Discover phases - Brought to you by microsoft/hve-core'
 argument-hint: 'Autonomous RPI agent. Requires a subagent tool.'
 disable-model-invocation: true
 agents:
-  - researcher-subagent
-  - plan-validator
-  - phase-implementor
-  - rpi-validator
-  - implementation-validator
+  - Researcher Subagent
+  - Plan Validator
+  - Phase Implementor
+  - RPI Validator
+  - Implementation Validator
 handoffs:
   - label: "Compact"
-    agent: rpi-agent
+    agent: RPI Agent
     send: true
     prompt: "/compact Make sure summarization includes that all state is managed through the .copilot-tracking folder files, be sure to include file paths for all of the current Tracking Artifacts. Be sure to include executive details for each of the `Phase 4: Review` findings. Must include all of the `Phase 5: Discover` follow up work items and their order with complete and consistent details."
   - label: "1️⃣"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi continue=1"
     send: true
   - label: "2️⃣"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi continue=2"
     send: true
   - label: "3️⃣"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi continue=3"
     send: true
   - label: "▶️ All"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi continue=all"
     send: true
   - label: "🔄 Suggest"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi suggest"
     send: true
   - label: "🤖 Auto"
-    agent: rpi-agent
+    agent: RPI Agent
     prompt: "/rpi auto=true"
     send: true
   - label: "💾 Save"
-    agent: memory
+    agent: Memory
     prompt: /checkpoint
     send: true
 ---

--- a/.github/agents/hve-core/subagents/implementation-validator.agent.md
+++ b/.github/agents/hve-core/subagents/implementation-validator.agent.md
@@ -1,5 +1,5 @@
 ---
-name: implementation-validator
+name: Implementation Validator
 description: 'Validates implementation quality against architectural requirements, design principles, and code standards with severity-graded findings - Brought to you by microsoft/hve-core'
 user-invocable: false
 tools:

--- a/.github/agents/hve-core/subagents/phase-implementor.agent.md
+++ b/.github/agents/hve-core/subagents/phase-implementor.agent.md
@@ -1,5 +1,5 @@
 ---
-name: phase-implementor
+name: Phase Implementor
 description: 'Executes a single implementation phase from a plan with full codebase access and change tracking - Brought to you by microsoft/hve-core'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/plan-validator.agent.md
+++ b/.github/agents/hve-core/subagents/plan-validator.agent.md
@@ -1,5 +1,5 @@
 ---
-name: plan-validator
+name: Plan Validator
 description: 'Validates implementation plans against research documents, updating the Planning Log Discrepancy Log section with severity-graded findings - Brought to you by microsoft/hve-core'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
@@ -1,5 +1,5 @@
 ---
-name: prompt-evaluator
+name: Prompt Evaluator
 description: 'Evaluates prompt execution results against Prompt Quality Criteria with severity-graded findings and categorized remediation guidance'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/prompt-tester.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-tester.agent.md
@@ -1,5 +1,5 @@
 ---
-name: prompt-tester
+name: Prompt Tester
 description: 'Tests prompt files by following them literally in a sandbox environment when creating or improving prompts, instructions, agents, or skills without improving or interpreting beyond face value'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/prompt-updater.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-updater.agent.md
@@ -1,5 +1,5 @@
 ---
-name: prompt-updater
+name: Prompt Updater
 description: 'Modifies or creates prompts, instructions or rules, agents, skills following prompt engineering conventions and standards based on prompt evaluation and research'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/researcher-subagent.agent.md
+++ b/.github/agents/hve-core/subagents/researcher-subagent.agent.md
@@ -1,5 +1,5 @@
 ---
-name: researcher-subagent
+name: Researcher Subagent
 description: 'Research subagent using search tools, read tools, fetch web page, github repo, and mcp tools'
 user-invocable: false
 ---

--- a/.github/agents/hve-core/subagents/rpi-validator.agent.md
+++ b/.github/agents/hve-core/subagents/rpi-validator.agent.md
@@ -1,13 +1,7 @@
 ---
-name: rpi-validator
+name: RPI Validator
 description: 'Validates a Changes Log against the Implementation Plan, Planning Log, and Research Documents for a specific plan phase - Brought to you by microsoft/hve-core'
 user-invocable: false
-tools:
-  - read_file
-  - grep_search
-  - file_search
-  - semantic_search
-  - list_dir
 ---
 
 # RPI Validator

--- a/.github/agents/hve-core/task-implementor.agent.md
+++ b/.github/agents/hve-core/task-implementor.agent.md
@@ -1,17 +1,17 @@
 ---
-name: task-implementor
+name: Task Implementor
 description: 'Executes implementation plans from .copilot-tracking/plans with progressive tracking and change records - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - phase-implementor
-  - researcher-subagent
+  - Phase Implementor
+  - Researcher Subagent
 handoffs:
   - label: "Compact"
-    agent: task-implementor
+    agent: Task Implementor
     send: true
     prompt: "/compact Make sure summarization includes that all state is managed through the .copilot-tracking folder files, and be sure to include that the next agent instructions will be Task Reviewer and the user will switch to it when they are done with Task Implementation"
   - label: "✅ Review"
-    agent: task-reviewer
+    agent: Task Reviewer
     prompt: /task-review
     send: true
 ---

--- a/.github/agents/hve-core/task-planner.agent.md
+++ b/.github/agents/hve-core/task-planner.agent.md
@@ -1,17 +1,17 @@
 ---
-name: task-planner
+name: Task Planner
 description: 'Implementation planner for creating actionable implementation plans - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - researcher-subagent
-  - plan-validator
+  - Researcher Subagent
+  - Plan Validator
 handoffs:
   - label: "Compact"
-    agent: task-planner
+    agent: Task Planner
     send: true
     prompt: "/compact  make sure summarization includes that all state is managed through the .copilot-tracking folder files, and be sure to include that the next agent instructions will be Task Implementor and the user will switch to it when they are done with Task Planner"
   - label: "⚡ Implement"
-    agent: task-implementor
+    agent: Task Implementor
     prompt: /task-implement
     send: true
 ---

--- a/.github/agents/hve-core/task-researcher.agent.md
+++ b/.github/agents/hve-core/task-researcher.agent.md
@@ -1,20 +1,20 @@
 ---
-name: task-researcher
+name: Task Researcher
 description: 'Task research specialist for comprehensive project analysis - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - researcher-subagent
+  - Researcher Subagent
 handoffs:
   - label: "Compact"
-    agent: task-researcher
+    agent: Task Researcher
     send: true
     prompt: "/compact make sure summarization includes that all state is managed through the .copilot-tracking folder files, and be sure to include that the next agent instructions will be Task Planner and the user will switch to it when they are done with Task Researcher"
   - label: "📋 Create Plan"
-    agent: task-planner
+    agent: Task Planner
     prompt: /task-plan
     send: true
   - label: "🔬 Deeper Research"
-    agent: task-researcher
+    agent: Task Researcher
     prompt: /task-research continue deeper research based on potential next research items
 ---
 

--- a/.github/agents/hve-core/task-reviewer.agent.md
+++ b/.github/agents/hve-core/task-reviewer.agent.md
@@ -1,26 +1,26 @@
 ---
-name: task-reviewer
+name: Task Reviewer
 description: 'Reviews completed implementation work for accuracy, completeness, and convention compliance - Brought to you by microsoft/hve-core'
 disable-model-invocation: true
 agents:
-  - rpi-validator
-  - researcher-subagent
-  - implementation-validator
+  - RPI Validator
+  - Researcher Subagent
+  - Implementation Validator
 handoffs:
   - label: "Compact"
-    agent: task-reviewer
+    agent: Task Reviewer
     send: true
     prompt: "/compact Make sure summarization includes that all state is managed through the .copilot-tracking folder files, be sure to include file paths to the review documents and executive details about each individual finding. Be sure to include that the next agent instructions will be one-of Task Researcher for deeper research on the chosen findings to address, Task Planner to go right into planning based off of the chosen findings from the review document, or right back into implementation addressing the chosen findings from the review document. The user will switch to the agent instructions when they are done with Task Review."
   - label: "🔬 Research More"
-    agent: task-researcher
+    agent: Task Researcher
     prompt: /task-research
     send: true
   - label: "📋 Revise Plan"
-    agent: task-planner
+    agent: Task Planner
     prompt: /task-plan
     send: true
   - label: "⚡ Implement Immediately"
-    agent: task-implementor
+    agent: Task Implementor
     prompt: /task-implement Address the findings found in the review document
     send: true
 ---

--- a/.github/agents/installer/hve-core-installer.agent.md
+++ b/.github/agents/installer/hve-core-installer.agent.md
@@ -1,4 +1,5 @@
 ---
+name: HVE Core Installer
 description: 'Decision-driven installer for HVE-Core with 6 installation methods for local, devcontainer, and Codespaces environments - Brought to you by microsoft/hve-core'
 tools: ['vscode/newWorkspace', 'vscode/runCommand', 'execute/runInTerminal', 'read', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'agent', 'todo']
 ---

--- a/.github/agents/project-planning/adr-creation.agent.md
+++ b/.github/agents/project-planning/adr-creation.agent.md
@@ -1,4 +1,5 @@
 ---
+name: ADR Creation
 description: 'Interactive AI coaching for collaborative architectural decision record creation with guided discovery, research integration, and progressive documentation building - Brought to you by microsoft/edge-ai'
 ---
 

--- a/.github/agents/project-planning/agile-coach.agent.md
+++ b/.github/agents/project-planning/agile-coach.agent.md
@@ -1,5 +1,5 @@
 ---
-name: agile-coach
+name: Agile Coach
 description: Conversational agent that helps create or refine goal-oriented user stories with clear acceptance criteria for any tracking tool - Brought to you by microsoft/hve-core
 ---
 

--- a/.github/agents/project-planning/arch-diagram-builder.agent.md
+++ b/.github/agents/project-planning/arch-diagram-builder.agent.md
@@ -1,4 +1,5 @@
 ---
+name: Arch Diagram Builder
 description: Architecture diagram builder agent that builds high quality ASCII-art diagrams - Brought to you by microsoft/hve-core
 ---
 

--- a/.github/agents/project-planning/brd-builder.agent.md
+++ b/.github/agents/project-planning/brd-builder.agent.md
@@ -1,4 +1,5 @@
 ---
+name: BRD Builder
 description: "Business Requirements Document builder with guided Q&A and reference integration"
 ---
 

--- a/.github/agents/project-planning/prd-builder.agent.md
+++ b/.github/agents/project-planning/prd-builder.agent.md
@@ -1,4 +1,5 @@
 ---
+name: PRD Builder
 description: "Product Requirements Document builder with guided Q&A and reference integration"
 ---
 

--- a/.github/agents/project-planning/product-manager-advisor.agent.md
+++ b/.github/agents/project-planning/product-manager-advisor.agent.md
@@ -1,20 +1,21 @@
 ---
+name: Product Manager Advisor
 description: 'Product management advisor for requirements discovery, validation, and issue creation'
 handoffs:
   - label: "📄 Build PRD"
-    agent: prd-builder
+    agent: PRD Builder
     prompt: "Create or refine a Product Requirements Document for this initiative based on our current discussion."
     send: true
   - label: "📋 Build BRD"
-    agent: brd-builder
+    agent: BRD Builder
     prompt: "Create or refine a Business Requirements Document for this initiative based on our current discussion."
     send: true
   - label: "🔍 Research Topic"
-    agent: task-researcher
+    agent: Task Researcher
     prompt: /task-research
     send: true
   - label: "🎨 UX Review"
-    agent: ux-ui-designer
+    agent: UX UI Designer
     prompt: "Run a UX and UI review of the proposed solution and suggest improvements."
     send: true
 ---

--- a/.github/agents/project-planning/system-architecture-reviewer.agent.md
+++ b/.github/agents/project-planning/system-architecture-reviewer.agent.md
@@ -1,12 +1,13 @@
 ---
+name: System Architecture Reviewer
 description: 'System architecture reviewer for design trade-offs, ADR creation, and well-architected alignment - Brought to you by microsoft/hve-core'
 handoffs:
   - label: "📐 Create ADR"
-    agent: adr-creation
+    agent: ADR Creation
     prompt: "Create an ADR based on the architecture review findings"
     send: true
   - label: "📋 Create Plan"
-    agent: task-planner
+    agent: Task Planner
     prompt: /task-plan
     send: true
 ---

--- a/.github/agents/project-planning/ux-ui-designer.agent.md
+++ b/.github/agents/project-planning/ux-ui-designer.agent.md
@@ -1,12 +1,13 @@
 ---
+name: UX UI Designer
 description: 'UX research specialist for Jobs-to-be-Done analysis, user journey mapping, and accessibility requirements'
 handoffs:
   - label: "📋 Product Review"
-    agent: product-manager-advisor
+    agent: Product Manager Advisor
     prompt: "Review this work from a product management perspective and identify any scope, risk, or alignment issues."
     send: true
   - label: "🔍 Research Topic"
-    agent: task-researcher
+    agent: Task Researcher
     prompt: /task-research
     send: true
 ---

--- a/.github/agents/security-planning/security-plan-creator.agent.md
+++ b/.github/agents/security-planning/security-plan-creator.agent.md
@@ -1,4 +1,5 @@
 ---
+name: Security Plan Creator
 description: "Expert security architect for creating comprehensive cloud security plans - Brought to you by microsoft/hve-core"
 ---
 

--- a/.github/prompts/design-thinking/dt-resume-coaching.prompt.md
+++ b/.github/prompts/design-thinking/dt-resume-coaching.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Resume a Design Thinking coaching session — reads coaching state and re-establishes context - Brought to you by microsoft/hve-core'
-agent: dt-coach
+agent: DT Coach
 argument-hint: "projectName=..."
 ---
 

--- a/.github/prompts/design-thinking/dt-start-project.prompt.md
+++ b/.github/prompts/design-thinking/dt-start-project.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Start a new Design Thinking coaching project with state initialization and first coaching interaction - Brought to you by microsoft/hve-core'
-agent: dt-coach
+agent: DT Coach
 argument-hint: "projectName=... [context=...] [stakeholders=...] [industry=...]"
 ---
 

--- a/.github/prompts/github/github-add-issue.prompt.md
+++ b/.github/prompts/github/github-add-issue.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create a GitHub issue using discovered repository templates and conversational field collection'
-agent: 'github-backlog-manager'
+agent: GitHub Backlog Manager
 argument-hint: "[templateName=...] [title=...] [labels=...]"
 ---
 

--- a/.github/prompts/github/github-discover-issues.prompt.md
+++ b/.github/prompts/github/github-discover-issues.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Discover GitHub issues through user-centric queries, artifact-driven analysis, or search-based exploration and produce planning files for review'
-agent: 'github-backlog-manager'
+agent: GitHub Backlog Manager
 argument-hint: "documents=... [milestone=...] [searchTerms=...]"
 ---
 

--- a/.github/prompts/github/github-execute-backlog.prompt.md
+++ b/.github/prompts/github/github-execute-backlog.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Execute a GitHub backlog plan by creating, updating, linking, closing, and commenting on issues from a handoff file'
-agent: 'github-backlog-manager'
+agent: GitHub Backlog Manager
 argument-hint: "handoff=... [autonomy={full|partial|manual}] [dryRun={true|false}]"
 ---
 

--- a/.github/prompts/github/github-sprint-plan.prompt.md
+++ b/.github/prompts/github/github-sprint-plan.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Plan a GitHub milestone sprint by analyzing issue coverage, identifying gaps, and organizing work into a prioritized sprint backlog'
-agent: 'github-backlog-manager'
+agent: GitHub Backlog Manager
 argument-hint: "milestone=... [documents=...] [sprintGoal=...] [capacity=...] [autonomy={full|partial|manual}]"
 ---
 

--- a/.github/prompts/github/github-triage-issues.prompt.md
+++ b/.github/prompts/github/github-triage-issues.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Triage GitHub issues not yet triaged with automated label suggestions, milestone assignment, and duplicate detection'
-agent: 'github-backlog-manager'
+agent: GitHub Backlog Manager
 ---
 
 # Triage GitHub Issues

--- a/.github/prompts/hve-core/checkpoint.prompt.md
+++ b/.github/prompts/hve-core/checkpoint.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Save or restore conversation context using memory files - Brought to you by microsoft/hve-core"
-agent: 'memory'
+agent: Memory
 argument-hint: "[mode={save|continue|incremental}] [description=...]"
 ---
 

--- a/.github/prompts/hve-core/doc-ops-update.prompt.md
+++ b/.github/prompts/hve-core/doc-ops-update.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: 'Invoke doc-ops agent for documentation quality assurance and updates'
-agent: 'doc-ops'
+agent: Doc Ops
 argument-hint: '[scope=all|docs|root|scripts] [validate-only={true|false}]'
 ---
 

--- a/.github/prompts/hve-core/prompt-analyze.prompt.md
+++ b/.github/prompts/hve-core/prompt-analyze.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Evaluates prompt engineering artifacts against quality criteria and reports findings - Brought to you by microsoft/hve-core"
-agent: 'prompt-builder'
+agent: Prompt Builder
 argument-hint: "[promptFiles=...]"
 ---
 

--- a/.github/prompts/hve-core/prompt-build.prompt.md
+++ b/.github/prompts/hve-core/prompt-build.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Build or improve prompt engineering artifacts following quality criteria - Brought to you by microsoft/hve-core"
-agent: prompt-builder
+agent: Prompt Builder
 argument-hint: "[files=...] [promptFiles=...] [create or update based on target files otherwise improve and cleanup existing promptFiles]"
 ---
 

--- a/.github/prompts/hve-core/prompt-refactor.prompt.md
+++ b/.github/prompts/hve-core/prompt-refactor.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Refactors and cleans up prompt engineering artifacts through iterative improvement - Brought to you by microsoft/hve-core"
 argument-hint: "[promptFiles=...] [requirements=...]"
-agent: 'prompt-builder'
+agent: Prompt Builder
 ---
 
 # Prompt Refactor

--- a/.github/prompts/hve-core/rpi.prompt.md
+++ b/.github/prompts/hve-core/rpi.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Autonomous Research-Plan-Implement-Review-Discover workflow for completing tasks - Brought to you by microsoft/hve-core"
-agent: rpi-agent
+agent: RPI Agent
 argument-hint: "task=... [auto={true|partial|false}] [continue={1|2|3|all}] [suggest]"
 ---
 

--- a/.github/prompts/hve-core/task-implement.prompt.md
+++ b/.github/prompts/hve-core/task-implement.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Locates and executes implementation plans using task-implementor - Brought to you by microsoft/hve-core"
-agent: task-implementor
+agent: Task Implementor
 argument-hint: "[plan=...] [phaseStop={true|false}] [stepStop={true|false}]"
 ---
 

--- a/.github/prompts/hve-core/task-plan.prompt.md
+++ b/.github/prompts/hve-core/task-plan.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Initiates implementation planning based on user context or research documents - Brought to you by microsoft/hve-core"
-agent: task-planner
+agent: Task Planner
 argument-hint: "[research=...] [chat={true|false}]"
 ---
 

--- a/.github/prompts/hve-core/task-research.prompt.md
+++ b/.github/prompts/hve-core/task-research.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Initiates research for implementation planning based on user requirements - Brought to you by microsoft/hve-core"
-agent: task-researcher
+agent: Task Researcher
 argument-hint: "topic=... [chat={true|false}]"
 ---
 

--- a/.github/prompts/hve-core/task-review.prompt.md
+++ b/.github/prompts/hve-core/task-review.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Initiates implementation review based on user context or automatic artifact discovery - Brought to you by microsoft/hve-core"
-agent: task-reviewer
+agent: Task Reviewer
 argument-hint: "[plan=...] [changes=...] [research=...] [scope=...]"
 ---
 

--- a/docs/architecture/ai-artifacts.md
+++ b/docs/architecture/ai-artifacts.md
@@ -27,7 +27,7 @@ Prompts (`.prompt.md`) serve as workflow entry points. They capture user intent 
 ```yaml
 ---
 description: 'Protocol for creating ADO pull requests'
-agent: 'task-planner'
+agent: Task Planner
 ---
 ```
 
@@ -50,7 +50,15 @@ Agents (`.agent.md`) define task-specific behaviors with access to Copilot tools
 ---
 description: 'Orchestrates task planning with research integration'
 tools: ['codebase', 'search', 'editFiles', 'changes']
-handoffs: ['task-implementor', 'task-researcher']
+handoffs:
+  - label: "⚡ Implement"
+    agent: Task Implementor
+    prompt: /task-implement
+    send: true
+  - label: "🔬 Research"
+    agent: Task Researcher
+    prompt: /task-research
+    send: true
 ---
 ```
 

--- a/docs/contributing/custom-agents.md
+++ b/docs/contributing/custom-agents.md
@@ -219,7 +219,7 @@ Agent files **MUST**:
   ```yaml
   handoffs:
     - label: "📋 Create Plan"
-      agent: task-planner
+      agent: Task Planner
       prompt: /task-plan
       send: true
   ```
@@ -239,8 +239,8 @@ description: 'Validates and reviews contributed agents, prompts, and instruction
 tools: ['codebase', 'search', 'problems', 'editFiles', 'changes', 'usages']
 disable-model-invocation: true
 agents:
-  - prompt-tester
-  - prompt-evaluator
+  - Prompt Tester
+  - Prompt Evaluator
 ---
 ```
 


### PR DESCRIPTION
This PR migrates all GHCP agent `name:` frontmatter from kebab-case identifiers to human-readable Title Case names across the entire artifact ecosystem. The change spans 54 files, updating 34 agent files, 17 prompt files, 1 instructions file, and 2 documentation files. All cross-references between artifacts (handoffs, agent delegation, subagent lists) were updated to match, and the authoritative *prompt-builder.instructions.md* was updated to codify this as the documented standard going forward.

> The previous convention used kebab-case names matching the filename (e.g., `task-planner`). VS Code's agent picker displays these identifiers directly to users, making human-readable names a better fit for discoverability and presentation.

Fixes: #717

## Description

### Agent Name Standardization

Standardized `name:` frontmatter across all 34 agent files. Files that previously lacked a `name:` field received one; files with kebab-case names were updated to Title Case with **acronym preservation** (RPI, DT, DS, AzDO, PRD, WIT, BRD, ADR, UX, UI).

- Added `name:` to 18 agent files that previously had none, including `AzDO PRD to WIT`, `DS Gen Data Spec`, `GitHub Backlog Manager`, `Prompt Builder`, `Doc Ops`, and `Memory`
- Renamed existing `name:` values in 16 agent files, such as `rpi-agent` → `RPI Agent`, `task-planner` → `Task Planner`, and `implementation-validator` → `Implementation Validator`
- Data-science collection agents use a consistent **DS** prefix (`DS Gen Data Spec`, `DS Gen Jupyter Notebook`, `DS Gen Streamlit Dashboard`, `DS Test Streamlit Dashboard`)

### Cross-Reference Alignment

Updated all frontmatter references that point to other agents so resolution works with the new human-readable names.

- 10 parent agents updated `handoffs:` entries (e.g., `agent: task-planner` → `agent: Task Planner`)
- 7 parent agents updated `agents:` subagent dependency lists (e.g., `- researcher-subagent` → `- Researcher Subagent`)
- 17 prompt files updated `agent:` delegation fields (e.g., `agent: 'prompt-builder'` → `agent: Prompt Builder`)
- Quoting inconsistency in old values (mix of single-quoted and bare strings) normalized to unquoted values

### Convention Documentation

Updated the authoritative guidance and reference documentation to reflect the new naming standard.

- *prompt-builder.instructions.md* updated all guidance and code examples for `name:`, `agents:`, `agent:`, and `handoffs:` fields. Established a **dual-reference rule**: frontmatter uses human-readable names for display, while body text references agents by filename for resolution.
  - Added explicit guidance that `name:` is now a human-readable identifier rather than matching the filename
- *ai-artifacts.md* updated the agent example and expanded the `handoffs:` example from an inline array to the structured format with human-readable names
- *custom-agents.md* updated handoff and agents list examples to human-readable names

### Tool Configuration Cleanup

Three files had tool configuration adjustments alongside the name changes.

- *gen-data-spec.agent.md* had an explicit `tools:` line removed
- *dt-coach.agent.md* had its explicit tool list replaced with shorthand notation
- *rpi-validator.agent.md* had its explicit `tools:` list removed

## Related Issue(s)

Fixes: #717

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [x] Copilot instructions (`.github/instructions/*.instructions.md`)
- [x] Copilot prompt (`.github/prompts/*.prompt.md`)
- [x] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- AI artifact changes are metadata-only name field updates, not new artifact contributions. -->

**User Request:**

Agents are invoked using the same prompts as before (e.g., `/task-research`, `/rpi`, `/prompt-build`). The `agent:` frontmatter in prompt files now uses human-readable names (`Task Researcher`, `RPI Agent`, `Prompt Builder`) for display in the VS Code agent picker.

**Execution Flow:**

No execution flow changes. The `name:` field update affects how agents appear in the VS Code picker and handoff labels. All tool configurations, instruction references, and behavioral logic remain unchanged.

**Output Artifacts:**

No new output artifacts. Existing artifacts generated by these agents are unchanged.

**Success Indicators:**

- Agents display with human-readable Title Case names in the VS Code agent picker
- Handoff buttons display correctly with updated agent references
- Prompt slash commands delegate to the correct agent through the updated `agent:` field

For detailed contribution requirements, see:

- **Common Standards**: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
- **Agents**: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
- **Prompts**: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
- **Instructions**: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
- **Skills**: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

- Markdown linting (`npm run lint:md`): Passed
- Spell checking (`npm run spell-check`): Passed
- Frontmatter validation (`npm run lint:frontmatter`): Passed
- Skill structure validation (`npm run validate:skills`): Passed
- Link validation (`npm run lint:md-links`): Passed
- PowerShell analysis (`npm run lint:ps`): Passed
- Plugin freshness (`npm run plugin:generate`): Passed (no uncommitted changes)
- Security analysis: No sensitive data, credential, or privilege changes detected in the diff. All modifications are frontmatter metadata updates.
- Diff-based assessment: All 54 changed files verified against `git diff --name-status origin/main..HEAD`. Cross-references between agents, prompts, and instructions are internally consistent.
- Manual testing was not performed.

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [ ] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable) (N/A — metadata-only changes)

### AI Artifact Contributions

<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->

- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [x] Skill structure validation: `npm run validate:skills`
- [x] Link validation: `npm run lint:md-links`
- [x] PowerShell analysis: `npm run lint:ps`
- [x] Plugin freshness: `npm run plugin:generate`

### PR Generation Validation

- [x] PR description preserves all template sections.
- [x] pr-reference-log.md analysis is accurately reflected in the description.
- [x] Description uses past tense and follows writing-style conventions.
- [x] All significant changes from the diff are included.
- [x] Referenced files are accurate and exist in the repository.
- [x] Follow-up tasks are actionable and tied to specific code, files, or components.

## Security Considerations

<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->

- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
- [ ] Security-related scripts follow the principle of least privilege (N/A — no security script changes)

> [!WARNING]
> This PR includes **experimental** GHCP artifacts that may have breaking changes.
>
> - `.github/agents/design-thinking/dt-coach.agent.md`
> - `.github/prompts/design-thinking/dt-resume-coaching.prompt.md`
> - `.github/prompts/design-thinking/dt-start-project.prompt.md`

## GHCP Artifact Maturity

| File                                                      | Type         | Maturity          | Notes            |
|-----------------------------------------------------------|--------------|-------------------|------------------|
| `.github/agents/design-thinking/dt-coach.agent.md`        | Agent        | ⚠️ experimental   | Pre-release only |
| `.github/prompts/design-thinking/dt-resume-coaching.prompt.md` | Prompt  | ⚠️ experimental   | Pre-release only |
| `.github/prompts/design-thinking/dt-start-project.prompt.md`   | Prompt  | ⚠️ experimental   | Pre-release only |
| All other 51 changed GHCP artifacts                       | Mixed        | ✅ stable          | All builds       |

### GHCP Maturity Acknowledgment

- [ ] I acknowledge this PR includes non-stable GHCP artifacts
- [ ] Non-stable artifacts are intentional for this change

## Additional Notes

- The repository template was used for this PR description.
- All changes are frontmatter metadata updates with no behavioral logic modifications (except tool list cleanup in 3 agent files).
- The dual-reference convention (human-readable names in frontmatter, filenames in body text) is now documented in *prompt-builder.instructions.md* as the authoritative standard.