### PR TITLE
fix(workflows): replace even/odd versioning with SemVer -rc.N suffixes

### DIFF
--- a/.github/workflows/extension-publish-marketplace.yml
+++ b/.github/workflows/extension-publish-marketplace.yml
@@ -71,7 +71,7 @@ jobs:
           CHANNEL_LABEL="Stable"
           PRE_RELEASE_FLAG=""
           if [ "$PRE_RELEASE" == "true" ]; then
-            CHANNEL_LABEL="Pre-Release (ODD minor)"
+            CHANNEL_LABEL="Pre-Release"
             PRE_RELEASE_FLAG="--pre-release"
           fi
 
@@ -89,7 +89,7 @@ jobs:
           EMOJI="🎉"
           EXTRA=""
           if [ "$PRE_RELEASE" == "true" ]; then
-            CHANNEL_LABEL="Pre-Release (ODD minor)"
+            CHANNEL_LABEL="Pre-Release"
             EMOJI="🚀"
             EXTRA=$'\nUsers can install via **Switch to Pre-Release Version** in VS Code.\n'
           fi

--- a/.github/workflows/extension-publish-prerelease.yml
+++ b/.github/workflows/extension-publish-prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "ODD minor version (e.g., 1.1.0). Leave empty to auto-detect from latest release."
+        description: "Pre-release version with -rc.N suffix (e.g., 3.1.0-rc.5). Leave empty to auto-detect."
         required: false
         type: string
         default: ""
@@ -29,7 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.validate.outputs.version }}
     steps:
-      - name: Validate ODD minor version
+      - name: Validate pre-release version
         id: validate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,41 +40,34 @@ jobs:
           VERSION="${VERSION#v}"
           VERSION="${VERSION#hve-core-v}"
 
-          # Auto-detect from latest release tag when no version specified
+          # Auto-detect from latest pre-release tag when no version specified
           if [ -z "$VERSION" ]; then
-            TAG=$(gh release view --json tagName -q '.tagName' -R "${{ github.repository }}")
-            VERSION="${TAG#hve-core-v}"
-
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH=$(echo "$VERSION" | cut -d. -f3)
-
-            # Derive ODD minor: if even, bump minor by 1 and reset patch
-            if (( MINOR % 2 == 0 )); then
-              MINOR=$((MINOR + 1))
-              PATCH=0
+            TAG=$(gh release list --exclude-drafts --limit 10 --json tagName,isPrerelease \
+              -q '[.[] | select(.isPrerelease)] | .[0].tagName // empty' \
+              -R "${{ github.repository }}")
+            if [ -n "$TAG" ]; then
+              VERSION="${TAG#hve-core-v}"
+              echo "📦 Auto-detected pre-release version: $VERSION"
+            else
+              echo "::error::No pre-release found. Provide a version manually (e.g., 3.1.0-rc.1)"
+              exit 1
             fi
-            VERSION="${MAJOR}.${MINOR}.${PATCH}"
-            echo "📦 Auto-derived pre-release version from latest release: $VERSION"
           fi
 
-          # Validate format
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: $VERSION. Expected semantic version (e.g., 1.1.0)"
+          # Validate semver format (with optional -rc.N suffix)
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION. Expected semantic version (e.g., 3.1.0-rc.5)"
             exit 1
           fi
 
-          # Extract minor version
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-
-          # Check if ODD (pre-release channel uses ODD minor versions)
-          if (( MINOR % 2 == 0 )); then
-            echo "::error::Pre-release requires ODD minor version. Got: $VERSION (minor=$MINOR is EVEN)"
-            echo "::error::Use version like 1.1.0, 1.3.0, 2.1.0 for pre-release channel"
+          # Pre-release channel requires -rc.N suffix
+          if ! echo "$VERSION" | grep -qE '\-rc\.[0-9]+$'; then
+            echo "::error::Pre-release version $VERSION must contain an -rc.N suffix (e.g., 3.1.0-rc.5)"
+            echo "::error::Use extension-publish workflow for stable versions"
             exit 1
           fi
 
