### PR TITLE
fix(instructions): reorder branch freshness gate before diff generation

### DIFF
--- a/.github/instructions/hve-core/pull-request.instructions.md
+++ b/.github/instructions/hve-core/pull-request.instructions.md
@@ -37,11 +37,14 @@ Entry criteria:
 
 * Repository context is available and the target branch is known.
 
-1. Resolve PR template candidates using a case-insensitive file name search for `pull_request_template.md` and the directory `.github/pull_request_template/`. Match any casing variation for both file names and directory names (for example, `PULL_REQUEST_TEMPLATE.md`, `Pull_Request_Template.md`, `pull_request_template.md`).
-2. Apply location priority, matching any casing variation at each location:
-   1. `.github/PULL_REQUEST_TEMPLATE.md` or `.github/pull_request_template.md`
-   2. `docs/PULL_REQUEST_TEMPLATE.md` or `docs/pull_request_template.md`
-   3. `PULL_REQUEST_TEMPLATE.md` or `pull_request_template.md`
+1. Resolve PR template candidates:
+   1. Search tools for files are case-sensitive.
+   2. Search for `pull_request_template.md`, `PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template/`, `.github/PULL_REQUEST_TEMPLATE/`.
+   3. Search for any casing variation for both file names and directory names (for example, `PULL_REQUEST_TEMPLATE.md`, `Pull_Request_Template.md`, `pull_request_template.md`).
+2. Apply location priority, based on location:
+   1. `.github/` folder.
+   2. `docs/` folder.
+   3. Anywhere else found.
 3. If multiple templates exist at the same priority level, list candidates and ask the user to choose one.
 4. Persist template state for later steps:
    * `templatePath`: chosen template path, or `None`.


### PR DESCRIPTION
## Description

Restructured the pull request workflow in *pull-request.instructions.md* to validate branch currency earlier in the process. The **Branch Freshness Gate**, previously buried inside the PR creation step (Step 7A), was promoted to its own standalone **Step 2**, positioned immediately after template resolution. This ensures stale-branch issues surface before any diff generation or analysis work begins, avoiding wasted effort.

> The core motivation: catch branch staleness *before* investing in diff generation and subagent review, not after.

All downstream steps were renumbered to accommodate the insertion, and every internal cross-reference (fallback rules, entry/exit criteria, sub-step labels, and prose references) was updated to stay consistent with the new numbering.

### Workflow restructuring

The Branch Freshness Gate logic itself remained unchanged (resolve base ref, fetch, compute ahead/behind, prompt for merge or rebase). Its position in the workflow shifted to enable earlier failure detection.

- Promoted **Branch Freshness Gate** from Step 7A (inside PR creation) to standalone **Step 2**, running before diff generation
- Cascaded the renumbering across all steps: Generate PR Reference (→ Step 3), Parallel Subagent Review (→ Step 4), Merge and Verify (→ Step 5), Generate PR Description (→ Step 6), Validate PR Readiness (→ Step 7), Create Pull Request (→ Step 8), Cleanup (→ Step 9)
- Updated all internal cross-references including fallback rules, entry/exit criteria, sub-step labels (7B→8A, 7C→8B, 7D→8C), and approval flow targets

### Template resolution improvements

Step 1's template resolution guidance was clarified to address case sensitivity when using file search tools.

- Restructured template resolution into a numbered sub-list with explicit statement that **search tools are case-sensitive**
- Simplified location priority to folder-based ordering (`.github/` → `docs/` → anywhere else) instead of enumerating every casing variant at each location
- Removed redundant `git fetch` from the Generate PR Reference step since the new Step 2 already fetches the base branch ref

## Related Issue(s)

Fixes: #724

## Type of Change

Select all that apply:

**Code & Documentation:**

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

**Infrastructure & Configuration:**

- [ ] GitHub Actions workflow
- [ ] Linting configuration (markdown, PowerShell, etc.)
- [ ] Security configuration
- [ ] DevContainer configuration
- [ ] Dependency update

**AI Artifacts:**

- [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
- [x] Copilot instructions (`.github/instructions/*.instructions.md`)
- [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
- [ ] Copilot agent (`.github/agents/*.agent.md`)
- [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> **Note for AI Artifact Contributors**:
>
> - **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> - **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> - **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> - See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

- [ ] Script/automation (`.ps1`, `.sh`, `.py`)
- [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->

**User Request:**

Invoke the pull request generation workflow using the `pull-request.prompt.md` prompt or ask Copilot to generate a PR description. The modified instructions govern the step ordering and cross-references used during PR generation.

**Execution Flow:**

1. Step 1 resolves the PR template using case-sensitive file searches across `.github/`, `docs/`, and root locations.
2. Step 2 (Branch Freshness Gate) fetches the base branch and validates the working branch is current before any analysis begins.
3. Steps 3–6 generate the PR reference XML, run parallel subagent reviews, merge findings, and produce the PR description.
4. Steps 7–9 handle validation, optional PR creation, and cleanup.

**Output Artifacts:**

The instructions file itself does not produce artifacts directly. It governs the PR workflow that produces `.copilot-tracking/pr/pr.md`, `.copilot-tracking/pr/pr-reference-log.md`, and temporary subagent logs.

**Success Indicators:**

Branch freshness is validated before diff generation (Step 2 runs before Step 3). All step number references in the instructions are internally consistent. The PR workflow completes without orphaned cross-references.

For detailed contribution requirements, see:

- **Common Standards**: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
- **Agents**: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
- **Prompts**: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
- **Instructions**: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
- **Skills**: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

- **Markdown linting** (`npm run lint:md`): Passed (0 errors across 232 files)
- **Spell checking** (`npm run spell-check`): Passed (0 issues across 186 files)
- **Frontmatter validation** (`npm run lint:frontmatter`): Passed (218 files, 0 errors)
- **Skill structure validation** (`npm run validate:skills`): Passed (2 skills, 0 errors)
- **Link validation** (`npm run lint:md-links`): Passed
- **PowerShell analysis** (`npm run lint:ps`): Passed (all files clean)
- **Plugin freshness** (`npm run plugin:generate`): Passed (no uncommitted changes)
- **Security analysis**: No sensitive data, credentials, or security-impacting changes detected in the diff. Single instructions file modified with workflow reordering only.
- **Diff-based assessment**: Verified all step number cross-references are internally consistent with the new numbering. No orphaned references to old step numbers remain.
- Manual testing was not performed.

## Checklist

### Required Checks

- [x] Documentation is updated (if applicable)
- [x] Files follow existing naming conventions
- [x] Changes are backwards compatible (if applicable)
- [ ] Tests added for new functionality (if applicable) (N/A — no new testable functionality added)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
- [ ] Used `/prompt-analyze` to review contribution
- [ ] Addressed all feedback from `prompt-builder` review
- [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

- [x] Markdown linting: `npm run lint:md`
- [x] Spell checking: `npm run spell-check`
- [x] Frontmatter validation: `npm run lint:frontmatter`
- [x] Skill structure validation: `npm run validate:skills`
- [x] Link validation: `npm run lint:md-links`
- [x] PowerShell analysis: `npm run lint:ps`
- [x] Plugin freshness: `npm run plugin:generate`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
- [x] This PR does not contain any sensitive or NDA information
- [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
- [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

This change is purely structural, improving workflow ordering and documentation clarity. No behavioral changes to the PR generation logic, conflict handling, merge/rebase strategies, or error handling.