### PR TITLE
fix(workflows): update prerelease publish to use even/odd convention

### DIFF
--- a/.github/workflows/extension-publish-prerelease.yml
+++ b/.github/workflows/extension-publish-prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Pre-release version with -rc.N suffix (e.g., 3.1.0-rc.5). Leave empty to auto-detect."
+        description: "Pre-release version with odd minor (e.g., 3.1.44). Leave empty to auto-detect."
         required: false
         type: string
         default: ""
@@ -49,21 +49,22 @@ jobs:
               VERSION="${TAG#hve-core-v}"
               echo "📦 Auto-detected pre-release version: $VERSION"
             else
-              echo "::error::No pre-release found. Provide a version manually (e.g., 3.1.0-rc.1)"
+              echo "::error::No pre-release found. Provide a version manually (e.g., 3.1.44)"
               exit 1
             fi
           fi
 
-          # Validate semver format (with optional -rc.N suffix)
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION. Expected semantic version (e.g., 3.1.0-rc.5)"
+          # Validate version format (MAJOR.MINOR.PATCH)
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: $VERSION. Expected MAJOR.MINOR.PATCH (e.g., 3.1.44)"
             exit 1
           fi
 
-          # Pre-release channel requires -rc.N suffix
-          if ! echo "$VERSION" | grep -qE '\-rc\.[0-9]+$'; then
-            echo "::error::Pre-release version $VERSION must contain an -rc.N suffix (e.g., 3.1.0-rc.5)"
-            echo "::error::Use extension-publish workflow for stable versions"
+          # Even/odd convention: odd minor = pre-release, even minor = stable
+          PUBLISH_MINOR=$(echo "$VERSION" | cut -d. -f2)
+          if (( PUBLISH_MINOR % 2 == 0 )); then
+            echo "::error::Pre-release channel requires odd minor version. Got: $VERSION (even minor = stable)"
+            echo "::error::Use the stable publish workflow for even-minor versions"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Update `extension-publish-prerelease.yml` to use the even/odd versioning convention adopted in #816, replacing the legacy `-rc.N` suffix validation.

## Problem

After merging even/odd versioning hardening (PR #816), the pre-release publish workflow was missed. Running it against version `3.1.44` fails with:

```
Pre-release version 3.1.44 must contain an -rc.N suffix (e.g., 3.1.0-rc.5)
```

## Changes

- Replace `-rc.N` suffix validation with `MAJOR.MINOR.PATCH` format check
- Add even/odd minor guard rejecting even minor versions for pre-release channel
- Update input description and error messages for even/odd convention

## Validation

- YAML lint passed
- Diff reviewed: single file, 10 insertions, 9 deletions

Fixes #820