-          echo "✅ Valid pre-release version: $VERSION (minor=$MINOR is ODD)"
+          echo "✅ Valid pre-release version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   package:

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -58,11 +58,10 @@ jobs:
             exit 1
           fi
 
-          # Validate even minor version (stable channel convention)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          if (( MINOR % 2 != 0 )); then
-            echo "::error::Stable channel requires EVEN minor version. Got: $VERSION (minor=$MINOR is ODD)"
-            echo "::error::Use extension-publish-prerelease workflow for ODD minor (pre-release) versions"
+          # Validate stable version (must not contain pre-release suffix)
+          if echo "$VERSION" | grep -qE '\-rc\.[0-9]+'; then
+            echo "::error::Stable channel does not accept pre-release versions. Got: $VERSION"
+            echo "::error::Use extension-publish-prerelease workflow for -rc.N versions"
             exit 1
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,11 +192,7 @@ jobs:
             RELEASED="${{ needs.release-please.outputs.version }}"
             MAJOR=$(echo "$RELEASED" | cut -d. -f1)
             MINOR=$(echo "$RELEASED" | cut -d. -f2)
-            ODD_MINOR=$((MINOR + 1))
-            if [ $((ODD_MINOR % 2)) -eq 0 ]; then
-              ODD_MINOR=$((ODD_MINOR + 1))
-            fi
-            PRE_VERSION="${MAJOR}.${ODD_MINOR}.0"
+            PRE_VERSION="${MAJOR}.$((MINOR + 1)).0-rc.0"
             gh pr edit "$PR_NUMBER" \
               --title "chore(main): pre-release $PRE_VERSION" \
               --body "## Pre-Release $PRE_VERSION

--- a/.github/workflows/prerelease-release.yml
+++ b/.github/workflows/prerelease-release.yml
@@ -45,7 +45,7 @@ jobs:
           REPO: ${{ github.repository }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          VERSION=$(echo "$PR_TITLE" | grep -oE 'pre-release [0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          VERSION=$(echo "$PR_TITLE" | grep -oE 'pre-release [0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?')
           if [ -z "$VERSION" ]; then
             echo "⚠️ Could not extract version from PR title, falling back to manifest"
             VERSION=$(jq -r '.["."]//"0.0.0"' .release-please-manifest.json 2>/dev/null || echo "")
@@ -55,10 +55,9 @@ jobs:
             exit 1
           fi
 
-          # Validate odd minor version (pre-release convention)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          if [ $((MINOR % 2)) -eq 0 ]; then
-            echo "::error::Pre-release version $VERSION has even minor ($MINOR). Pre-release versions must have odd minor."
+          # Validate pre-release version contains SemVer -rc suffix
+          if ! echo "$VERSION" | grep -qE '\-rc\.[0-9]+$'; then
+            echo "::error::Pre-release version $VERSION must contain an -rc.N suffix"
             exit 1
           fi
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -45,29 +45,38 @@ jobs:
           CURRENT=$(jq -r '.["."]//"0.0.0"' .release-please-manifest.json)
           MAJOR=$(echo "$CURRENT" | cut -d. -f1)
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
 
-          # Next ODD minor version
-          NEXT_MINOR=$((MINOR + 1))
-          if [ $((NEXT_MINOR % 2)) -eq 0 ]; then
-            NEXT_MINOR=$((NEXT_MINOR + 1))
-          fi
-
-          # Check for breaking changes since last release tag
+          # Find the last release tag for commit range analysis
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'hve-core-v*' 2>/dev/null || echo "")
+
+          # Check for breaking changes and new features since last release.
+          # Match conventional commit subject with ! (e.g. feat!:) or
+          # a BREAKING CHANGE / BREAKING-CHANGE footer token at line start.
           HAS_BREAKING=0
+          HAS_FEAT=0
           if [ -n "$LAST_TAG" ]; then
             HAS_BREAKING=$(git log "$LAST_TAG"..HEAD --format='%s%n%b' | \
-              grep -cE '^[a-z]+(\(.+\))?!:|BREAKING[ -]CHANGE' || true)
+              grep -cE '^[a-z]+(\(.+\))?!:|^BREAKING[ -]CHANGE:' || true)
+            HAS_FEAT=$(git log "$LAST_TAG"..HEAD --format='%s' | \
+              grep -cE '^feat(\(.+\))?[!]?:' || true)
           fi
 
+          # Compute base version using conventional commit bump rules
           if [ "$HAS_BREAKING" -gt 0 ]; then
-            PRE_VERSION="$((MAJOR + 1)).1.0"
+            BASE_VERSION="$((MAJOR + 1)).0.0"
+          elif [ "$HAS_FEAT" -gt 0 ]; then
+            BASE_VERSION="${MAJOR}.$((MINOR + 1)).0"
           else
-            PRE_VERSION="${MAJOR}.${NEXT_MINOR}.0"
+            BASE_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
           fi
+
+          # Append SemVer pre-release suffix with commit count as rc number
+          RC_NUMBER=$(git rev-list --count "${LAST_TAG}..HEAD" 2>/dev/null || echo "1")
+          PRE_VERSION="${BASE_VERSION}-rc.${RC_NUMBER}"
 
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed pre-release version: $PRE_VERSION (current: $CURRENT)"
+          echo "Computed pre-release version: $PRE_VERSION (base: $BASE_VERSION, rc: $RC_NUMBER, current: $CURRENT)"
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
Pre-release versioning previously relied on an even/odd minor version convention to distinguish stable from pre-release builds across the CI/CD pipeline. This scheme was fragile, produced version collisions when both pipelines targeted the same minor, and was redundant — the VS Code Marketplace determines channel placement via the `--pre-release` flag, not version number inspection. This PR replaces the entire even/odd scheme with standard SemVer `-rc.N` pre-release suffixes.

## Changes

### Pre-release version computation

> The core versioning logic in *prerelease.yml* was the most significant change, replacing arithmetic parity checks with conventional commit analysis.

- Rewrote version computation in *prerelease.yml* to use **conventional commit bump rules** — breaking changes bump major, new features bump minor, all others bump patch
- Added **feature commit detection** (`HAS_FEAT`) alongside existing breaking change detection for accurate minor version bumps
- Fixed an unanchored `BREAKING[ -]CHANGE` regex to `^BREAKING[ -]CHANGE:` to prevent **false positives** from commit body content
- Appended **`-rc.N` suffix** using `git rev-list --count` as the RC number, producing versions like `3.1.0-rc.5`

### Validation and channel routing

The remaining five workflow files enforce the `-rc.N` convention at their respective gates.

- Updated *prerelease-release.yml* to extract and validate `-rc.N` suffixes from PR titles instead of checking minor version parity
- Replaced **auto-detection** in *extension-publish-prerelease.yml* — queries `gh release list` with `isPrerelease` filter instead of deriving an odd minor from the latest stable tag
- Updated *extension-publish.yml* stable channel guard to **reject `-rc.N` versions** rather than requiring even minor numbers
  - The existing format regex `^[0-9]+\.[0-9]+\.[0-9]+$` provides defense-in-depth by rejecting `-rc.N` before the explicit check
- Simplified *main.yml* post-release reset to `"${MAJOR}.$((MINOR + 1)).0-rc.0"`, removing the `ODD_MINOR` arithmetic and modulo guard
- Cleaned up **channel labels** in *extension-publish-marketplace.yml* from `"Pre-Release (ODD minor)"` to `"Pre-Release"`

## Type of Change

* [x] Bug fix (non-breaking change fixing an issue)
* [x] GitHub Actions workflow

## Related Issues

None

## Testing

- All six workflow files pass YAML lint validation (`npm run lint:yaml`)
- Verified the `--pre-release` flag on `vsce publish` controls VS Code Marketplace channel placement, confirming even/odd was never used by the marketplace
- Traced each pipeline path end-to-end: pre-release computation, pre-release validation, pre-release extension publish, stable extension publish, and post-release reset

## Checklist

### Required Checks

* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)