### PR TITLE
fix(docs): remediate writing-style convention violations

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -58,9 +58,9 @@ A pre-configured development environment that includes all tools, extensions, an
 
 ### Code Quality
 
-* **Markdown**: markdownlint, markdown-table-formatter
-* **Spelling**: Code Spell Checker (VS Code extension)
-* **Shell**: shellcheck
+* Markdown: markdownlint, markdown-table-formatter
+* Spelling: Code Spell Checker (VS Code extension)
+* Shell: shellcheck
 
 ### Security
 
@@ -74,9 +74,9 @@ A pre-configured development environment that includes all tools, extensions, an
 
 ## Pre-installed VS Code Extensions
 
-* **Spell Checking**: Street Side Software Spell Checker
-* **Markdown**: markdownlint, Markdown All in One, Mermaid support
-* **GitHub**: GitHub Pull Requests
+* Spell Checking: Street Side Software Spell Checker
+* Markdown: markdownlint, Markdown All in One, Mermaid support
+* GitHub: GitHub Pull Requests
 
 ## Common Commands
 
@@ -98,9 +98,9 @@ gitleaks detect --source . --verbose
 
 ## Troubleshooting
 
-**Container won't build**: Ensure Docker Desktop is running and you have sufficient disk space (5GB+).
+Container won't build: Ensure Docker Desktop is running and you have sufficient disk space (5GB+).
 
-**Extensions not loading**: Reload the window (`F1` → **Developer: Reload Window**).
+Extensions not loading: Reload the window (`F1` → **Developer: Reload Window**).
 
 For more help, see [SUPPORT.md](../SUPPORT.md).
 

--- a/.github/CUSTOM-AGENTS.md
+++ b/.github/CUSTOM-AGENTS.md
@@ -420,7 +420,7 @@ The Research-Plan-Implement (RPI) workflow provides a structured approach to com
 * **Linting Exemption:** Files in `.copilot-tracking/**` are exempt from repository linting rules
 * **Agent Switching:** Clear context or start a new chat when switching between specialized agents
 * **Research First:** Task planner requires completed research; will automatically invoke researcher if missing
-* **No Implementation:** Task planner and researcher never implement actual project code—they create planning artifacts only
+* **No Implementation:** Task planner and researcher never implement actual project code. They create planning artifacts only
 * **Subagent Requirements:** Several agents require a subagent tool enabled in Copilot settings
 
 ## Tips

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,11 +33,11 @@ Select all that apply:
 * [ ] Copilot agent (`.github/agents/*.agent.md`)
 * [ ] Copilot skill (`.github/skills/*/SKILL.md`)
 
-> **Note for AI Artifact Contributors**:
+> Note for AI Artifact Contributors:
 >
-> * **Agents**: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
-> * **Skills**: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
-> * **Model Versions**: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
+> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
+> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
+> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
 > * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).
 
 **Other:**
@@ -64,11 +64,11 @@ Select all that apply:
 
 For detailed contribution requirements, see:
 
-* **Common Standards**: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
-* **Agents**: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
-* **Prompts**: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
-* **Instructions**: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
-* **Skills**: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts
+* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
+* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
+* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
+* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
+* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts
 
 ## Testing
 <!-- Describe how you tested these changes -->

--- a/.github/instructions/hve-core/writing-style.instructions.md
+++ b/.github/instructions/hve-core/writing-style.instructions.md
@@ -62,6 +62,7 @@ Avoid these common patterns that reduce clarity and create clutter.
 
 ### Em Dashes
 
+<!-- markdownlint-disable-next-line search-replace -->
 Do not use em dashes (—) for parenthetical statements, explanations, or dramatic pauses. Use these alternatives instead:
 
 | Instead of Em Dash  | Use This    | Example                                         |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,9 +54,9 @@ Compose multiple reusable workflows for comprehensive validation and security sc
 | `weekly-security-maintenance.yml` | Schedule (Sun 2AM UTC)                  | 4 (validate-pinning, check-staleness, codeql-analysis, summary) | Soft-fail warnings         | Weekly security posture              |
 | `scorecard.yml`                   | Push to main, Schedule (Sun 3AM UTC)    | 1 (scorecard)                                                   | SARIF upload               | OpenSSF Scorecard security posture   |
 
-**pr-validation.yml jobs**: codeql-analysis, spell-check, markdown-lint, table-format, psscriptanalyzer, frontmatter-validation, link-lang-check, markdown-link-check, dependency-pinning-check
+pr-validation.yml jobs: codeql-analysis, spell-check, markdown-lint, table-format, psscriptanalyzer, frontmatter-validation, link-lang-check, markdown-link-check, dependency-pinning-check
 
-**release-stable.yml jobs**: spell-check, markdown-lint, table-format, codeql-analysis, dependency-pinning-scan
+release-stable.yml jobs: spell-check, markdown-lint, table-format, codeql-analysis, dependency-pinning-scan
 
 ## Reusable Workflows
 
@@ -75,7 +75,7 @@ Compose multiple reusable workflows for comprehensive validation and security sc
 
 All validation workflows use `permissions: contents: read`, publish PR annotations, and retain artifacts for 30 days.
 
-**Usage example**:
+Usage example:
 
 ```yaml
 jobs:
@@ -89,10 +89,10 @@ jobs:
 
 Each modular workflow implements comprehensive 4-channel result publishing:
 
-1. **PR Annotations**: Warnings/errors appear on Files Changed tab
-2. **Artifacts**: Raw output files retained for 30 days
-3. **SARIF Reports**: Security tab integration (security workflows only)
-4. **Job Summaries**: Rich markdown summaries in Actions tab
+1. PR Annotations: Warnings/errors appear on Files Changed tab
+2. Artifacts: Raw output files retained for 30 days
+3. SARIF Reports: Security tab integration (security workflows only)
+4. Job Summaries: Rich markdown summaries in Actions tab
 
 ## Security Best Practices
 
@@ -144,40 +144,40 @@ The SHA staleness check workflow complements Dependabot by monitoring for stale 
 
 #### `codeql-analysis.yml`
 
-**Purpose**: Performs comprehensive security analysis using GitHub CodeQL
+Purpose: Performs comprehensive security analysis using GitHub CodeQL
 
-**Triggers**: `schedule` (Sundays at 4 AM UTC), `workflow_call`
+Triggers: `schedule` (Sundays at 4 AM UTC), `workflow_call`
 
-**Features**:
+Features:
 
-* **Languages**: JavaScript/TypeScript analysis
-* **Queries**: security-extended and security-and-quality query suites
-* **Coverage**: Detects SQL injection, XSS, command injection, path traversal, and 200+ other vulnerabilities
-* **Integration**: Results appear in Security > Code Scanning tab
-* **Auto-build**: Automatically detects and builds JavaScript/TypeScript projects
+* Languages: JavaScript/TypeScript analysis
+* Queries: security-extended and security-and-quality query suites
+* Coverage: Detects SQL injection, XSS, command injection, path traversal, and 200+ other vulnerabilities
+* Integration: Results appear in Security > Code Scanning tab
+* Auto-build: Automatically detects and builds JavaScript/TypeScript projects
 
-**Outputs**: SARIF results uploaded to GitHub Security tab, job summary with analysis details
+Outputs: SARIF results uploaded to GitHub Security tab, job summary with analysis details
 
 #### `dependency-review.yml`
 
-**Purpose**: Reviews dependency changes in pull requests for known vulnerabilities
+Purpose: Reviews dependency changes in pull requests for known vulnerabilities
 
-**Triggers**: `pull_request`, `workflow_call`
+Triggers: `pull_request`, `workflow_call`
 
-**Features**:
+Features:
 
-* **Threshold**: Fails on moderate or higher severity vulnerabilities
-* **PR Comments**: Automatically comments on PRs with vulnerability summary
-* **Coverage**: Checks npm packages against GitHub Advisory Database
-* **Integration**: Works with Dependabot alerts and security advisories
+* Threshold: Fails on moderate or higher severity vulnerabilities
+* PR Comments: Automatically comments on PRs with vulnerability summary
+* Coverage: Checks npm packages against GitHub Advisory Database
+* Integration: Works with Dependabot alerts and security advisories
 
-**Behavior**: Blocks PRs introducing vulnerable dependencies (moderate+ severity)
+Behavior: Blocks PRs introducing vulnerable dependencies (moderate+ severity)
 
 #### `dependency-pinning-scan.yml`
 
-**Purpose**: Validates that all GitHub Actions use SHA-pinned versions
+Purpose: Validates that all GitHub Actions use SHA-pinned versions
 
-**Inputs**:
+Inputs:
 
 * `threshold` (number, default: 95): Minimum compliance percentage
 * `dependency-types` (string, default: 'actions,containers'): Types to validate
@@ -185,7 +185,7 @@ The SHA staleness check workflow complements Dependabot by monitoring for stale 
 * `upload-sarif` (boolean, default: false): Upload to Security tab
 * `upload-artifact` (boolean, default: true): Upload JSON results
 
-**Outputs**:
+Outputs:
 
 * `compliance-score`: Percentage of dependencies properly pinned
 * `unpinned-count`: Number of unpinned dependencies
@@ -193,18 +193,18 @@ The SHA staleness check workflow complements Dependabot by monitoring for stale 
 
 #### `sha-staleness-check.yml`
 
-**Purpose**: Detects outdated GitHub Action SHA pins
+Purpose: Detects outdated GitHub Action SHA pins
 
-**Inputs**:
+Inputs:
 
 * `max-age-days` (number, default: 30): Maximum age before stale
 
-**Outputs**:
+Outputs:
 
 * `stale-count`: Number of stale SHA pins
 * `has-stale`: Boolean indicating stale pins found
 
-**Severity Levels**:
+Severity Levels:
 
 * Info: 0-30 days
 * Low: 31-90 days
@@ -214,18 +214,18 @@ The SHA staleness check workflow complements Dependabot by monitoring for stale 
 
 #### `scorecard.yml`
 
-**Purpose**: Performs OpenSSF Scorecard analysis for security posture assessment
+Purpose: Performs OpenSSF Scorecard analysis for security posture assessment
 
-**Triggers**: `schedule` (Sundays at 3 AM UTC), `push` to main
+Triggers: `schedule` (Sundays at 3 AM UTC), `push` to main
 
-**Features**:
+Features:
 
-* **Analysis**: Supply chain security, CI/CD best practices, code review practices
-* **Integration**: Results published to OpenSSF Scorecard API and GitHub Security tab
-* **Badge**: Live Scorecard badge available for README display
-* **Artifacts**: SARIF results retained for 90 days
+* Analysis: Supply chain security, CI/CD best practices, code review practices
+* Integration: Results published to OpenSSF Scorecard API and GitHub Security tab
+* Badge: Live Scorecard badge available for README display
+* Artifacts: SARIF results retained for 90 days
 
-**Outputs**: SARIF results uploaded to GitHub Security tab, job summary with badge link
+Outputs: SARIF results uploaded to GitHub Security tab, job summary with badge link
 
 ## Architecture Decisions
 
@@ -235,9 +235,9 @@ The SHA staleness check workflow complements Dependabot by monitoring for stale 
 
 **Current Architecture:** CodeQL now runs exclusively through orchestrator workflows to prevent duplicate runs and ensure consistent security scanning:
 
-* **CodeQL PR validation**: Runs via `pr-validation.yml` on all PR activity (open, push, reopen)
-* **Main branch**: Runs via `release-stable.yml` on every push to main
-* **Weekly scan**: Standalone scheduled run every Sunday at 4 AM UTC for continuous security monitoring
+* CodeQL PR validation: Runs via `pr-validation.yml` on all PR activity (open, push, reopen)
+* Main branch: Runs via `release-stable.yml` on every push to main
+* Weekly scan: Standalone scheduled run every Sunday at 4 AM UTC for continuous security monitoring
 
 This architecture ensures:
 
@@ -246,7 +246,7 @@ This architecture ensures:
 * Clear ownership of when and why CodeQL executes
 * Reduced GitHub Actions minutes consumption
 
-**Workflow Execution Matrix**:
+Workflow Execution Matrix:
 
 | Event                                | Workflows That Run                                       | CodeQL Included       |
 |--------------------------------------|----------------------------------------------------------|-----------------------|
@@ -359,10 +359,10 @@ jobs:
 
 ### Artifact Handling
 
-* **Retention**: 30 days for all artifacts
-* **Naming**: `{workflow-name}-results`
-* **Contents**: JSON results, markdown summaries, logs
-* **Condition**: `if: always()` to upload even on failure
+* Retention: 30 days for all artifacts
+* Naming: `{workflow-name}-results`
+* Contents: JSON results, markdown summaries, logs
+* Condition: `if: always()` to upload even on failure
 
 ### GitHub Annotations
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -15,6 +15,13 @@
     "plugins/**/commands/**",
     "plugins/**/skills/**",
     "plugins/**/docs/**",
-    "plugins/**/scripts/**"
+    "plugins/**/scripts/**",
+    ".github/instructions/**",
+    ".github/agents/**",
+    ".github/prompts/**",
+    ".github/skills/**"
+  ],
+  "customRules": [
+    "markdownlint-rule-search-replace"
   ]
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -49,7 +49,7 @@
   },
   "MD023": true,
   "MD024": {
-    "siblings_only": false
+    "siblings_only": true
   },
   "MD025": {
     "level": 1,
@@ -146,5 +146,23 @@
   "MD058": true,
   "MD060": {
     "style": "leading_and_trailing"
+  },
+  "search-replace": {
+    "rules": [
+      {
+        "name": "no-em-dash",
+        "message": "Do not use em dashes (—); use colons, commas, or parentheses instead",
+        "searchPattern": "/—/g",
+        "searchScope": "text",
+        "information": "https://github.com/microsoft/hve-core/blob/main/.github/instructions/hve-core/writing-style.instructions.md"
+      },
+      {
+        "name": "no-bolded-prefix-list",
+        "message": "Do not use bolded-prefix list items (e.g., '* **Label**: desc'); use tables, headings, or plain lists",
+        "searchPattern": "/\\*\\*[^*]+\\*\\*\\s*[:—–-]/g",
+        "searchScope": "text",
+        "information": "https://github.com/microsoft/hve-core/blob/main/.github/instructions/hve-core/writing-style.instructions.md"
+      }
+    ]
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,10 +357,10 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 
 ### How Releases Work
 
-1. **Commit with Conventional Commits** - All commits to `main` must follow conventional commit format (see [commit message instructions](./.github/instructions/hve-core/commit-message.instructions.md))
-2. **Release PR Creation** - After commits are pushed to `main`, release-please automatically creates or updates a "release PR"
-3. **Review Release PR** - Maintainers review the release PR to verify version bump and changelog accuracy
-4. **Merge to Release** - When the release PR is merged, a git tag and GitHub Release are automatically created
+1. Commit with Conventional Commits - All commits to `main` must follow conventional commit format (see [commit message instructions](./.github/instructions/hve-core/commit-message.instructions.md))
+2. Release PR Creation - After commits are pushed to `main`, release-please automatically creates or updates a "release PR"
+3. Review Release PR - Maintainers review the release PR to verify version bump and changelog accuracy
+4. Merge to Release - When the release PR is merged, a git tag and GitHub Release are automatically created
 
 ### Version Determination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,7 +17,7 @@ HVE Core uses a liberal contribution model where active contributors are recogni
 
 ## Governance Model
 
-This project operates under a **corporate-sponsored maintainer model**:
+This project operates under a corporate-sponsored maintainer model:
 
 * Microsoft provides stewardship, infrastructure, and core maintainer resources
 * Community contributors participate through standard open source workflows
@@ -148,9 +148,9 @@ Nomination process:
 
 When contributors disagree on technical or process matters:
 
-1. **Discussion**: Parties discuss the issue in the relevant pull request or issue
-2. **Maintainer input**: If unresolved, a maintainer provides guidance
-3. **Maintainer decision**: If consensus remains elusive, maintainers make a binding decision
+1. Discussion: Parties discuss the issue in the relevant pull request or issue
+2. Maintainer input: If unresolved, a maintainer provides guidance
+3. Maintainer decision: If consensus remains elusive, maintainers make a binding decision
 
 Code of conduct violations follow the process defined in [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,15 +30,15 @@ HVE Core is an open-source project maintained by Microsoft and community contrib
 | Major (Accessibility)      | Significant accessibility issues                 | 3-5 business days              |
 | General Issues & Questions | Bug reports, feature requests, questions         | 48-hour (24x6) response window |
 
-**Note**: Response times indicate initial acknowledgment. Resolution time varies based on issue complexity and community availability.
+Note: Response times indicate initial acknowledgment. Resolution time varies based on issue complexity and community availability.
 
 ### Our Support Performance
 
 We track our response time commitments publicly. Our performance metrics demonstrate consistent delivery:
 
-* **48-hour SLO Compliance**: High compliance rate with response targets
-* **Average PR Completion**: Typically completed within 3 days
-* **Fast Resolution**: Significant portion of issues/PRs resolved in under 1 day
+* 48-hour SLO Compliance: High compliance rate with response targets
+* Average PR Completion: Typically completed within 3 days
+* Fast Resolution: Significant portion of issues/PRs resolved in under 1 day
 
 ## Filing Issues
 
@@ -46,7 +46,7 @@ We track our response time commitments publicly. Our performance metrics demonst
 
 1. **Search existing issues** in our [GitHub Issues](https://github.com/microsoft/hve-core/issues)
 2. **Create a new issue** if yours isn't already tracked: [New Issue](https://github.com/microsoft/hve-core/issues/new/choose)
-3. **Provide details**:
+3. Provide details:
    * Clear description of the problem or request
    * Steps to reproduce (for bugs)
    * Expected vs. actual behavior

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,9 +75,9 @@ hve-core provides specialized agents organized into functional groups. Each grou
 
 AI-assisted Design Thinking uses the dt-coach agent to guide teams through nine methods across three spaces.
 
-* [Design Thinking Guide](design-thinking/README.md) — Overview and method catalog
-* [Why Design Thinking?](design-thinking/why-design-thinking.md) — When to use DT
-* [Using the DT Coach](design-thinking/dt-coach.md) — Agent usage guide
+* [Design Thinking Guide](design-thinking/README.md): Overview and method catalog
+* [Why Design Thinking?](design-thinking/why-design-thinking.md): When to use DT
+* [Using the DT Coach](design-thinking/dt-coach.md): Agent usage guide
 * [Browse all Design Thinking docs →](design-thinking/)
 
 ## RPI Methodology

--- a/docs/architecture/ai-artifacts.md
+++ b/docs/architecture/ai-artifacts.md
@@ -17,13 +17,13 @@ The artifact system organizes customizations by scope and responsibility. Prompt
 
 Prompts (`.prompt.md`) serve as workflow entry points. They capture user intent and translate requests into structured guidance for Copilot execution.
 
-**Core characteristics:**
+#### Core Characteristics
 
 * Define single-session workflows with clear inputs and outputs
 * Accept user inputs through `${input:varName}` template syntax
 * Delegate to agents via `agent:` frontmatter references
 
-**Frontmatter structure:**
+#### Frontmatter Structure
 
 ```yaml
 ---
@@ -38,14 +38,14 @@ Prompts answer the question "what does the user want to accomplish?" and route e
 
 Agents (`.agent.md`) define task-specific behaviors with access to Copilot tools. They orchestrate multi-step workflows and make decisions based on context.
 
-**Core characteristics:**
+#### Core Characteristics
 
 * Specify available tools through `tools:` frontmatter arrays
 * Enable workflow handoffs via `handoffs:` references to other agents
 * Maintain conversation context across multiple interactions
 * Apply domain expertise through detailed behavioral instructions
 
-**Frontmatter structure:**
+#### Frontmatter Structure
 
 ```yaml
 ---
@@ -69,14 +69,14 @@ Agents answer the question "how should this task be executed?" and coordinate th
 
 Instructions (`.instructions.md`) encode technology-specific standards and conventions. They apply automatically based on file patterns and provide consistent guidance across the codebase.
 
-**Core characteristics:**
+#### Core Characteristics
 
 * Match files through `applyTo:` glob patterns for automatic application
 * Define coding standards, naming conventions, and quality requirements
 * Apply to specific languages, frameworks, or file types
 * Stack with other instructions when multiple patterns match
 
-**Frontmatter structure:**
+#### Frontmatter Structure
 
 ```yaml
 ---
@@ -98,13 +98,13 @@ Instructions placed at the root of `.github/instructions/` (without a subdirecto
 
 Skills (`.github/skills/<name>/SKILL.md`) provide executable utilities that agents invoke for specialized tasks. Unlike instructions (passive reference), skills contain actual scripts that perform operations.
 
-**Core characteristics:**
+#### Core Characteristics
 
 * Provide self-contained utility packages with documentation and scripts
 * Include parallel implementations for cross-platform support (`.sh` and `.ps1`)
 * Execute actual operations rather than providing guidance
 
-**Directory structure (by convention):**
+#### Directory Structure (by Convention)
 
 ```text
 .github/skills/{collection-id}/<skill-name>/
@@ -116,7 +116,7 @@ Skills (`.github/skills/<name>/SKILL.md`) provide executable utilities that agen
     └── README.md      # Usage examples
 ```
 
-**Frontmatter structure:**
+#### Frontmatter Structure
 
 ```yaml
 ---
@@ -125,7 +125,7 @@ description: 'Video-to-GIF conversion with FFmpeg optimization'
 ---
 ```
 
-**Required frontmatter fields:**
+#### Required Frontmatter Fields
 
 | Field         | Description                                             |
 |---------------|---------------------------------------------------------|
@@ -136,7 +136,7 @@ Maturity is tracked in `collections/*.collection.yml`, not in skill frontmatter.
 
 Skills answer the question "what specialized utility does this task require?" and provide executable capabilities beyond conversational guidance.
 
-**Key distinction from instructions:**
+#### Key Distinction from Instructions
 
 | Aspect     | Instructions                | Skills                |
 |------------|-----------------------------|-----------------------|
@@ -157,7 +157,7 @@ graph LR
     AGENT --> SKILLS[Skills]
 ```
 
-**Flow mechanics:**
+### Flow Mechanics
 
 1. User invokes a prompt through `/prompt` commands or workflow triggers.
 2. Prompt references an agent via `agent:` frontmatter, delegating execution.

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -263,10 +263,12 @@ Collection manifests in `collections/*.collection.yml` define collection-scoped 
 
 Maturity filtering rules:
 
-* **Deprecated** collections are always excluded.
-* **Experimental** collections are excluded from Stable channel builds.
-* **Preview** collections are included in both Stable and PreRelease channel builds.
-* **Stable** collections are included in all channel builds.
+| Maturity Level | Build Inclusion                                 |
+|----------------|-------------------------------------------------|
+| Deprecated     | Always excluded                                 |
+| Experimental   | Excluded from Stable channel builds             |
+| Preview        | Included in both Stable and PreRelease channels |
+| Stable         | Included in all channel builds                  |
 
 ### Version Channels
 

--- a/docs/contributing/ROADMAP.md
+++ b/docs/contributing/ROADMAP.md
@@ -36,7 +36,7 @@ HVE Core v1.1.0 provides:
 
 ### Agent Framework Evolution
 
-**Will Do:**
+#### Will Do
 
 * Expand MCP (Model Context Protocol) integration for standardized tool connections
 * Develop multi-agent coordination patterns for complex enterprise scenarios
@@ -45,7 +45,7 @@ HVE Core v1.1.0 provides:
 * Add agent metrics and observability for understanding AI decision patterns
 * Implement agent memory and context management capabilities
 
-**Won't Do:**
+#### Won't Do
 
 * Build a custom orchestration runtime; use LangGraph or similar established frameworks instead
 * Create proprietary tool protocols that compete with MCP
@@ -53,7 +53,7 @@ HVE Core v1.1.0 provides:
 
 ### Instructions Expansion
 
-**Will Do:**
+#### Will Do
 
 * Add instructions for emerging Azure services (Azure AI Foundry, Azure Container Apps)
 * Create security-focused instructions for threat modeling and secure coding patterns
@@ -62,7 +62,7 @@ HVE Core v1.1.0 provides:
 * Enhance existing C# instructions with .NET 9+ patterns and minimal API guidance
 * Add instructions for GitHub Actions workflow authoring
 
-**Won't Do:**
+#### Won't Do
 
 * Create instructions for out-of-market Azure services
 * Maintain instructions for non-Microsoft technology stacks unless directly relevant to Azure integration
@@ -70,21 +70,21 @@ HVE Core v1.1.0 provides:
 
 ### Prompt Engineering
 
-**Will Do:**
+#### Will Do
 
 * Develop prompt templates for common Azure architecture patterns (hub-spoke, landing zones)
 * Create code review prompts that understand Azure Well-Architected & Cloud-Adoption Framework principles
 * Add incident response prompts for Azure operations scenarios
 * Develop security audit prompts for Azure resource configurations
 
-**Won't Do:**
+#### Won't Do
 
 * Create prompts for general-purpose coding tasks without Azure context
 * Build prompts that duplicate functionality available in GitHub Copilot's native capabilities
 
 ### Enterprise Readiness
 
-**Will Do:**
+#### Will Do
 
 * Document governance patterns for organization-wide Hypervelocity Engineering adoption
 * Create compliance mapping for Azure Policy and Defender for Cloud alignment
@@ -92,14 +92,14 @@ HVE Core v1.1.0 provides:
 * Develop approval workflow patterns for high-risk AI operations
 * Add data classification guidance for sensitive context handling
 
-**Won't Do:**
+#### Won't Do
 
 * Build enterprise licensing or access control systems
 * Create centralized management infrastructure; organizations should use existing policy mechanisms
 
 ### Documentation and Learning
 
-**Will Do:**
+#### Will Do
 
 * Create video tutorials demonstrating RPI workflow with real Azure projects
 * Develop scenario-based guides (greenfield, modernization, migration)
@@ -107,14 +107,14 @@ HVE Core v1.1.0 provides:
 * Add architecture decision records (ADRs) explaining design choices
 * Create certification-style learning paths for HVE Core proficiency
 
-**Won't Do:**
+#### Won't Do
 
 * Duplicate Azure documentation: link to authoritative sources instead
 * Create marketing materials or promotional content
 
 ### Community and Ecosystem
 
-**Will Do:**
+#### Will Do
 
 * Establish contribution guidelines for new agents and instructions
 * Create agent and instruction quality criteria for inclusion
@@ -122,7 +122,7 @@ HVE Core v1.1.0 provides:
 * Develop community showcase for organization-specific customizations
 * Add integration guides for popular Azure development tools
 
-**Won't Do:**
+#### Won't Do
 
 * Accept agents or instructions that don't align with project scope
 * Maintain community contributions without active maintainers

--- a/docs/contributing/ai-artifacts-common.md
+++ b/docs/contributing/ai-artifacts-common.md
@@ -11,7 +11,7 @@ This document defines shared standards, conventions, and quality gates that appl
 
 ## Agents Not Accepted
 
-The following agent types will likely be **rejected or closed automatically** because **equivalent agents already exist in hve-core**:
+The following agent types will likely be **rejected or closed automatically** because equivalent agents already exist in hve-core:
 
 ### Duplicate Agent Categories
 
@@ -48,20 +48,20 @@ General-purpose coding agents that implement features.
 
 These agent types are rejected because:
 
-1. Existing agents are hardened and heavily used — the hve-core library already contains production-tested agents in these categories
-2. Consistency and maintenance — coalescing around existing agents reduces fragmentation and maintenance burden
-3. Avoid duplication — multiple agents serving the same purpose create confusion and divergent behavior
-4. Standard tooling already integrated — VS Code GitHub Copilot built-in tools and widely-adopted MCP tools are already used by existing agents
+1. Existing agents are hardened and heavily used: the hve-core library already contains production-tested agents in these categories
+2. Consistency and maintenance: coalescing around existing agents reduces fragmentation and maintenance burden
+3. Avoid duplication: multiple agents serving the same purpose create confusion and divergent behavior
+4. Standard tooling already integrated: VS Code GitHub Copilot built-in tools and widely-adopted MCP tools are already used by existing agents
 
 ### Before Submitting
 
 When planning to submit an agent that falls into these categories:
 
-1. Question necessity — does your use case truly require a new agent, or can existing agents meet your needs?
-2. Review existing agents — examine `.github/agents/` to identify agents that already serve your purpose
-3. Check tool integration — verify whether the VS Code GitHub Copilot tools or MCP tools you need are already used by existing agents
-4. Consider enhancement over creation — if existing agents don't fully meet your requirements, evaluate whether your changes are generic enough to benefit all users and valuable enough to justify modifying the existing agent
-5. Propose enhancements — submit a PR to enhance an existing agent rather than creating a duplicate
+1. Question necessity: does your use case truly require a new agent, or can existing agents meet your needs?
+2. Review existing agents: examine `.github/agents/` to identify agents that already serve your purpose
+3. Check tool integration: verify whether the VS Code GitHub Copilot tools or MCP tools you need are already used by existing agents
+4. Consider enhancement over creation: if existing agents don't fully meet your requirements, evaluate whether your changes are generic enough to benefit all users and valuable enough to justify modifying the existing agent
+5. Propose enhancements: submit a PR to enhance an existing agent rather than creating a duplicate
 
 ### What Makes a Good New Agent
 
@@ -95,10 +95,10 @@ All AI artifacts (agents, instructions, prompts) **MUST** target the **latest av
 
 ### Rationale
 
-1. Feature parity — latest models support the most advanced features and capabilities
-2. Maintenance burden — supporting multiple model versions creates testing and compatibility overhead
-3. Performance — latest models provide superior reasoning, accuracy, and efficiency
-4. Future-proofing — older models will be deprecated and removed from service
+1. Feature parity: latest models support the most advanced features and capabilities
+2. Maintenance burden: supporting multiple model versions creates testing and compatibility overhead
+3. Performance: latest models provide superior reasoning, accuracy, and efficiency
+4. Future-proofing: older models will be deprecated and removed from service
 
 ## Collections
 
@@ -256,11 +256,11 @@ Collections represent role-targeted artifact packages for HVE-Core artifacts. Th
 
 When assigning collections to artifacts:
 
-* **Universal artifacts** should include `hve-core-all` plus any role-specific collections that particularly benefit
-* **Role-specific artifacts** should include only the relevant collections (omit `hve-core-all` for highly specialized artifacts)
-* **Cross-cutting tools** like RPI workflow artifacts (`task-researcher`, `task-planner`) should include multiple relevant collections
+* Include `hve-core-all` plus any role-specific collections that particularly benefit for universal artifacts
+* Include only the relevant collections for role-specific artifacts (omit `hve-core-all` for highly specialized artifacts)
+* Assign cross-cutting tools like RPI workflow artifacts (`task-researcher`, `task-planner`) to multiple relevant collections
 
-**Example collection assignments:**
+#### Example Collection Assignments
 
 Adding an artifact to multiple collections means adding its `items[]` entry in each relevant `collections/*.collection.yml`:
 
@@ -301,10 +301,10 @@ During VS Code Extension packaging, agent handoff dependencies are automatically
 
 The extension packaging process (`scripts/extension/Prepare-Extension.ps1`) includes the `Resolve-HandoffDependencies` function:
 
-1. **Seed agents**: Starts with agents listed in the collection manifest
-2. **Parse frontmatter**: Reads the `handoffs` field from each agent's frontmatter
-3. **BFS traversal**: Performs breadth-first search to find all reachable agents through handoff chains
-4. **Include all**: Adds all discovered agents to the extension package
+1. Seed agents: Starts with agents listed in the collection manifest
+2. Parse frontmatter: Reads the `handoffs` field from each agent's frontmatter
+3. BFS traversal: Performs breadth-first search to find all reachable agents through handoff chains
+4. Include all: Adds all discovered agents to the extension package
 
 #### Collection Manifests and Dependencies
 
@@ -375,7 +375,7 @@ items:
 
 For detailed channel and lifecycle information, see [Release Process - Extension Channels](release-process.md#extension-channels-and-maturity).
 
-**Before submitting**: Verify your artifact targets the current latest model versions from Anthropic or OpenAI. Contributions targeting older or alternative models will be automatically rejected.
+Before submitting: Verify your artifact targets the current latest model versions from Anthropic or OpenAI. Contributions targeting older or alternative models will be automatically rejected.
 
 ## Plugin Generation
 
@@ -385,11 +385,11 @@ The `plugins/` directory contains **auto-generated plugin bundles** created from
 
 When you add an artifact to a collection manifest:
 
-1. **Author artifact**: Create your agent, prompt, instruction, or skill in `.github/`
-2. **Update collection**: Add an `items[]` entry to one or more `collections/*.collection.yml` files
-3. **Validate collections**: Run `npm run plugin:validate` to check manifest correctness
-4. **Generate plugins**: Run `npm run plugin:generate` to regenerate all plugin directories
-5. **Commit both**: Commit the source artifact, collection manifest updates, AND generated plugin outputs together
+1. Author artifact: Create your agent, prompt, instruction, or skill in `.github/`
+2. Update collection: Add an `items[]` entry to one or more `collections/*.collection.yml` files
+3. Validate collections: Run `npm run plugin:validate` to check manifest correctness
+4. Generate plugins: Run `npm run plugin:generate` to regenerate all plugin directories
+5. Commit both: Commit the source artifact, collection manifest updates, AND generated plugin outputs together
 
 ### Plugin Directory Structure
 
@@ -548,7 +548,7 @@ All AI artifacts MUST follow these markdown quality requirements:
 * Use proper language identifiers: `bash`, `python`, `json`, `yaml`, `markdown`, `text`, `plaintext`
 * No naked code blocks without language specification
 
-❌ **Bad**:
+❌ Bad:
 
 ````markdown
 ```
@@ -556,7 +556,7 @@ code without language tag
 ```
 ````
 
-✅ **Good**:
+✅ Good:
 
 ````markdown
 ```python
@@ -570,13 +570,13 @@ def example(): pass
 * Wrap in angle brackets: `<https://example.com>`
 * Use markdown links: `[text](https://example.com)`
 
-❌ **Bad**:
+❌ Bad:
 
 ```markdown
 See https://example.com for details.
 ```
 
-✅ **Good**:
+✅ Good:
 
 ```markdown
 See <https://example.com> for details.
@@ -615,11 +615,9 @@ Use standardized keywords for clarity and enforceability:
 
 ### Required Behavior
 
-* **MUST** / **WILL** / **MANDATORY** / **REQUIRED** / **CRITICAL**
-* Indicates absolute requirement
-* Non-compliance is a defect
+MUST, WILL, MANDATORY, REQUIRED, and CRITICAL indicate absolute requirements. Non-compliance is a defect.
 
-**Example**:
+#### Example: Required Behavior
 
 ```markdown
 All functions MUST include type hints for parameters and return values.
@@ -628,12 +626,9 @@ You WILL validate frontmatter before proceeding (MANDATORY).
 
 ### Strong Recommendations
 
-* **SHOULD** / **RECOMMENDED**
-* Indicates best practice
-* Valid reasons may exist for exceptions
-* Non-compliance requires justification
+SHOULD and RECOMMENDED indicate best practices. Valid reasons may exist for exceptions, but non-compliance requires justification.
 
-**Example**:
+#### Example: Strong Recommendations
 
 ```markdown
 Examples SHOULD be wrapped in XML-style blocks for reusability.
@@ -642,11 +637,9 @@ Functions SHOULD include docstrings with parameter descriptions.
 
 ### Optional/Permitted
 
-* **MAY** / **OPTIONAL** / **CAN**
-* Indicates permitted but not required
-* Implementer choice
+MAY, OPTIONAL, and CAN indicate permitted but not required behavior. The choice is left to the implementer.
 
-**Example**:
+#### Example: Optional Behavior
 
 ```markdown
 You MAY include version fields in frontmatter.
@@ -655,7 +648,7 @@ Contributors CAN organize examples by complexity level.
 
 ### Avoid Ambiguous Language
 
-❌ **Ambiguous (Never Use)**:
+❌ Ambiguous (Never Use):
 
 ```markdown
 You might want to validate the input...
@@ -665,7 +658,7 @@ Try to follow the pattern...
 Maybe include tests...
 ```
 
-✅ **Clear (Always Use)**:
+✅ Clear (Always Use):
 
 ```markdown
 You MUST validate all input before processing.
@@ -810,7 +803,7 @@ All AI artifacts MUST include attribution as a suffix in the frontmatter `descri
 description: 'Tests prompt files in a sandbox environment - Brought to you by microsoft/hve-core'
 ```
 
-**Format**: `- Brought to you by organization/repository-name` appended to the description value.
+Format: `- Brought to you by organization/repository-name` appended to the description value.
 
 Skill files (`SKILL.md`) additionally include a blockquote attribution footer as the last line of body content:
 

--- a/docs/contributing/branch-protection.md
+++ b/docs/contributing/branch-protection.md
@@ -38,7 +38,7 @@ The following CI jobs must pass before a PR can be merged:
 | npm Security Audit          | Scans for vulnerable dependencies |
 | CodeQL Security Analysis    | Security vulnerability scanning   |
 
-**Note**: `Markdown Link Check` uses soft-fail and is not a required check.
+Note: `Markdown Link Check` uses soft-fail and is not a required check.
 
 ## Review Requirements
 
@@ -61,7 +61,7 @@ The `.github/CODEOWNERS` file defines code ownership:
 
 With this configuration, the expected OpenSSF Scorecard Branch Protection score is **~8/10**.
 
-**Note**: Achieving 10/10 requires 2 reviewers. The current configuration prioritizes team velocity with 1 reviewer.
+Note: Achieving 10/10 requires 2 reviewers. The current configuration prioritizes team velocity with 1 reviewer.
 
 ## Configuration Reference
 
@@ -69,19 +69,19 @@ With this configuration, the expected OpenSSF Scorecard Branch Protection score 
 
 Navigate to: **Settings → Branches → Branch protection rules → Edit `main`**
 
-**Require a pull request before merging**:
+#### Require a Pull Request before Merging
 
 * [x] Require approvals (1)
 * [x] Dismiss stale pull request approvals when new commits are pushed
 * [x] Require approval of the most recent reviewable push
 * [x] Require review from Code Owners
 
-**Require status checks to pass before merging**:
+#### Require Status Checks to Pass before Merging
 
 * [x] Require branches to be up to date before merging
 * Add all status checks listed in table above
 
-**Other settings**:
+#### Other Settings
 
 * [x] Do not allow bypassing the above settings
 

--- a/docs/contributing/custom-agents.md
+++ b/docs/contributing/custom-agents.md
@@ -9,7 +9,7 @@ ms.topic: how-to
 
 This guide defines the requirements, standards, and best practices for contributing GitHub Copilot agent files (`.agent.md`) to the hve-core library.
 
-**⚙️ Common Standards**: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
+⚙️ Common Standards: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
 
 ## What is an Agent?
 
@@ -27,7 +27,7 @@ Create an agent when you need to:
 
 ## Agents Not Accepted
 
-The following agent types will likely be **rejected or closed automatically** because **equivalent agents already exist in hve-core**:
+The following agent types will likely be **rejected or closed automatically** because equivalent agents already exist in hve-core:
 
 ### Duplicate Agent Categories
 
@@ -64,20 +64,20 @@ General-purpose coding agents that implement features.
 
 These agent types are rejected because:
 
-1. Existing agents are hardened and heavily used — the hve-core library already contains production-tested agents in these categories
-2. Consistency and maintenance — coalescing around existing agents reduces fragmentation and maintenance burden
-3. Avoid duplication — multiple agents serving the same purpose create confusion and divergent behavior
-4. Standard tooling already integrated — VS Code GitHub Copilot built-in tools and widely-adopted MCP tools are already used by existing agents
+1. Existing agents are hardened and heavily used: the hve-core library already contains production-tested agents in these categories
+2. Consistency and maintenance: coalescing around existing agents reduces fragmentation and maintenance burden
+3. Avoid duplication: multiple agents serving the same purpose create confusion and divergent behavior
+4. Standard tooling already integrated: VS Code GitHub Copilot built-in tools and widely-adopted MCP tools are already used by existing agents
 
 ### Before Submitting
 
 When planning to submit an agent that falls into these categories:
 
-1. Question necessity — does your use case truly require a new agent, or can existing agents meet your needs?
-2. Review existing agents — examine `.github/agents/` to identify agents that already serve your purpose
-3. Check tool integration — verify whether the VS Code GitHub Copilot tools or MCP tools you need are already used by existing agents
-4. Consider enhancement over creation — if existing agents don't fully meet your requirements, evaluate whether your changes are generic enough to benefit all users and valuable enough to justify modifying the existing agent
-5. Propose enhancements — submit a PR to enhance an existing agent rather than creating a duplicate
+1. Question necessity: does your use case truly require a new agent, or can existing agents meet your needs?
+2. Review existing agents: examine `.github/agents/` to identify agents that already serve your purpose
+3. Check tool integration: verify whether the VS Code GitHub Copilot tools or MCP tools you need are already used by existing agents
+4. Consider enhancement over creation: if existing agents don't fully meet your requirements, evaluate whether your changes are generic enough to benefit all users and valuable enough to justify modifying the existing agent
+5. Propose enhancements: submit a PR to enhance an existing agent rather than creating a duplicate
 
 ### What Makes a Good New Agent
 
@@ -95,11 +95,11 @@ Focus on agents that:
 
 All agents **MUST** target the **latest available models** from **Anthropic and OpenAI only**.
 
-**Accepted**: Latest Claude models (e.g., Claude Sonnet 4, Claude Opus 4) and latest GPT models (e.g., GPT-5.1, o1)
+Accepted: Latest Claude models (e.g., Claude Sonnet 4, Claude Opus 4) and latest GPT models (e.g., GPT-5.1, o1)
 
-**Not Accepted**: Older model versions (e.g., GPT-3.5, GPT-4.1, Claude 2), models from other providers, custom/fine-tuned models
+Not Accepted: Older model versions (e.g., GPT-3.5, GPT-4.1, Claude 2), models from other providers, custom/fine-tuned models
 
-**Rationale**: Latest models provide superior capabilities, reduce maintenance burden, and ensure future compatibility. Older model versions will be deprecated.
+Rationale: Latest models provide superior capabilities, reduce maintenance burden, and ensure future compatibility. Older model versions will be deprecated.
 
 ## File Structure Requirements
 
@@ -126,7 +126,7 @@ Agent files are typically organized in a collection subdirectory by convention:
 
 ### File Format
 
-Agent files **MUST**:
+Agent files MUST:
 
 1. Use the `.agent.md` extension
 2. Start with valid YAML frontmatter between `---` delimiters
@@ -326,13 +326,13 @@ For complete collection documentation, see [AI Artifacts Common Standards - Coll
 
 When agents reference MCP tools in their `tools:` frontmatter or body content, document the dependencies clearly.
 
-**Frontmatter declaration:**
+#### Frontmatter Declaration
 
 ```yaml
 tools: ['github/*', 'ado/*', 'context7/*', 'microsoft-docs/*']
 ```
 
-**Curated MCP servers referenced by HVE-Core agents:**
+#### Curated MCP Servers Referenced by HVE-Core Agents
 
 | Server         | Tool Pattern       | Purpose                                   |
 |----------------|--------------------|-------------------------------------------|
@@ -341,7 +341,7 @@ tools: ['github/*', 'ado/*', 'context7/*', 'microsoft-docs/*']
 | context7       | `context7/*`       | Library and SDK documentation lookup      |
 | microsoft-docs | `microsoft-docs/*` | Microsoft Learn documentation             |
 
-**Guidelines for MCP tool references:**
+#### Guidelines for MCP Tool References
 
 * Document MCP dependencies in agent body text when using `mcp_*` tool patterns
 * Agents should gracefully handle missing MCP servers (tools unavailable)
@@ -377,9 +377,9 @@ before they're merged into the library.
 
 * Uses clear, imperative language
 * Employs RFC 2119 keywords consistently:
-  * **MUST/WILL/MANDATORY/CRITICAL** - Required behavior
-  * **SHOULD/RECOMMENDED** - Strong guidance
-  * **MAY/OPTIONAL** - Permitted but not required
+  * MUST, WILL, MANDATORY, and CRITICAL indicate required behavior
+  * SHOULD and RECOMMENDED indicate strong guidance
+  * MAY and OPTIONAL indicate permitted but not required behavior
 * Provides step-by-step workflows
 * Includes decision points and branching logic
 
@@ -422,7 +422,7 @@ When agents use tools, they **MUST** follow these patterns:
 Before any batch of tool calls, include a one-sentence explanation:
 
 ```markdown
-**Tool Usage Preamble**: "Analyzing file structure, reading schemas, and checking
+Tool Usage Preamble: "Analyzing file structure, reading schemas, and checking
 repository conventions to establish validation baseline."
 ```
 
@@ -431,7 +431,7 @@ repository conventions to establish validation baseline."
 After 3-5 tool calls or more than 3 file edits, provide a compact checkpoint:
 
 ```markdown
-**Checkpoint After Discovery**: "Identified [file type], loaded [schema name],
+Checkpoint After Discovery: "Identified [file type], loaded [schema name],
 found [N] related files for comparison."
 ```
 
@@ -447,7 +447,7 @@ Define how the agent communicates with users:
 
 ### Response Format
 
-* Start all responses with: `## **[Agent Name]**: [Action Description]`
+* Start all responses with: `## [Agent Name]: [Action Description]`
 * Use short, action-oriented section headers
 * Employ proper markdown formatting
 * Include emojis for visual clarity (when appropriate)
@@ -480,9 +480,9 @@ Report validation status:
 ```markdown
 ### Quality Gates
 
-- **Build**: PASS
-- **Lint**: FAIL - Markdownlint flagged: bare URLs (lines 45, 67)
-- **Schema**: PASS - Frontmatter validates
+- Build: PASS
+- Lint: FAIL - Markdownlint flagged: bare URLs (lines 45, 67)
+- Schema: PASS - Frontmatter validates
 ```
 
 ## Research and External Sources

--- a/docs/contributing/instructions.md
+++ b/docs/contributing/instructions.md
@@ -9,7 +9,7 @@ ms.topic: how-to
 
 This guide defines the requirements, standards, and best practices for contributing GitHub Copilot instruction files (`.instructions.md`) to the hve-core library.
 
-**⚙️ Common Standards**: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
+⚙️ Common Standards: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
 
 ## What is an Instructions File?
 
@@ -55,7 +55,7 @@ Instruction files are typically organized in a collection subdirectory by conven
 > Collections can reference artifacts from any subfolder. The `path:` field in collection YAML files
 > accepts any valid repo-relative path regardless of the artifact's parent directory.
 
-**Examples**:
+#### Examples
 
 * `.github/instructions/coding-standards/python-script.instructions.md`
 * `.github/instructions/hve-core/markdown.instructions.md`
@@ -71,7 +71,7 @@ Instruction files are typically organized in a collection subdirectory by conven
 
 ### File Format
 
-Instruction files **MUST**:
+Instruction files MUST:
 
 1. Use the `.instructions.md` extension
 2. Start with valid YAML frontmatter between `---` delimiters
@@ -83,39 +83,45 @@ Instruction files **MUST**:
 
 **`description`** (string, MANDATORY)
 
-* **Purpose**: Concise explanation of instruction scope and target
-* **Format**: Single sentence, 10-200 characters
-* **Style**: Sentence case with proper punctuation
-* **Example**: `'Required instructions for Python script implementation with type hints and docstrings'`
+| Property | Value                                                                                     |
+|----------|-------------------------------------------------------------------------------------------|
+| Purpose  | Concise explanation of instruction scope and target                                       |
+| Format   | Single sentence, 10-200 characters                                                        |
+| Style    | Sentence case with proper punctuation                                                     |
+| Example  | `'Required instructions for Python script implementation with type hints and docstrings'` |
 
 **`applyTo`** (string, MANDATORY for auto-applied instructions)
 
-* **Purpose**: Glob pattern(s) defining when these instructions activate
-* **Format**: Valid glob pattern or comma-separated patterns
-* **Scope**: Matches from repository root
-* **Examples**:
-  * Single pattern: `**/*.py`
-  * Multiple files: `**/*.py, **/*.ipynb`
-  * Directory scope: `**/src/**/*.sh`
-  * Specific paths: `**/.copilot-tracking/pr/new/**`
+| Property | Value                                                     |
+|----------|-----------------------------------------------------------|
+| Purpose  | Glob pattern(s) defining when these instructions activate |
+| Format   | Valid glob pattern or comma-separated patterns            |
+| Scope    | Matches from repository root                              |
+
+Examples:
+
+* Single pattern: `**/*.py`
+* Multiple files: `**/*.py, **/*.ipynb`
+* Directory scope: `**/src/**/*.sh`
+* Specific paths: `**/.copilot-tracking/pr/new/**`
 
 ### Optional Fields
 
 **`version`** (string)
 
-* **Purpose**: Tracks instruction file revisions
-* **Format**: Semantic versioning (e.g., `1.0.0`)
-* **Pattern**: `^\d+\.\d+(\.\d+)?$` (major.minor or major.minor.patch)
+| Property | Value                                                   |
+|----------|---------------------------------------------------------|
+| Purpose  | Tracks instruction file revisions                       |
+| Format   | Semantic versioning (e.g., `1.0.0`)                     |
+| Pattern  | `^\d+\.\d+(\.\d+)?$` (major.minor or major.minor.patch) |
 
 **`author`** (string)
 
-* **Purpose**: Attribution for instruction creator
-* **Example**: `microsoft/hve-core`, `your-team-name`
+Attribution for the instruction creator (e.g., `microsoft/hve-core`, `your-team-name`).
 
 **`lastUpdated`** (string)
 
-* **Purpose**: Timestamp of last modification
-* **Format**: ISO 8601 date (YYYY-MM-DD)
+Timestamp of last modification in ISO 8601 format (YYYY-MM-DD).
 
 ### Frontmatter Example
 
@@ -231,11 +237,11 @@ Scripts MUST follow this organization:
 ```markdown
 ## Naming Conventions
 
-* **Files**: `snake_case.py` (e.g., `data_processor.py`)
-* **Functions**: `snake_case()` (e.g., `process_data()`)
-* **Classes**: `PascalCase` (e.g., `DataProcessor`)
-* **Constants**: `SCREAMING_SNAKE_CASE` (e.g., `MAX_RETRIES`)
-* **Private**: `_leading_underscore` (e.g., `_internal_helper()`)
+* Files: `snake_case.py` (e.g., `data_processor.py`)
+* Functions: `snake_case()` (e.g., `process_data()`)
+* Classes: `PascalCase` (e.g., `DataProcessor`)
+* Constants: `SCREAMING_SNAKE_CASE` (e.g., `MAX_RETRIES`)
+* Private: `_leading_underscore` (e.g., `_internal_helper()`)
 ```
 
 #### 5. Code Examples
@@ -278,7 +284,7 @@ def calculate_average(numbers: list[float]) -> float:
 ```markdown
 ## Anti-Patterns
 
-❌ **Bare except clauses**:
+❌ Bare except clauses:
 ```python
 try:
     risky_operation()
@@ -286,7 +292,7 @@ except:  # DON'T DO THIS
     pass
 ```
 
-✅ **Specific exception handling**:
+✅ Specific exception handling:
 
 ```python
 try:
@@ -307,15 +313,15 @@ except FileNotFoundError as e:
 
 All Python code MUST pass:
 
-* **Linting**: `ruff check .`
-* **Type checking**: `mypy --strict .`
-* **Testing**: `pytest tests/ --cov=src`
-* **Coverage**: Minimum 80% line coverage
+* Linting: `ruff check .`
+* Type checking: `mypy --strict .`
+* Testing: `pytest tests/ --cov=src`
+* Coverage: Minimum 80% line coverage
 ```
 
 #### 8. Attribution Footer
 
-* **MANDATORY**: Include at end of file
+Always include an attribution footer at the end of the file.
 
 ```markdown
 ---
@@ -431,12 +437,12 @@ Formatting and style rules:
 ```markdown
 ## Style Conventions
 
-* **Indentation**: 4 spaces (no tabs)
-* **Line length**: 88 characters (Black formatter default)
-* **Quotes**: Double quotes for strings, single for dict keys
-* **Imports**: Organized by isort with Black-compatible settings
-* **Trailing commas**: Use in multi-line collections
-* **Type hints**: Use modern syntax (`list[str]` not `List[str]`)
+* Indentation: 4 spaces (no tabs)
+* Line length: 88 characters (Black formatter default)
+* Quotes: Double quotes for strings, single for dict keys
+* Imports: Organized by isort with Black-compatible settings
+* Trailing commas: Use in multi-line collections
+* Type hints: Use modern syntax (`list[str]` not `List[str]`)
 ```
 
 ## Validation and Tooling
@@ -472,11 +478,11 @@ Define test expectations:
 ```markdown
 ## Testing Requirements
 
-* **Coverage**: Minimum 80% line coverage
-* **Test location**: `tests/` directory mirroring `src/` structure
-* **Test naming**: `test_*.py` files, `test_*` functions
-* **Fixtures**: Use pytest fixtures for shared test data
-* **Mocking**: Mock external dependencies (file I/O, network calls)
+* Coverage: Minimum 80% line coverage
+* Test location: `tests/` directory mirroring `src/` structure
+* Test naming: `test_*.py` files, `test_*` functions
+* Fixtures: Use pytest fixtures for shared test data
+* Mocking: Mock external dependencies (file I/O, network calls)
 
 <!-- <example-pytest-test> -->
 ```python
@@ -623,13 +629,11 @@ See [AI Artifacts Common Standards - Common Testing Practices](ai-artifacts-comm
 
 ### Invalid Glob Pattern
 
-* **Problem**: Glob patterns that only match root directory or contain syntax errors
-* **Solution**: Use `**/` prefix for recursive matching (e.g., `**/*.py` for all Python files recursively)
+Glob patterns that only match root directory or contain syntax errors cause matching failures. Use the `**/` prefix for recursive matching (e.g., `**/*.py` for all Python files recursively).
 
 ### Conflicting Patterns
 
-* **Problem**: Multiple instruction files with overlapping glob patterns causing ambiguity
-* **Solution**: Make patterns more specific (e.g., `**/tests/**/*.py` vs `**/*.py`) or ensure they target distinct file sets
+Multiple instruction files with overlapping glob patterns cause ambiguity. Make patterns more specific (e.g., `**/tests/**/*.py` vs `**/*.py`) or ensure they target distinct file sets.
 
 For additional common issues (XML blocks, markdown, directives), see [AI Artifacts Common Standards - Common Issues and Fixes](ai-artifacts-common.md#common-issues-and-fixes).
 

--- a/docs/contributing/prompts.md
+++ b/docs/contributing/prompts.md
@@ -9,7 +9,7 @@ ms.topic: how-to
 
 This guide defines the requirements, standards, and best practices for contributing GitHub Copilot prompt files (`.prompt.md`) to the hve-core library.
 
-**⚙️ Common Standards**: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
+⚙️ Common Standards: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
 
 ## What is a Prompt?
 
@@ -49,7 +49,7 @@ Prompt files are typically organized in a collection subdirectory by convention:
 
 ### File Format
 
-Prompt files **MUST**:
+Prompt files MUST:
 
 1. Use the `.prompt.md` extension
 2. Start with valid YAML frontmatter between `---` delimiters
@@ -62,47 +62,52 @@ Prompt files **MUST**:
 
 **`description`** (string, MANDATORY)
 
-* **Purpose**: Concise explanation of prompt purpose and use case
-* **Format**: Single sentence, 10-200 characters
-* **Style**: Sentence case with proper punctuation
-* **Example**: `'Required protocol for creating Azure DevOps pull requests with work item discovery and reviewer identification'`
+| Property | Value                                                                                                              |
+|----------|--------------------------------------------------------------------------------------------------------------------|
+| Purpose  | Concise explanation of prompt purpose and use case                                                                 |
+| Format   | Single sentence, 10-200 characters                                                                                 |
+| Style    | Sentence case with proper punctuation                                                                              |
+| Example  | `'Required protocol for creating Azure DevOps pull requests with work item discovery and reviewer identification'` |
 
 **`mode`** (string enum, MANDATORY for prompts)
 
-* **Purpose**: Defines when/how the prompt is invoked
-* **Valid values**:
-  * `agent` - Used by specialized AI agents
-  * `assistant` - General-purpose assistance context
-  * `copilot` - GitHub Copilot-specific workflows
-  * `workflow` - Automated workflow/pipeline context
-* **Example**: `workflow`
+| Property | Value                                  |
+|----------|----------------------------------------|
+| Purpose  | Defines when/how the prompt is invoked |
+| Example  | `workflow`                             |
+
+Valid values:
+
+* `agent` - Used by specialized AI agents
+* `assistant` - General-purpose assistance context
+* `copilot` - GitHub Copilot-specific workflows
+* `workflow` - Automated workflow/pipeline context
 
 ### Optional Fields
 
 **`category`** (string enum)
 
-* **Purpose**: Organizes prompts by domain
-* **Valid values**:
-  * `ado` - Azure DevOps workflows
-  * `git` - Git operations
-  * `documentation` - Documentation generation/maintenance
-  * `workflow` - General workflow automation
-  * `development` - Development tasks
+Organizes prompts by domain.
+
+Valid values:
+
+* `ado` - Azure DevOps workflows
+* `git` - Git operations
+* `documentation` - Documentation generation/maintenance
+* `workflow` - General workflow automation
+* `development` - Development tasks
 
 **`version`** (string)
 
-* **Purpose**: Tracks prompt revisions
-* **Format**: Semantic versioning (e.g., `1.0.0`)
+Tracks prompt revisions using semantic versioning (e.g., `1.0.0`).
 
 **`author`** (string)
 
-* **Purpose**: Attribution for prompt creator
-* **Example**: `microsoft/hve-core`, `your-team-name`
+Attribution for the prompt creator (e.g., `microsoft/hve-core`, `your-team-name`).
 
 **`lastUpdated`** (string)
 
-* **Purpose**: Timestamp of last modification
-* **Format**: ISO 8601 date (YYYY-MM-DD)
+Timestamp of last modification in ISO 8601 format (YYYY-MM-DD).
 
 ### Frontmatter Example
 
@@ -198,10 +203,10 @@ work item discovery, reviewer identification, and compliance validation.
 ```markdown
 ## Workflow Steps
 
-1. **Discovery Phase**: Identify related work items from branch name or commit messages
-2. **Reviewer Selection**: Query ADO for default reviewers based on repository policies
-3. **PR Creation**: Generate PR with title, description, and work item links
-4. **Validation**: Verify PR was created successfully with correct metadata
+1. Discovery Phase: Identify related work items from branch name or commit messages
+2. Reviewer Selection: Query ADO for default reviewers based on repository policies
+3. PR Creation: Generate PR with title, description, and work item links
+4. Validation: Verify PR was created successfully with correct metadata
 ```
 
 #### 5. Success Criteria
@@ -233,7 +238,7 @@ work item discovery, reviewer identification, and compliance validation.
 
 #### 8. Attribution Footer
 
-* **MANDATORY**: Include at end of file
+Always include an attribution footer at the end of the file.
 
 ```markdown
 ---
@@ -267,7 +272,7 @@ assignee: "<user.email>"
 ```
 <!-- </example-template-variables> -->
 
-**Variable Naming**:
+#### Variable Naming
 
 * Use snake_case: `{{work_item_id}}`, `{{user_name}}`
 * Be descriptive: `{{target_branch}}` not `{{tb}}`
@@ -308,7 +313,7 @@ Where choices affect flow:
 **Else if** work items in commit messages:
   → Extract and use those work items
 
-**Else**:
+Else:
   → Prompt user for work item IDs
 ```
 
@@ -331,9 +336,9 @@ What artifacts are produced:
 ```markdown
 ## Output Artifacts
 
-1. **Pull Request**: Created in ADO with metadata
-2. **Handoff Document**: `.copilot-tracking/pr/{{YYYY-MM-DD}}-pr-{{id}}-handoff.md`
-3. **Validation Report**: Summary of PR creation status
+1. Pull Request: Created in ADO with metadata
+2. Handoff Document: `.copilot-tracking/pr/{{YYYY-MM-DD}}-pr-{{id}}-handoff.md`
+3. Validation Report: Summary of PR creation status
 ```
 
 ## Context Requirements
@@ -391,11 +396,11 @@ Structure for user-facing output:
 
 ### PR Creation Summary
 
-**Status**: [Success|Failed]
-**PR ID**: [ID]
-**PR URL**: [URL]
-**Work Items Linked**: [IDs]
-**Reviewers Added**: [Names]
+Status: [Success|Failed]
+PR ID: [ID]
+PR URL: [URL]
+Work Items Linked: [IDs]
+Reviewers Added: [Names]
 
 ### Validation Results
 
@@ -428,9 +433,9 @@ Format for failure scenarios:
 ```markdown
 ## Error Format
 
-**Error Type**: [Authentication|Validation|Network]
-**Message**: [Detailed error description]
-**Recovery Steps**:
+Error Type: [Authentication|Validation|Network]
+Message: [Detailed error description]
+Recovery Steps:
 
 1. [Step to resolve]
 2. [Alternative approach]
@@ -504,13 +509,11 @@ See [AI Artifacts Common Standards - Common Testing Practices](ai-artifacts-comm
 
 ### Template Variables with Wrong Format
 
-* **Problem**: Using incorrect syntax for template variables (angle brackets or shell-style)
-* **Solution**: Always use `{{variable_name}}` handlebars format for template variables
+Using incorrect syntax for template variables (angle brackets or shell-style) causes failures. Always use `{{variable_name}}` handlebars format for template variables.
 
 ### Ambiguous Workflow Steps
 
-* **Problem**: Vague workflow steps without specific tools, conditions, or decision logic
-* **Solution**: Provide explicit tool usage, decision trees, and fallback strategies with clear conditional logic
+Vague workflow steps without specific tools, conditions, or decision logic cause confusion. Provide explicit tool usage, decision trees, and fallback strategies with clear conditional logic.
 
 For additional common issues (XML blocks, markdown, directives), see [AI Artifacts Common Standards - Common Issues and Fixes](ai-artifacts-common.md#common-issues-and-fixes).
 

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -14,7 +14,7 @@ estimated_reading_time: 8
 
 This guide defines the requirements, standards, and best practices for contributing skill packages to the hve-core library.
 
-**⚙️ Common Standards**: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
+⚙️ Common Standards: See [AI Artifacts Common Standards](ai-artifacts-common.md) for shared requirements (XML blocks, markdown quality, RFC 2119, validation, testing).
 
 ## What is a Skill?
 
@@ -40,12 +40,14 @@ Create a skill when you need to:
 
 ## Skills Not Accepted
 
-The following skill types will likely be **rejected**:
+The following skill types will likely be rejected:
 
-* **Duplicate Skills**: Skills that replicate functionality of existing tools or skills
-* **Missing PowerShell Scripts**: Skills that include a `scripts/` directory without a `.ps1` file (PowerShell is required; bash is recommended)
-* **Undocumented Utilities**: Scripts without comprehensive SKILL.md documentation
-* **Untested Skills**: Skills that lack unit tests or fail to achieve 80% code coverage
+| Reason                     | Details                                                                                                        |
+|----------------------------|----------------------------------------------------------------------------------------------------------------|
+| Duplicate Skills           | Skills that replicate functionality of existing tools or skills                                                |
+| Missing PowerShell Scripts | Skills that include a `scripts/` directory without a `.ps1` file (PowerShell is required; bash is recommended) |
+| Undocumented Utilities     | Scripts without comprehensive SKILL.md documentation                                                           |
+| Untested Skills            | Skills that lack unit tests or fail to achieve 80% code coverage                                               |
 
 ## File Structure Requirements
 
@@ -88,15 +90,19 @@ The `scripts/` directory is **optional**. When present, it **MUST** contain at l
 
 **`name`** (string, MANDATORY)
 
-* **Purpose**: Unique identifier for the skill
-* **Format**: Lowercase kebab-case matching the directory name
-* **Example**: `video-to-gif`
+| Property | Value                                            |
+|----------|--------------------------------------------------|
+| Purpose  | Unique identifier for the skill                  |
+| Format   | Lowercase kebab-case matching the directory name |
+| Example  | `video-to-gif`                                   |
 
 **`description`** (string, MANDATORY)
 
-* **Purpose**: Concise explanation of skill functionality
-* **Format**: Single sentence ending with attribution
-* **Example**: `'Video-to-GIF conversion skill with FFmpeg two-pass optimization - Brought to you by microsoft/hve-core'`
+| Property | Value                                                                                                      |
+|----------|------------------------------------------------------------------------------------------------------------|
+| Purpose  | Concise explanation of skill functionality                                                                 |
+| Format   | Single sentence ending with attribution                                                                    |
+| Example  | `'Video-to-GIF conversion skill with FFmpeg two-pass optimization - Brought to you by microsoft/hve-core'` |
 
 ### Frontmatter Example
 
@@ -111,26 +117,32 @@ description: 'Video-to-GIF conversion skill with FFmpeg two-pass optimization - 
 
 **`user-invocable`** (boolean, optional)
 
-* **Purpose**: Controls visibility in the VS Code slash command menu
-* **Default**: `true`
-* **When true**: Skill appears in the `/` menu for manual invocation via `/skill-name`
-* **When false**: Skill does not appear in the `/` menu; loaded only by semantic matching or explicit `#file:` reference
-* **Use case**: Set `false` for background skills that support other workflows without direct user invocation
+| Property   | Value                                                                                                  |
+|------------|--------------------------------------------------------------------------------------------------------|
+| Purpose    | Controls visibility in the VS Code slash command menu                                                  |
+| Default    | `true`                                                                                                 |
+| When true  | Skill appears in the `/` menu for manual invocation via `/skill-name`                                  |
+| When false | Skill does not appear in the `/` menu; loaded only by semantic matching or explicit `#file:` reference |
+| Use case   | Set `false` for background skills that support other workflows without direct user invocation          |
 
 **`disable-model-invocation`** (boolean, optional)
 
-* **Purpose**: Controls whether Copilot automatically loads the skill via semantic matching
-* **Default**: `false`
-* **When false**: Copilot loads the skill automatically when the task description semantically matches the `description` field
-* **When true**: Skill is only loaded via manual `/skill-name` slash command invocation
-* **Use case**: Set `true` for skills with high token cost or niche applicability that should not load automatically
+| Property   | Value                                                                                                        |
+|------------|--------------------------------------------------------------------------------------------------------------|
+| Purpose    | Controls whether Copilot automatically loads the skill via semantic matching                                 |
+| Default    | `false`                                                                                                      |
+| When false | Copilot loads the skill automatically when the task description semantically matches the `description` field |
+| When true  | Skill is only loaded via manual `/skill-name` slash command invocation                                       |
+| Use case   | Set `true` for skills with high token cost or niche applicability that should not load automatically         |
 
 **`argument-hint`** (string, optional)
 
-* **Purpose**: Displays expected inputs in the VS Code prompt picker
-* **Format**: Brief text with required arguments first, then optional arguments
-* **Conventions**: Use `[]` for positional arguments, `key=value` for named parameters, `{option1|option2}` for enumerations, `...` for free-form text
-* **Example**: `"input=video.mp4 [--fps={5|10|15|24}] [--width=1280]"`
+| Property    | Value                                                                                                                                |
+|-------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Purpose     | Displays expected inputs in the VS Code prompt picker                                                                                |
+| Format      | Brief text with required arguments first, then optional arguments                                                                    |
+| Conventions | Use `[]` for positional arguments, `key=value` for named parameters, `{option1\|option2}` for enumerations, `...` for free-form text |
+| Example     | `"input=video.mp4 [--fps={5\|10\|15\|24}] [--width=1280]"`                                                                           |
 
 ### Invocation Control Matrix
 
@@ -304,7 +316,7 @@ Scripts are **optional** for skills. A skill can function purely as a documentat
 
 ### Bash Scripts
 
-Bash scripts **MUST**:
+Bash scripts MUST:
 
 * Use `#!/usr/bin/env bash` shebang
 * Enable strict mode: `set -euo pipefail`
@@ -317,7 +329,7 @@ See [bash.instructions.md](https://github.com/microsoft/hve-core/blob/main/.gith
 
 ### PowerShell Scripts
 
-PowerShell scripts **MUST**:
+PowerShell scripts MUST:
 
 * Use `[CmdletBinding()]` attribute
 * Include comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`)
@@ -428,9 +440,9 @@ Copilot reads the `name` and `description` fields from all SKILL.md files at sta
 
 When a user request or caller description semantically matches a skill's `description`:
 
-1. **Level 1 (Discovery)**: Copilot matches the task against `name` and `description` frontmatter (always loaded, ~100 tokens per skill).
-2. **Level 2 (Instructions)**: The full SKILL.md body loads into context with script usage, parameters, and troubleshooting (under 5000 tokens recommended).
-3. **Level 3 (Resources)**: Scripts, examples, and references in the skill directory load on-demand during execution.
+1. Level 1 (Discovery): Copilot matches the task against `name` and `description` frontmatter (always loaded, ~100 tokens per skill).
+2. Level 2 (Instructions): The full SKILL.md body loads into context with script usage, parameters, and troubleshooting (under 5000 tokens recommended).
+3. Level 3 (Resources): Scripts, examples, and references in the skill directory load on-demand during execution.
 
 ### Writing Effective Descriptions
 

--- a/docs/customization/README.md
+++ b/docs/customization/README.md
@@ -34,13 +34,15 @@ graph LR
     style G fill:#388e3c
 ```
 
-* **VS Code Settings** suit individual preferences like font size, theme, and editor behavior. No files to create or share.
-* **Instructions** configure Copilot behavior through `.github/copilot-instructions.md` and `.instructions.md` files. Lowest effort with the highest return for shaping AI output.
-* **Agents and Prompts** define specialized workflows: agents for multi-turn interactions, prompts for single-shot tasks. Both accept tool restrictions and delegation rules.
-* **Skills** package domain knowledge into self-contained bundles with optional scripts. Use when instruction files alone cannot capture the depth of a domain.
-* **Collections** bundle agents, prompts, instructions, and skills into distributable packages for team or organization adoption.
-* **Build System** customization lets you add validation scripts, schema checks, and plugin generation pipelines.
-* **Fork and Extend** gives full control over every artifact. Fork the repository when your changes diverge significantly from upstream.
+| Approach           | Description                                                                                                                                                 |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| VS Code Settings   | Individual preferences like font size, theme, and editor behavior. No files to create or share.                                                             |
+| Instructions       | Configure Copilot behavior through `.github/copilot-instructions.md` and `.instructions.md` files. Lowest effort with highest return for shaping AI output. |
+| Agents and Prompts | Specialized workflows: agents for multi-turn interactions, prompts for single-shot tasks. Both accept tool restrictions and delegation rules.               |
+| Skills             | Domain knowledge in self-contained bundles with optional scripts. Use when instruction files alone cannot capture the depth of a domain.                    |
+| Collections        | Bundle agents, prompts, instructions, and skills into distributable packages for team or organization adoption.                                             |
+| Build System       | Validation scripts, schema checks, and plugin generation pipelines.                                                                                         |
+| Fork and Extend    | Full control over every artifact. Fork the repository when your changes diverge significantly from upstream.                                                |
 
 ## Choose Your Approach
 

--- a/docs/customization/agents.md
+++ b/docs/customization/agents.md
@@ -16,10 +16,10 @@ estimated_reading_time: 7
 
 Agents are specialized Copilot configurations that define behavior, available tools, and domain-specific instructions for complex workflows. In the artifact hierarchy, agents sit between prompts (single-shot tasks) and skills (knowledge packages):
 
-* **Prompts** invoke agents for one-shot execution
-* **Agents** orchestrate multi-turn conversations or autonomous task execution
-* **Instructions** provide scoped guidance that agents inherit automatically
-* **Skills** supply domain knowledge that agents reference on demand
+* Prompts invoke agents for one-shot execution
+* Agents orchestrate multi-turn conversations or autonomous task execution
+* Instructions provide scoped guidance that agents inherit automatically
+* Skills supply domain knowledge that agents reference on demand
 
 An agent file (`.agent.md`) contains YAML frontmatter and a Markdown body. The frontmatter declares metadata, optional tool restrictions, subagent dependencies, and handoff configurations. The body defines the agent's protocol: its purpose, steps or phases, and response format.
 
@@ -145,7 +145,7 @@ tools:
 ---
 ```
 
-**When to use subagents vs. inline logic:**
+### When to use subagents vs. inline logic
 
 * Use subagents when the subtask has its own distinct tool requirements or produces a structured output that the parent consumes.
 * Keep logic inline when the task is a simple step within the parent's protocol and does not benefit from isolation.
@@ -164,8 +164,8 @@ tools:
 
 Tool restrictions serve two purposes:
 
-* **Security**: Prevent agents from modifying files, running terminal commands, or accessing external services when their role is read-only.
-* **Focus**: Reduce noise from irrelevant tool suggestions. A documentation agent does not need terminal access.
+* Agents with read-only roles cannot modify files, run terminal commands, or access external services
+* Restricting irrelevant tools reduces noise. A documentation agent does not need terminal access.
 
 > [!IMPORTANT]
 > Agents that modify files or run commands require explicit tool grants. Read-only agents should omit tools like `run_in_terminal`, `replace_string_in_file`, and `create_file` to enforce safe operation.

--- a/docs/customization/collections.md
+++ b/docs/customization/collections.md
@@ -97,9 +97,9 @@ Collections support four maturity tiers that control inclusion in generated plug
 
 Maturity applies at two levels:
 
-* **Collection-level**: Set the `maturity` field on the manifest root. A collection marked
+* Collection-level: Set the `maturity` field on the manifest root. A collection marked
   `experimental` excludes all its items from the stable release channel.
-* **Item-level**: Set the `maturity` field on individual items within the `items` array.
+* Item-level: Set the `maturity` field on individual items within the `items` array.
   This overrides the collection-level default for specific artifacts.
 
 When `maturity` is omitted at either level, it defaults to `stable`.

--- a/docs/customization/forking.md
+++ b/docs/customization/forking.md
@@ -18,7 +18,7 @@ Forking creates an independent copy of HVE Core that you fully control. Consider
 when in-place customization (adding instructions, creating collections, extending
 validation) is insufficient for your needs.
 
-**Fork when you need to:**
+### Fork when you need to
 
 * Replace core workflow agents with organization-specific versions
 * Modify the plugin generation pipeline or build system
@@ -26,7 +26,7 @@ validation) is insufficient for your needs.
 * Maintain a private distribution channel with proprietary artifacts
 * Integrate with internal systems that require changes to core scripts
 
-**Stay with in-place customization when you:**
+### Stay with in-place customization when you
 
 * Add new agents, prompts, or instructions without modifying existing ones
 * Create organization-specific collections alongside existing collections

--- a/docs/customization/skills.md
+++ b/docs/customization/skills.md
@@ -18,10 +18,10 @@ Skills are self-contained knowledge packages that Copilot loads on demand. Unlik
 
 Use a skill when the knowledge you want to share is:
 
-* **Domain-specific**: Relevant to a narrow topic rather than all files
-* **Reference-heavy**: Includes data schemas, API specs, or compliance checklists
-* **Reusable across agents**: Multiple agents or prompts can reference the same skill
-* **Large**: Exceeds the practical size of an instruction file
+* Domain-specific: Relevant to a narrow topic rather than all files
+* Reference-heavy: Includes data schemas, API specs, or compliance checklists
+* Reusable across agents: Multiple agents or prompts can reference the same skill
+* Large: Exceeds the practical size of an instruction file
 
 Instructions work better for coding conventions and file-level rules that should apply passively to every edit. Skills work better for structured knowledge that Copilot should pull in selectively.
 

--- a/docs/customization/team-adoption.md
+++ b/docs/customization/team-adoption.md
@@ -202,63 +202,63 @@ starting points and progression for each of the nine roles.
 
 ### Engineer
 
-* **Quick win:** Create an instructions file for your team's coding standards
-* **Next step:** Build a custom agent for your most common code review patterns
-* **Advanced:** Package domain knowledge into a skill with scripts and references
+1. Create an instructions file for your team's coding standards
+2. Build a custom agent for your most common code review patterns
+3. Package domain knowledge into a skill with scripts and references
 
 ### TPM (Technical Program Manager)
 
-* **Quick win:** Use the RPI workflow to research and document project status
-* **Next step:** Create prompts for generating status reports and risk summaries
-* **Advanced:** Build an agent that tracks cross-team dependencies
+1. Use the RPI workflow to research and document project status
+2. Create prompts for generating status reports and risk summaries
+3. Build an agent that tracks cross-team dependencies
 
 ### Tech Lead
 
-* **Quick win:** Write instructions for architecture decision conventions
-* **Next step:** Create a code review agent that enforces team standards
-* **Advanced:** Establish a collection that bundles your team's full workflow
+1. Write instructions for architecture decision conventions
+2. Create a code review agent that enforces team standards
+3. Establish a collection that bundles your team's full workflow
 
 ### Security Architect
 
-* **Quick win:** Add security-focused instructions for threat modeling
-* **Next step:** Create a security review agent that checks for common
+1. Add security-focused instructions for threat modeling
+2. Create a security review agent that checks for common
   vulnerabilities
-* **Advanced:** Build a skill that integrates with security scanning tools
+3. Build a skill that integrates with security scanning tools
 
 ### Data Scientist
 
-* **Quick win:** Create instructions for notebook conventions and data handling
-* **Next step:** Build prompts for exploratory data analysis patterns
-* **Advanced:** Package statistical methodology into a skill with reference
+1. Create instructions for notebook conventions and data handling
+2. Build prompts for exploratory data analysis patterns
+3. Package statistical methodology into a skill with reference
   datasets
 
 ### SRE/Operations
 
-* **Quick win:** Write instructions for runbook format and incident response
-* **Next step:** Create an agent for infrastructure review workflows
-* **Advanced:** Build a collection integrating monitoring, alerting, and
+1. Write instructions for runbook format and incident response
+2. Create an agent for infrastructure review workflows
+3. Build a collection integrating monitoring, alerting, and
   deployment tools
 
 ### Business PM (Product Manager)
 
-* **Quick win:** Use prompts to generate user story drafts from requirements
-* **Next step:** Create an agent for requirements analysis
-* **Advanced:** Build a Design Thinking workflow with custom agents
+1. Use prompts to generate user story drafts from requirements
+2. Create an agent for requirements analysis
+3. Build a Design Thinking workflow with custom agents
 
 ### New Contributor
 
-* **Quick win:** Follow the [Getting Started](../getting-started/README.md)
+1. Follow the [Getting Started](../getting-started/README.md)
   guide and complete your first interaction
-* **Next step:** Create your first instructions file with the onboarding
+2. Create your first instructions file with the onboarding
   walkthrough above
-* **Advanced:** Propose a new agent or skill for a workflow gap you've
+3. Propose a new agent or skill for a workflow gap you've
   identified
 
 ### Utility
 
-* **Quick win:** Use existing prompts and agents without modification
-* **Next step:** Customize instructions for your specific workflow context
-* **Advanced:** Contribute improvements to shared collections based on
+1. Use existing prompts and agents without modification
+2. Customize instructions for your specific workflow context
+3. Contribute improvements to shared collections based on
   usage patterns
 
 ## Measuring Success

--- a/docs/design-thinking/README.md
+++ b/docs/design-thinking/README.md
@@ -33,15 +33,15 @@ Most projects fail not because the code is wrong, but because the team solved th
 
 ```mermaid
 flowchart LR
-    subgraph problem["Problem Space — rough / exploratory"]
+    subgraph problem["Problem Space (rough / exploratory)"]
         M1["1 · Scope<br/>Conversations"] --> M2["2 · Design<br/>Research"] --> M3["3 · Input<br/>Synthesis"]
     end
 
-    subgraph solution["Solution Space — scrappy / concept-grade"]
+    subgraph solution["Solution Space (scrappy / concept-grade)"]
         M4["4 · Brain-<br/>storming"] --> M5["5 · User<br/>Concepts"] --> M6["6 · Lo-Fi<br/>Prototypes"]
     end
 
-    subgraph validation["Validation Space — functionally rigorous"]
+    subgraph validation["Validation Space (functionally rigorous)"]
         M7["7 · Hi-Fi<br/>Prototypes"] --> M8["8 · User<br/>Testing"] --> M9["9 · Iteration<br/>at Scale"]
     end
 

--- a/docs/design-thinking/dt-coach.md
+++ b/docs/design-thinking/dt-coach.md
@@ -46,8 +46,8 @@ DT Coach creates session artifacts at:
 
 This directory contains:
 
-* `coaching-state.md` — Session state with method progress, transition log, and recovery points
-* `method-{NN}-*/` — Per-method working artifacts (notes, themes, prototypes)
+* `coaching-state.md`: Session state with method progress, transition log, and recovery points
+* `method-{NN}-*/`: Per-method working artifacts (notes, themes, prototypes)
 * Handoff artifacts when transitioning to RPI agents
 
 ## How to Use DT Coach
@@ -121,9 +121,9 @@ Session state persists in `.copilot-tracking/dt/{project-slug}/coaching-state.md
 
 ## Next Steps
 
-* [Design Thinking Guide](README.md) — Overview of all nine methods and three spaces
-* [DT to RPI Integration](dt-rpi-integration.md) — How DT outputs feed into the RPI workflow
-* [DT Learning Tutor](dt-learning-tutor.md) — Curriculum-based training across all methods
+* [Design Thinking Guide](README.md): Overview of all nine methods and three spaces
+* [DT to RPI Integration](dt-rpi-integration.md): How DT outputs feed into the RPI workflow
+* [DT Learning Tutor](dt-learning-tutor.md): Curriculum-based training across all methods
 
 > Brought to you by microsoft/hve-core
 

--- a/docs/design-thinking/dt-learning-tutor.md
+++ b/docs/design-thinking/dt-learning-tutor.md
@@ -65,8 +65,8 @@ The tutor begins by assessing your experience level and learning goals. Answer i
 
 You have two options:
 
-* **Full curriculum**: Work through all nine modules sequentially from Method 1 to Method 9
-* **Targeted modules**: Jump to specific methods you want to learn or review
+* Full curriculum: Work through all nine modules sequentially from Method 1 to Method 9
+* Targeted modules: Jump to specific methods you want to learn or review
 
 ### Step 4: Learn and Practice
 

--- a/docs/design-thinking/tutorial-handoff-to-rpi.md
+++ b/docs/design-thinking/tutorial-handoff-to-rpi.md
@@ -225,21 +225,21 @@ The Implementation Space provides the richest artifacts of any exit point, givin
 
 Open the generated handoff artifact and verify the contents match your exit tier:
 
-**All tiers (Method 7+):**
+#### All tiers (Method 7+)
 
 * Architecture decisions and technical trade-offs with comparison results
 * Fidelity mapping matrix and performance benchmarks
 * Integration validation results with confidence markers
 * Specification drafts connected to prototype evidence
 
-**Tier 2+ (Methods 7-8):**
+#### Tier 2+ (Methods 7-8)
 
 * Test protocols and participant profiles
 * Behavioral observation data (not just opinions)
 * Severity-frequency matrix findings
 * Assumption validation results showing which assumptions were confirmed, challenged, or invalidated
 
-**Tier 3 (Methods 7-9):**
+#### Tier 3 (Methods 7-9)
 
 * Refinement log with baseline measurements
 * Scaling assessment across technical, user, process, and constraint dimensions

--- a/docs/design-thinking/using-together.md
+++ b/docs/design-thinking/using-together.md
@@ -183,7 +183,7 @@ Design Thinking produces validated understanding; RPI delivers implementation. T
 | Concept Validated          | 4-6     | Exit 1 plus tested concepts with D/F/V scores, lo-fi prototype feedback, constraint discoveries      | Moderate: concept feasibility, integration paths, risk areas       |
 | Implementation Spec Ready  | 7-9     | Exits 1-2 plus hi-fi specs, architecture decisions, benchmarks, test protocols, scaling plan         | Narrow: implementation refinement, deployment strategy, edge cases |
 
-**Exit 1 assets — Problem Space (Methods 1-3):**
+### Exit 1 Assets: Problem Space (Methods 1-3)
 
 * Stakeholder map with roles, perspectives, and influence levels
 * Scope boundaries with frozen/fluid classification
@@ -194,7 +194,9 @@ Design Thinking produces validated understanding; RPI delivers implementation. T
 * Constraint inventory (technical, environmental, workflow)
 * Assumptions log with each item tagged `validated`, `assumed`, `unknown`, or `conflicting`
 
-**Exit 2 assets — Solution Space (Methods 4-6),** cumulative with Exit 1:
+### Exit 2 Assets: Solution Space (Methods 4-6)
+
+Cumulative with Exit 1.
 
 * Brainstorming theme clusters with selected directions
 * `concepts.yml` with desirability/feasibility/viability evaluations per concept
@@ -204,7 +206,9 @@ Design Thinking produces validated understanding; RPI delivers implementation. T
 * User behavior patterns observed during prototype interactions
 * 1-2 narrowed concept directions advanced from initial ideation
 
-**Exit 3 assets — Validation Space (Methods 7-9),** cumulative with Exits 1-2:
+### Exit 3 Assets: Validation Space (Methods 7-9)
+
+Cumulative with Exits 1-2.
 
 * Architecture decisions and technical trade-offs
 * Implementation comparison results across 2-3 approaches

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -86,9 +86,9 @@ Copy the scripts you need to your project's `scripts/` directory and adjust path
 
 For projects requiring user-centered requirements discovery before implementation:
 
-* [Design Thinking Guide](../design-thinking/README.md) — Start here for DT overview
-* [Using the DT Coach](../design-thinking/dt-coach.md) — Learn to use the dt-coach agent
-* [DT to RPI Integration](../design-thinking/dt-rpi-integration.md) — Transition from DT to implementation
+* [Design Thinking Guide](../design-thinking/README.md): Start here for DT overview
+* [Using the DT Coach](../design-thinking/dt-coach.md): Learn to use the dt-coach agent
+* [DT to RPI Integration](../design-thinking/dt-rpi-integration.md): Transition from DT to implementation
 
 ## See Also
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -26,7 +26,7 @@ VS Code → Extensions → Search "HVE Core" → Install
 
 **Or visit:** [HVE Core on Marketplace](https://marketplace.visualstudio.com/items?itemName=ise-hve-essentials.hve-core)
 
-**Why choose the extension:**
+### Why choose the extension
 
 * ✅ Zero configuration required
 * ✅ Automatic updates via VS Code
@@ -34,7 +34,7 @@ VS Code → Extensions → Search "HVE Core" → Install
 * ✅ No project files needed
 * ✅ Instant availability
 
-**When to use alternatives:**
+### When to use alternatives
 
 * ❌ You need to customize components → Use custom installation methods below
 * ❌ Team needs version control → Use [Submodule](methods/submodule.md)
@@ -56,17 +56,17 @@ Open Copilot Chat, select the `hve-core-installer` agent, and use this prompt. T
 
 Answer these questions to find your recommended installation method:
 
-1. **What's your development environment?**
+1. What's your development environment?
    * Local VS Code (no devcontainer)
    * Local devcontainer (Docker Desktop)
    * GitHub Codespaces
    * Both local and Codespaces
 
-2. **Solo or team development?**
+2. Solo or team development?
    * Solo: Just you, no version control of HVE-Core needed
    * Team: Multiple people, need reproducible setup
 
-3. **Update preference?**
+3. Update preference?
    * Auto: Always get latest HVE-Core
    * Controlled: Pin to specific version, update explicitly
 
@@ -203,7 +203,7 @@ Run the installer in validation mode:
 
 HVE-Core agents create ephemeral workflow artifacts in a `.copilot-tracking/` folder within your project. These files include research documents, implementation plans, PR review tracking, and other machine-generated content that should typically not be committed to version control.
 
-**Add this line to your project's `.gitignore`:**
+### Add this line to your project's `.gitignore`
 
 ```text
 .copilot-tracking/
@@ -212,7 +212,7 @@ HVE-Core agents create ephemeral workflow artifacts in a `.copilot-tracking/` fo
 > [!IMPORTANT]
 > This applies to all installation methods (extension, submodule, peer clone, etc.). The `.copilot-tracking/` folder is created in your project directory, not in HVE-Core itself.
 
-**What gets stored there:**
+### What gets stored there
 
 * Research documents from `task-researcher`
 * Implementation plans from `task-planner`

--- a/docs/getting-started/mcp-configuration.md
+++ b/docs/getting-started/mcp-configuration.md
@@ -52,30 +52,38 @@ HVE-Core documents these four MCP servers:
 
 Library and SDK documentation lookup.
 
-* **Type**: stdio
-* **Package**: `@upstash/context7-mcp`
+| Property | Value                   |
+|----------|-------------------------|
+| Type     | stdio                   |
+| Package  | `@upstash/context7-mcp` |
 
 ### microsoft-docs
 
 Microsoft Learn documentation access.
 
-* **Type**: http
-* **URL**: `https://learn.microsoft.com/api/mcp`
+| Property | Value                                 |
+|----------|---------------------------------------|
+| Type     | http                                  |
+| URL      | `https://learn.microsoft.com/api/mcp` |
 
 ### ado (Azure DevOps)
 
 Azure DevOps work items, pipelines, and repositories.
 
-* **Type**: stdio
-* **Package**: `@azure-devops/mcp`
-* **Requires**: Organization name, optional tenant ID
+| Property | Value                                 |
+|----------|---------------------------------------|
+| Type     | stdio                                 |
+| Package  | `@azure-devops/mcp`                   |
+| Requires | Organization name, optional tenant ID |
 
 ### github
 
 GitHub repository and issue management.
 
-* **Type**: http
-* **URL**: `https://api.githubcopilot.com/mcp/`
+| Property | Value                                |
+|----------|--------------------------------------|
+| Type     | http                                 |
+| URL      | `https://api.githubcopilot.com/mcp/` |
 
 ## Complete Configuration Template
 
@@ -148,8 +156,8 @@ MCP configuration can be placed in the `.code-workspace` file under `settings` o
 
 ### Authentication Errors
 
-* **GitHub**: Uses VS Code's built-in GitHub authentication
-* **ADO**: Verify organization name and tenant ID are correct
+* GitHub: Uses VS Code's built-in GitHub authentication
+* ADO: Verify organization name and tenant ID are correct
 
 ### MCP Server Not Starting
 

--- a/docs/getting-started/methods/codespaces.md
+++ b/docs/getting-started/methods/codespaces.md
@@ -127,8 +127,8 @@ git push
 
 ### Step 3: Create or Rebuild Codespace
 
-* **New Codespace:** Create from the updated branch
-* **Existing Codespace:** Rebuild (`Ctrl+Shift+P` → "Codespaces: Rebuild Container")
+* Create a new Codespace from the updated branch
+* Rebuild an existing Codespace (`Ctrl+Shift+P` → "Codespaces: Rebuild Container")
 
 ### Step 4: Validate Installation
 
@@ -364,13 +364,13 @@ To always get the latest version on rebuild:
 
 ### Agents Not Appearing
 
-**Check HVE-Core was cloned:**
+#### Check HVE-Core was cloned
 
 ```bash
 ls /workspaces/hve-core/.github/agents
 ```
 
-**Check postCreateCommand ran:**
+#### Check postCreateCommand ran
 
 Look at the Codespace creation log for clone output or errors.
 
@@ -386,11 +386,11 @@ gh auth status
 
 ### Settings Not Applied
 
-**Check devcontainer.json paths:**
+#### Check devcontainer.json paths
 
 Settings must use absolute paths (`/workspaces/hve-core/...`).
 
-**Verify settings in VS Code:**
+#### Verify settings in VS Code
 
 1. Open Command Palette (`Ctrl+Shift+P`)
 2. Type "Preferences: Open User Settings (JSON)"

--- a/docs/getting-started/methods/extension.md
+++ b/docs/getting-started/methods/extension.md
@@ -112,9 +112,9 @@ The extension provides all HVE-Core components:
 
 The extension updates automatically through VS Code's extension system:
 
-* **Auto-updates (default):** Extensions update automatically when new versions are released
-* **Manual updates:** Extensions view → Find "HVE Core" → Click **Update**
-* **Pre-release versions:** Right-click extension → "Switch to Pre-Release Version"
+* Extensions update automatically when new versions are released (default)
+* Open Extensions view → find "HVE Core" → click **Update** for manual updates
+* Right-click the extension → "Switch to Pre-Release Version" for pre-release access
 
 ## Comparison with Other Methods
 
@@ -148,7 +148,7 @@ The extension updates automatically through VS Code's extension system:
 
 **Solution:** Install the extension from marketplace
 
-**Steps:**
+#### Steps
 
 1. Install extension from marketplace
 2. Start using `task-planner` and other agents
@@ -160,7 +160,7 @@ The extension updates automatically through VS Code's extension system:
 
 **Solution:** Install extension on all machines via Settings Sync
 
-**Steps:**
+#### Steps
 
 1. Enable Settings Sync in VS Code
 2. Install extension on one machine
@@ -172,7 +172,7 @@ The extension updates automatically through VS Code's extension system:
 
 **Solution:** Share extension link and install instructions
 
-**Steps:**
+#### Steps
 
 1. Share marketplace link with team
 2. Team members install extension
@@ -184,7 +184,7 @@ The extension updates automatically through VS Code's extension system:
 
 **Solution:** Use extension initially, migrate to Peer Clone when needed
 
-**Steps:**
+#### Steps
 
 1. Start with extension for quick setup
 2. When customization needed, uninstall extension
@@ -194,25 +194,25 @@ The extension updates automatically through VS Code's extension system:
 
 ### Extension Not Appearing
 
-**Check extension is installed:**
+#### Check extension is installed
 
 1. Open Extensions view (`Ctrl+Shift+X`)
 2. Search "HVE Core"
 3. Verify "Installed" badge appears
 
-**Reload VS Code:**
+#### Reload VS Code
 
 1. Command Palette (`Ctrl+Shift+P`)
 2. "Developer: Reload Window"
 
 ### Agents Not Showing in Copilot Chat
 
-**Verify GitHub Copilot is active:**
+#### Verify GitHub Copilot is active
 
 1. Check Copilot icon in status bar
 2. Sign in if needed
 
-**Check extension status:**
+#### Check extension status
 
 1. Extensions view → "HVE Core"
 2. Verify no errors shown
@@ -231,12 +231,12 @@ If you have both extension and manual installation (like Peer Clone):
 
 ### Update Not Appearing
 
-**Force check for updates:**
+#### Force check for updates
 
 1. Extensions view → ⋯ (More Actions)
 2. "Check for Extension Updates"
 
-**Manually update:**
+#### Manually update
 
 1. Extensions view → Find "HVE Core"
 2. Click "Update" button

--- a/docs/getting-started/methods/git-ignored.md
+++ b/docs/getting-started/methods/git-ignored.md
@@ -72,7 +72,7 @@ Add the HVE-Core folder to your `.gitignore`:
 
 ### Step 2: Clone HVE-Core
 
-**PowerShell:**
+#### PowerShell
 
 ```powershell
 # Create folder and clone
@@ -83,7 +83,7 @@ if (-not (Test-Path $hveCoreFolder)) {
 }
 ```
 
-**Bash:**
+#### Bash
 
 ```bash
 HVE_CORE_FOLDER=".hve-core"
@@ -202,18 +202,18 @@ Add to `.devcontainer/devcontainer.json` so HVE-Core is cloned on container crea
 
 ## Updating HVE-Core
 
-**Manual update:**
+### Manual update
 
 ```bash
 cd .hve-core
 git pull
 ```
 
-**Auto-update on container rebuild:**
+### Auto-update on container rebuild
 
 The `postCreateCommand` re-clones on each container creation. To update, rebuild the container.
 
-**Auto-update with version check:**
+### Auto-update with version check
 
 ```jsonc
 {
@@ -227,13 +227,13 @@ The `postCreateCommand` re-clones on each container creation. To update, rebuild
 
 ### Agents Not Appearing
 
-**Check the folder exists:**
+#### Check the folder exists
 
 ```bash
 ls .hve-core/.github/agents
 ```
 
-**Check settings are applied:**
+#### Check settings are applied
 
 1. Open Command Palette (`Ctrl+Shift+P`)
 2. Type "Preferences: Open Workspace Settings (JSON)"

--- a/docs/getting-started/methods/mounted.md
+++ b/docs/getting-started/methods/mounted.md
@@ -126,7 +126,7 @@ Update `.devcontainer/devcontainer.json`:
 }
 ```
 
-**Alternative object format:**
+#### Alternative object format
 
 ```jsonc
 {
@@ -148,7 +148,7 @@ Update `.devcontainer/devcontainer.json`:
 2. Type "Dev Containers: Rebuild Container"
 3. Press Enter and wait for rebuild (1-3 minutes)
 
-**What happens during rebuild:**
+#### What happens during rebuild
 
 * Current container stops
 * New container builds with mount configuration
@@ -243,7 +243,7 @@ After rebuild, update `.vscode/settings.json`:
 2. Click the agent picker dropdown
 3. Verify HVE-Core agents appear (task-planner, task-researcher, prompt-builder)
 
-**Verify mount from container terminal:**
+#### Verify mount from container terminal
 
 ```bash
 ls /workspaces/hve-core/.github/agents
@@ -301,7 +301,7 @@ ls /workspaces/hve-core/.github/agents
 
 ## Updating HVE-Core
 
-Update on your **host machine**:
+Update on your host machine:
 
 ```bash
 cd /path/to/projects/hve-core
@@ -316,14 +316,14 @@ Changes are immediately available in all containers using the mount. No rebuild 
 
 **Cause:** HVE-Core wasn't cloned on the host, or was cloned in the wrong location.
 
-**Fix:**
+#### Fix
 
 1. Exit the container
 2. Clone HVE-Core on your host machine (see Phase 1)
 3. Verify the path matches the mount source
 4. Rebuild the container
 
-**Check from host terminal:**
+#### Check from host terminal
 
 ```bash
 # On host, not in container
@@ -334,7 +334,7 @@ ls /path/to/projects/hve-core/.github
 
 **Cause:** Mount source path doesn't exist.
 
-**Fix:**
+#### Fix
 
 1. Check `devcontainer.json` mount path
 2. Ensure HVE-Core exists at `${localWorkspaceFolder}/../hve-core`
@@ -343,14 +343,14 @@ ls /path/to/projects/hve-core/.github
 
 ### Agents Not Appearing
 
-**Check mount is working:**
+#### Check mount is working
 
 ```bash
 # Inside container
 ls /workspaces/hve-core/.github/agents
 ```
 
-**Check settings paths match:**
+#### Check settings paths match
 
 Settings must use absolute container paths (`/workspaces/hve-core/...`), not relative paths.
 

--- a/docs/getting-started/methods/multi-root.md
+++ b/docs/getting-started/methods/multi-root.md
@@ -71,7 +71,7 @@ Use the `hve-core-installer` agent:
 
 If your organization has not already forked HVE-Core, create a fork of `microsoft/hve-core` under your org's GitHub account. Then clone your fork.
 
-**Local VS Code:**
+#### Local VS Code
 
 ```bash
 # Clone your org's fork next to your project

--- a/docs/getting-started/methods/peer-clone.md
+++ b/docs/getting-started/methods/peer-clone.md
@@ -148,7 +148,7 @@ No VS Code restart required. Changes take effect immediately.
 
 ### Agents Not Appearing
 
-**Check the relative path:**
+#### Check the relative path
 
 ```bash
 # From your project directory
@@ -161,7 +161,7 @@ If the path doesn't resolve, verify:
 2. Your terminal is in your project directory
 3. The relative path in settings.json is correct
 
-**Check VS Code settings:**
+#### Check VS Code settings
 
 1. Open Command Palette (`Ctrl+Shift+P`)
 2. Type "Preferences: Open User Settings (JSON)"
@@ -179,7 +179,7 @@ Relative paths break if your project moves. Options:
 
 Peer directory clone doesn't work in devcontainers because the container can't access files outside the mounted workspace.
 
-**Solutions:**
+#### Solutions
 
 * Use [Git-Ignored Folder](git-ignored.md) for self-contained installation
 * Use [Mounted Directory](mounted.md) to share HVE-Core across projects

--- a/docs/getting-started/methods/submodule.md
+++ b/docs/getting-started/methods/submodule.md
@@ -144,13 +144,13 @@ Update `.devcontainer/devcontainer.json` to initialize submodules automatically:
 
 When team members clone your project, they need to initialize submodules.
 
-**Option A: Clone with submodules (recommended):**
+### Option A: Clone with submodules (recommended)
 
 ```bash
 git clone --recurse-submodules https://github.com/your-org/your-project.git
 ```
 
-**Option B: Initialize after clone:**
+### Option B: Initialize after clone
 
 ```bash
 git clone https://github.com/your-org/your-project.git
@@ -158,7 +158,7 @@ cd your-project
 git submodule update --init --recursive
 ```
 
-**Option C: Configure git to auto-recurse:**
+### Option C: Configure git to auto-recurse
 
 ```bash
 git config --global submodule.recurse true
@@ -174,7 +174,7 @@ git config --global submodule.recurse true
 | Pin to specific commit | `cd lib/hve-core && git checkout <sha>`                               |
 | Track different branch | `git config submodule.lib/hve-core.branch develop`                    |
 
-**After updating, commit the change:**
+### After updating, commit the change
 
 ```bash
 git add lib/hve-core
@@ -195,14 +195,14 @@ To update HVE-Core when rebuilding your devcontainer:
 
 Submodules pin to a specific commit by default. To verify or change the pinned version:
 
-**Check current version:**
+### Check current version
 
 ```bash
 cd lib/hve-core
 git log -1 --oneline
 ```
 
-**Pin to a specific tag or commit:**
+### Pin to a specific tag or commit
 
 ```bash
 cd lib/hve-core
@@ -233,9 +233,9 @@ git submodule update --init --recursive
 
 ### Agents not appearing
 
-* **Check settings paths:** Verify `.vscode/settings.json` paths match submodule location
-* **Reload window:** `Ctrl+Shift+P` → "Developer: Reload Window"
-* **Verify submodule content:** `ls lib/hve-core/.github/agents/`
+* Verify `.vscode/settings.json` paths match submodule location
+* Reload the window with `Ctrl+Shift+P` → "Developer: Reload Window"
+* Confirm submodule content exists with `ls lib/hve-core/.github/agents/`
 
 ### "Detached HEAD" warning in submodule
 

--- a/docs/hve-guide/README.md
+++ b/docs/hve-guide/README.md
@@ -54,7 +54,7 @@ flowchart LR
 | Stage 8 | Delivery           | pull-request, git-commit, git-merge, ado-get-build-info                                                     |
 | Stage 9 | Operations         | doc-ops, doc-ops-update, incident-response                                                                  |
 
-> **Cross-cutting**: memory is available at every stage and is not tied to any single phase.
+> Cross-cutting: memory is available at every stage and is not tied to any single phase.
 
 **[AI-Assisted Project Lifecycle Overview →](lifecycle/)**
 

--- a/docs/hve-guide/roles/README.md
+++ b/docs/hve-guide/roles/README.md
@@ -68,11 +68,11 @@ Each role intersects with 9 lifecycle stages, producing 81 role-stage pairs. Cov
 | Thin     |               18 |     22% |
 | None     |               32 |     40% |
 
-**Strongest coverage**: Engineer at Stages 6-7 (implementation and review), TPM at Stages 2-5 (requirements through sprint planning), SRE at Stage 9 (operations), UX Designer at Stages 2-3 (discovery and design via Design Thinking).
+Strongest coverage: Engineer at Stages 6-7 (implementation and review), TPM at Stages 2-5 (requirements through sprint planning), SRE at Stage 9 (operations), UX Designer at Stages 2-3 (discovery and design via Design Thinking).
 
-**Thinnest roles**: Security Architect (3 dedicated assets, 6 of 9 stages at None or Thin) and Business Program Manager (beta, all tooling borrowed from shared collections).
+Thinnest roles: Security Architect (3 dedicated assets, 6 of 9 stages at None or Thin) and Business Program Manager (beta, all tooling borrowed from shared collections).
 
-**Least-covered stage**: Stage 4 Decomposition: 8 of 9 roles have no dedicated tooling. Only TPM has strong coverage at this stage.
+Least-covered stage: Stage 4 Decomposition: 8 of 9 roles have no dedicated tooling. Only TPM has strong coverage at this stage.
 
 > [!NOTE]
 > Gaps represent contribution opportunities. See the [lifecycle stage guides](../lifecycle/) for per-stage details and [Contributing](../../contributing/) for guidance on creating new agents, prompts, and instructions.

--- a/docs/rpi/context-engineering.md
+++ b/docs/rpi/context-engineering.md
@@ -1,5 +1,5 @@
 ---
-title: Context Engineering — Why AI Context Management Matters
+title: "Context Engineering: Why AI Context Management Matters"
 description: Understanding LLM recency bias, context windows, and why /clear is an engineering practice, not just a step
 sidebar_position: 3
 author: Microsoft

--- a/docs/rpi/why-rpi.md
+++ b/docs/rpi/why-rpi.md
@@ -139,12 +139,12 @@ HVE Core provides two workflow options. The right choice depends on the task, no
 
 Use the four-phase workflow ([Task Researcher](task-researcher.md) → [Task Planner](task-planner.md) → [Task Implementor](task-implementor.md) → [Task Reviewer](task-reviewer.md)) when:
 
-* 🔍 **Deep research needed**: new frameworks, external APIs, compliance requirements
-* 📁 **Multi-file changes**: pattern discovery across the codebase
-* 👥 **Team handoff**: artifacts document decisions for others
-* 🛠️ **Long-term maintenance**: work you'll maintain and evolve over time
+* 🔍 New frameworks, external APIs, or compliance requirements demand deep research
+* 📁 Pattern discovery across the codebase requires multi-file changes
+* 👥 Artifacts that document decisions support team handoff
+* 🛠️ Work you'll maintain and evolve over time benefits from long-term maintenance records
 
-**The workflow:**
+#### The workflow
 
 1. Invoke Task Researcher → produces research document with citations
 2. Clear context, invoke Task Planner → produces implementation plan
@@ -155,9 +155,9 @@ Use the four-phase workflow ([Task Researcher](task-researcher.md) → [Task Pla
 
 Use the [autonomous agent](https://github.com/microsoft/hve-core/blob/main/.github/agents/hve-core/rpi-agent.agent.md) when:
 
-* ✅ **Clear scope**: straightforward feature or bug fix
-* ✅ **Minimal research**: codebase-only investigation
-* ✅ **Quick iteration**: active development with fast feedback loops
+* ✅ Straightforward feature or bug fix with clear scope
+* ✅ Codebase-only investigation requiring minimal research
+* ✅ Active development with fast feedback loops for quick iteration
 
 **The workflow:** Single rpi-agent session that orchestrates all four phases using subagent dispatch. The agent uses `runSubagent` to delegate work to specialized task agents while maintaining overall control.
 

--- a/docs/security/sbom-verification.md
+++ b/docs/security/sbom-verification.md
@@ -107,9 +107,11 @@ The SBOM follows the SPDX 2.3 specification. These fields are most relevant for 
 
 You can feed the SPDX JSON file into security and compliance tooling:
 
-* **Vulnerability scanning**: Import into tools like Grype, Trivy, or Dependabot to check for known CVEs in bundled components.
-* **License compliance**: Parse `licenseConcluded` and `licenseDeclared` fields to validate that all included licenses meet your organization's policy.
-* **Inventory tracking**: Use the package list to maintain an accurate record of third-party components in your environment.
+| Use Case               | Description                                                                                                                   |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Vulnerability scanning | Import into tools like Grype, Trivy, or Dependabot to check for known CVEs in bundled components.                             |
+| License compliance     | Parse `licenseConcluded` and `licenseDeclared` fields to validate that all included licenses meet your organization's policy. |
+| Inventory tracking     | Use the package list to maintain an accurate record of third-party components in your environment.                            |
 
 ## Related Resources
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -746,9 +746,9 @@ The `sbom-diff` job in `main.yml` runs during each release to surface supply cha
 
 The diff script parses SPDX JSON packages, excludes root document entries, and categorizes changes into three groups:
 
-* **Added** packages not present in the previous release
-* **Removed** packages no longer included in the current build
-* **Version changes** where the same package appears in both releases at different versions
+* Added packages not present in the previous release
+* Removed packages no longer included in the current build
+* Version changes where the same package appears in both releases at different versions
 
 When no previous release exists or the prior release lacks a dependency SBOM, the job exits cleanly without producing a diff. This graceful degradation ensures the first release in a repository proceeds without error.
 
@@ -785,7 +785,7 @@ This section presents the security assurance case using Goal Structuring Notatio
 
 ### Top-Level Goal
 
-**G0**: HVE Core is acceptably secure for its intended use as an enterprise prompt engineering framework.
+G0: HVE Core is acceptably secure for its intended use as an enterprise prompt engineering framework.
 
 ### Supporting Goals
 
@@ -818,10 +818,10 @@ This section presents the security assurance case using Goal Structuring Notatio
 
 HVE Core achieves acceptable security through:
 
-1. **Automated Controls**: 20+ security controls execute automatically via CI/CD
-2. **Defense-in-Depth**: Multiple overlapping controls for critical threats
-3. **Transparent Risk Acceptance**: AI-inherent risks documented with clear boundaries
-4. **Inherited Security**: Uses GitHub and Copilot platform security
+1. Automated Controls: 20+ security controls execute automatically via CI/CD
+2. Defense-in-Depth: Multiple overlapping controls for critical threats
+3. Transparent Risk Acceptance: AI-inherent risks documented with clear boundaries
+4. Inherited Security: Uses GitHub and Copilot platform security
 
 ## MCP Server Trust Analysis
 
@@ -889,8 +889,8 @@ HVE Core documents integrations with Model Context Protocol servers. This sectio
 
 ### Trust Recommendations
 
-1. **First-party servers (GitHub, Azure DevOps, Microsoft Docs)**: Enable with organization policy controls; GitHub MCP is enabled by default
-2. **Third-party servers (Context7)**: Evaluate data flow, use API key rotation, review Upstash trust center
+1. First-party servers (GitHub, Azure DevOps, Microsoft Docs): Enable with organization policy controls; GitHub MCP is enabled by default
+2. Third-party servers (Context7): Evaluate data flow, use API key rotation, review Upstash trust center
 
 ## Quantitative Security Metrics
 

--- a/docs/templates/adr-template-solutions.md
+++ b/docs/templates/adr-template-solutions.md
@@ -195,21 +195,21 @@ After completing the YAML drafting guide above, use this structure for your fina
 
 ### Context
 
-**Scenario Context**: [Describe the business scenario or use case]
+Scenario Context: [Describe the business scenario or use case]
 
-**Problem Statement**: [Clearly articulate the problem being solved]
+Problem Statement: [Clearly articulate the problem being solved]
 
-**Constraints and Requirements**: [Document technical, business, and organizational boundaries]
+Constraints and Requirements: [Document technical, business, and organizational boundaries]
 
-**Success Criteria**: [Define measurable outcomes for success]
+Success Criteria: [Define measurable outcomes for success]
 
 ### Decision
 
-**Decision Statement**: [Clear, single sentence stating what was decided]
+Decision Statement: [Clear, single sentence stating what was decided]
 
-**Decision Rationale**: [Explain the reasoning behind this decision]
+Decision Rationale: [Explain the reasoning behind this decision]
 
-**Implementation Approach**: [Outline how this decision will be implemented]
+Implementation Approach: [Outline how this decision will be implemented]
 
 ### Decision Drivers (optional)
 
@@ -221,23 +221,23 @@ List the key factors that influenced this decision:
 
 ### Considered Options (optional)
 
-**Option Evaluation Framework**: [For each option considered, provide:]
+Option Evaluation Framework: [For each option considered, provide:]
 
 #### Option [Number]: [Option Name]
 
-**Description**: [What this option entails]
+Description: [What this option entails]
 
-**Technical Details**: [Architecture, components, requirements]
+Technical Details: [Architecture, components, requirements]
 
-**Pros**: [Specific advantages with supporting detail]
+Pros: [Specific advantages with supporting detail]
 
-**Cons**: [Specific disadvantages with impact assessment]
+Cons: [Specific disadvantages with impact assessment]
 
-**Risks and Mitigation**: [Risks with probability, impact, and mitigation strategies]
+Risks and Mitigation: [Risks with probability, impact, and mitigation strategies]
 
-**Dependencies**: [External dependencies and prerequisites]
+Dependencies: [External dependencies and prerequisites]
 
-**Cost Analysis**: [Implementation and operational costs]
+Cost Analysis: [Implementation and operational costs]
 
 ### Comparison Matrix (optional)
 
@@ -248,17 +248,17 @@ List the key factors that influenced this decision:
 
 ### Consequences
 
-**Positive Consequences**: [Benefits and positive outcomes]
+Positive Consequences: [Benefits and positive outcomes]
 
-**Negative Consequences**: [Risks and negative impacts]
+Negative Consequences: [Risks and negative impacts]
 
-**Neutral Consequences**: [Other changes or considerations]
+Neutral Consequences: [Other changes or considerations]
 
 ### Future Considerations (optional)
 
-**Monitoring and Evolution**: [What to watch for and when to re-evaluate]
+Monitoring and Evolution: [What to watch for and when to re-evaluate]
 
-**Review Triggers**: [Conditions that would require re-evaluation of this decision]
+Review Triggers: [Conditions that would require re-evaluation of this decision]
 
 ---
 

--- a/docs/templates/rca-template.md
+++ b/docs/templates/rca-template.md
@@ -130,11 +130,11 @@ All times in UTC.
 
 ## Usage Guidelines
 
-1. **Start the document immediately** when an incident is declared
-2. **Update continuously** during the incident - don't rely on memory afterward
-3. **Be blameless** - focus on systems and processes, not individuals
-4. **Be thorough** - future responders will thank you
-5. **Track action items** - incidents without follow-through will repeat
+1. Start the document immediately when an incident is declared
+2. Update continuously during the incident - don't rely on memory afterward
+3. Be blameless - focus on systems and processes, not individuals
+4. Be thorough - future responders will thank you
+5. Track action items - incidents without follow-through will repeat
 
 ## References
 

--- a/docs/templates/security-plan-template.md
+++ b/docs/templates/security-plan-template.md
@@ -121,7 +121,7 @@ For each applicable threat, provide detailed analysis following this format:
 **Affected Asset:** [Specific system component]
 **Threat:** [Detailed threat description]
 
-**Recommended Mitigations:**
+#### Recommended Mitigations
 
 1. [Specific, actionable mitigation step]
 2. [Implementation details and configuration]

--- a/extension/PACKAGING.md
+++ b/extension/PACKAGING.md
@@ -28,8 +28,8 @@ extension/
 
 The extension is configured with `"extensionKind": ["workspace", "ui"]` in `package.json` to support multiple execution contexts:
 
-* **Workspace mode**: Extension runs in the workspace (remote) extension host. In this mode, the extension accesses its bundled files from the extension installation directory in the remote/workspace context (for example, the packaged `.github/` folder).
-* **UI mode**: Extension runs in the UI extension host on the user's local machine and accesses the same bundled extension files from the local installation directory.
+* In workspace mode, the extension runs in the workspace (remote) extension host and accesses its bundled files from the extension installation directory in the remote/workspace context (for example, the packaged `.github/` folder).
+* In UI mode, the extension runs in the UI extension host on the user's local machine and accesses the same bundled extension files from the local installation directory.
 
 Access to files in the user's project workspace always uses the standard VS Code workspace APIs and is independent of the extension kind. Both modes use the same packaged extension assets and differ only in execution context (local UI versus remote/workspace). This bundling approach ensures GitHub Copilot can reliably access instruction files and scripts regardless of cross-platform path resolution issues (for example, Windows/WSL environments).
 
@@ -220,7 +220,7 @@ rm -rf .github scripts && cp -r ../.github . && mkdir -p scripts && vsce package
 
 **Important:** Versions are managed by `release-please` via `extension/templates/package.template.json`. The `Prepare-Extension.ps1` script generates all collection package files with the correct version before preparing the extension.
 
-**Setup Personal Access Token (one-time):**
+### Setup Personal Access Token (one-time)
 
 Set your Azure DevOps PAT as an environment variable:
 
@@ -235,7 +235,7 @@ To get a PAT:
 3. Set scope to **Marketplace (Manage)**
 4. Copy the token
 
-**Publish command:**
+### Publish command
 
 ```bash
 # Publish the packaged extension (replace X.Y.Z with actual version)
@@ -468,19 +468,19 @@ pwsh ./scripts/extension/Package-Extension.ps1 -Version "1.0.0-test" -WhatIf
 
 ### Troubleshooting Collection Builds
 
-**Missing artifacts in collection:**
+#### Missing artifacts in collection
 
 1. Verify the artifact has an `items[]` entry in the relevant `collections/*.collection.yml` manifest
 2. Check the collection manifest includes the artifact with the correct `kind` and `path`
 3. Run `npm run lint:collections-metadata` to validate collection consistency
 
-**Dependency not included:**
+#### Dependency not included
 
 1. Check the parent artifact's `requires` field in the collection item
 2. Ensure dependent artifacts exist and have valid collection entries
 3. Dependencies are included regardless of collection filter
 
-**Validation errors:**
+#### Validation errors
 
 ```bash
 # Run full collection metadata validation

--- a/extension/templates/README.template.md
+++ b/extension/templates/README.template.md
@@ -16,7 +16,7 @@ After installing this extension, the chat agents are available in GitHub Copilot
 
 1. **Use custom agents** by selecting the custom agent from the agent picker drop-down list in Copilot Chat
 2. **Apply prompts** through the Copilot Chat interface
-3. **Reference instructions** — they are automatically applied based on file patterns
+3. Reference instructions: they are automatically applied based on file patterns
 
 ### Post-Installation Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "cspell": "9.7.0",
         "markdown-link-check": "3.14.2",
         "markdown-table-formatter": "^1.7.0",
-        "markdownlint-cli2": "^0.21.0"
+        "markdownlint-cli2": "^0.21.0",
+        "markdownlint-rule-search-replace": "1.2.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -4153,6 +4154,42 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-micromark": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.2.tgz",
+      "integrity": "sha512-jRxlQg8KpOfM2IbCL9RXM8ZiYWz2rv6DlZAnGv8ASJQpUh6byTBnEsbuMZ6T2/uIgntyf7SKg/mEaEBo1164fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/markdownlint-rule-helpers": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.21.0.tgz",
+      "integrity": "sha512-27WM6H76t79EZjEl3jSabV0ZzXsC5QaSslI/5N1XuXV0mJRA6i3BPMGFrtZUbhlCNgtY6oC9h5JhtpDMv95tKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "markdownlint-micromark": "0.1.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/markdownlint-rule-search-replace": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.2.0.tgz",
+      "integrity": "sha512-l2eeVjb0ijxO+dO1ZrODcht+qnJ0VuiAAdBx1J8oa2kAugXl3NhxAGjfNuTfEJae5OQbdSGT+NjMczyzBXvWMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "markdownlint-rule-helpers": "0.21.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/markdownlint/node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "cspell": "9.7.0",
     "markdown-link-check": "3.14.2",
     "markdown-table-formatter": "^1.7.0",
-    "markdownlint-cli2": "^0.21.0"
+    "markdownlint-cli2": "^0.21.0",
+    "markdownlint-rule-search-replace": "1.2.0"
   },
   "overrides": {
     "markdown-it": "14.1.1",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,7 +115,7 @@ npm run test:ps
 
 All scripts are designed to run both locally and in GitHub Actions workflows. They support common parameters like `-Verbose` and `-Debug` for troubleshooting.
 
-**Local Testing**:
+### Local Testing
 
 ```powershell
 # Test PSScriptAnalyzer on changed files
@@ -128,7 +128,7 @@ All scripts are designed to run both locally and in GitHub Actions workflows. Th
 ./scripts/linting/Invoke-LinkLanguageCheck.ps1 -Verbose
 ```
 
-**GitHub Actions Integration**:
+### GitHub Actions Integration
 
 All scripts automatically detect GitHub Actions environment and provide appropriate output formatting (annotations, summaries, artifacts).
 

--- a/scripts/extension/README.md
+++ b/scripts/extension/README.md
@@ -36,9 +36,9 @@ platform detection and YAML manifest parsing.
 Prepares extension contents by auto-discovering agents, prompts, instructions,
 and skills from the repository.
 
-**Purpose**: Gather and filter artifacts for inclusion in the extension package.
+Purpose: Gather and filter artifacts for inclusion in the extension package.
 
-**Features**:
+#### Features
 
 * Auto-discovers `.agent.md`, `.prompt.md`, `.instructions.md`, and `SKILL.md`
   files
@@ -46,14 +46,14 @@ and skills from the repository.
 * Supports collection-scoped preparation
 * Dry-run mode for previewing changes
 
-**Parameters**:
+#### Parameters
 
 * `-ChangelogPath` - Path to the changelog file
 * `-Channel` - Release channel: `Stable` or `PreRelease`
 * `-DryRun` (switch) - Preview changes without modifying files
 * `-Collection` - Collection name for scoped preparation
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Prepare stable channel
@@ -70,16 +70,16 @@ and skills from the repository.
 
 Packages the VS Code extension into a `.vsix` file using `vsce`.
 
-**Purpose**: Produce a distributable extension package from prepared contents.
+Purpose: Produce a distributable extension package from prepared contents.
 
-**Features**:
+#### Features
 
 * Sets version from parameters or changelog
 * Supports pre-release and dev patch builds
 * Collection-scoped packaging
 * Dry-run mode for validation
 
-**Parameters**:
+#### Parameters
 
 * `-Version` - Explicit version string
 * `-DevPatchNumber` - Development patch number for dev builds
@@ -88,7 +88,7 @@ Packages the VS Code extension into a `.vsix` file using `vsce`.
 * `-Collection` - Collection name for scoped packaging
 * `-DryRun` (switch) - Preview changes without producing a package
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Package the extension
@@ -105,21 +105,21 @@ Packages the VS Code extension into a `.vsix` file using `vsce`.
 
 Discovers collection manifests for the packaging matrix.
 
-**Purpose**: Build a list of collections to package based on channel and
+Purpose: Build a list of collections to package based on channel and
 maturity rules.
 
-**Features**:
+#### Features
 
 * Scans `collections/` for `.collection.yml` files
 * Filters collections by maturity and channel
 * Outputs a matrix for CI workflow consumption
 
-**Parameters**:
+#### Parameters
 
 * `-Channel` - Release channel filter: `Stable` or `PreRelease`
 * `-CollectionsDir` - Path to the collections directory
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Discover stable collections

--- a/scripts/lib/README.md
+++ b/scripts/lib/README.md
@@ -21,15 +21,15 @@ This directory contains shared utility scripts and modules used across the
 
 Downloads and verifies artifacts using SHA256 checksums.
 
-**Purpose**: Provide tamper-evident file downloads for CI tooling.
+Purpose: Provide tamper-evident file downloads for CI tooling.
 
-**Features**:
+#### Features
 
 * Downloads files from a URL and verifies against an expected SHA256 hash
 * Supports optional extraction of archives
 * Exposes `Get-FileHashValue` and `Test-HashMatch` functions for reuse
 
-**Parameters**:
+#### Parameters
 
 * `-Url` - Download URL
 * `-ExpectedSHA256` - Expected SHA256 hash for verification
@@ -37,7 +37,7 @@ Downloads and verifies artifacts using SHA256 checksums.
 * `-Extract` (switch) - Extract the downloaded archive after verification
 * `-ExtractPath` - Destination path for extraction
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Download and verify a tool

--- a/scripts/linting/README.md
+++ b/scripts/linting/README.md
@@ -35,9 +35,9 @@ The linting scripts follow a **modular architecture** with shared helper functio
 
 Static analysis for PowerShell scripts using PSScriptAnalyzer.
 
-**Purpose**: Enforce PowerShell best practices and detect common issues.
+Purpose: Enforce PowerShell best practices and detect common issues.
 
-**Features**:
+##### Features
 
 * Detects changed PowerShell files via Git
 * Supports analyzing all files or changed files only
@@ -45,11 +45,11 @@ Static analysis for PowerShell scripts using PSScriptAnalyzer.
 * Exports JSON results and markdown summary
 * Configurable via `PSScriptAnalyzer.psd1`
 
-**Parameters**:
+##### Parameters
 
 * `-ChangedFilesOnly` (switch) - Analyze only files changed in current branch
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Analyze all PowerShell files
@@ -62,7 +62,7 @@ Static analysis for PowerShell scripts using PSScriptAnalyzer.
 ./scripts/linting/Invoke-PSScriptAnalyzer.ps1 -Verbose -Debug
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/ps-script-analyzer.yml`
 * Artifacts: `psscriptanalyzer-results` (JSON + markdown)
@@ -72,7 +72,7 @@ Static analysis for PowerShell scripts using PSScriptAnalyzer.
 
 Configuration file for PSScriptAnalyzer rules.
 
-**Enforced Rules**:
+##### Enforced Rules
 
 | Rule Category  | Description                                       |
 |----------------|---------------------------------------------------|
@@ -82,7 +82,7 @@ Configuration file for PSScriptAnalyzer rules.
 | Security       | Check for credentials in code                     |
 | Performance    | Identify inefficient patterns                     |
 
-**Excluded Rules**:
+##### Excluded Rules
 
 * `PSAvoidUsingWriteHost` - Allowed for script output
 
@@ -92,9 +92,9 @@ Configuration file for PSScriptAnalyzer rules.
 
 Static analysis for GitHub Actions workflow files using actionlint.
 
-**Purpose**: Validate GitHub Actions workflow YAML syntax and best practices.
+Purpose: Validate GitHub Actions workflow YAML syntax and best practices.
 
-**Features**:
+##### Features
 
 * Validates `.github/workflows/*.yml` and `.yaml` files
 * Detects changed workflow files via Git
@@ -103,13 +103,13 @@ Static analysis for GitHub Actions workflow files using actionlint.
 * Exports JSON results and markdown summary
 * Configurable via `.github/actionlint.yaml`
 
-**Parameters**:
+##### Parameters
 
 * `-ChangedFilesOnly` (switch) - Analyze only files changed in current branch
 * `-BaseBranch` (string) - Base branch for comparison (default: `origin/main`)
 * `-OutputPath` (string) - Output path for JSON results (default: `logs/yaml-lint-results.json`)
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Analyze all workflow files
@@ -122,7 +122,7 @@ Static analysis for GitHub Actions workflow files using actionlint.
 ./scripts/linting/Invoke-YamlLint.ps1 -Verbose -Debug
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/yaml-lint.yml`
 * Configuration: `.github/actionlint.yaml`
@@ -135,9 +135,9 @@ Static analysis for GitHub Actions workflow files using actionlint.
 
 Validates YAML frontmatter and footer format in markdown files.
 
-**Purpose**: Ensure consistent metadata across documentation.
+Purpose: Ensure consistent metadata across documentation.
 
-**Features**:
+##### Features
 
 * Validates required frontmatter fields
 * Checks footer format and copyright notice
@@ -147,21 +147,21 @@ Validates YAML frontmatter and footer format in markdown files.
 * Exports JSON results with detailed statistics
 * Generates comprehensive step summary
 
-**Parameters**:
+##### Parameters
 
 * `-ChangedFilesOnly` (switch) - Validate only changed markdown files
 * `-SkipFooterValidation` (switch) - Skip footer checks
 * `-WarningsAsErrors` (switch) - Treat warnings as errors
 * `-EnableSchemaValidation` (switch) - Enable JSON Schema validation (advisory only)
 
-**Artifacts Generated**:
+##### Artifacts Generated
 
 * `logs/frontmatter-validation-results.json` - Complete validation results including:
   * Timestamp and script name
   * Summary statistics (total files, error/warning counts)
   * Lists of all errors and warnings
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Validate all markdown files
@@ -174,7 +174,7 @@ Validates YAML frontmatter and footer format in markdown files.
 ./scripts/linting/Validate-MarkdownFrontmatter.ps1 -SkipFooterValidation
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/frontmatter-validation.yml`
 * Artifacts: `frontmatter-validation-results` (JSON)
@@ -185,16 +185,16 @@ Validates YAML frontmatter and footer format in markdown files.
 
 Detects URLs with language paths (e.g., `/en-us/`) that should be removed.
 
-**Purpose**: Ensure language-agnostic URLs for better internationalization.
+Purpose: Ensure language-agnostic URLs for better internationalization.
 
-**Features**:
+##### Features
 
 * Scans all markdown files recursively
 * Calls `Link-Lang-Check.ps1` for detection logic
 * Creates CI warning annotations
 * Provides fix instructions in summary
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Check all markdown files
@@ -204,7 +204,7 @@ Detects URLs with language paths (e.g., `/en-us/`) that should be removed.
 ./scripts/linting/Invoke-LinkLanguageCheck.ps1 -Debug
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/link-lang-check.yml`
 * Annotations: Warnings on files with language paths
@@ -214,15 +214,15 @@ Detects URLs with language paths (e.g., `/en-us/`) that should be removed.
 
 Core logic for detecting language paths in URLs.
 
-**Detection Pattern**: Matches `/[a-z]{2}-[a-z]{2}/` patterns in Microsoft domain URLs.
+Detection Pattern: Matches `/[a-z]{2}-[a-z]{2}/` patterns in Microsoft domain URLs.
 
 #### `Markdown-Link-Check.ps1`
 
 Validates all links in markdown files using markdown-link-check npm package.
 
-**Purpose**: Detect broken links before deployment.
+Purpose: Detect broken links before deployment.
 
-**Features**:
+##### Features
 
 * Checks internal and external links
 * Configurable via `markdown-link-check.config.json`
@@ -232,14 +232,14 @@ Validates all links in markdown files using markdown-link-check npm package.
 * Exports JSON results with link statistics
 * Generates detailed step summary
 
-**Artifacts Generated**:
+##### Artifacts Generated
 
 * `logs/markdown-link-check-results.json` - Complete validation results including:
   * Timestamp and script name
   * Summary statistics (total files, broken links count)
   * List of all broken links with file paths
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/markdown-link-check.yml`
 * Configuration: `markdown-link-check.config.json`
@@ -253,9 +253,9 @@ Validates all links in markdown files using markdown-link-check npm package.
 
 Validates the structural integrity of skill directories under `.github/skills/`.
 
-**Purpose**: Ensure all skill packages comply with the agentskills.io specification and hve-core conventions.
+Purpose: Ensure all skill packages comply with the agentskills.io specification and hve-core conventions.
 
-**Features**:
+##### Features
 
 * Validates SKILL.md presence in each skill directory
 * Checks frontmatter for required `name` and `description` fields
@@ -266,14 +266,14 @@ Validates the structural integrity of skill directories under `.github/skills/`.
 * Creates CI annotations for violations
 * Exports JSON results to `logs/skill-validation-results.json`
 
-**Parameters**:
+##### Parameters
 
 * `-SkillsPath` (string) - Root path containing skill directories (default: `.github/skills`)
 * `-WarningsAsErrors` (switch) - Treat warnings as errors
 * `-ChangedFilesOnly` (switch) - Validate only skills with changed files
 * `-BaseBranch` (string) - Git reference for changed file detection (default: `origin/main`)
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Validate all skills
@@ -286,7 +286,7 @@ Validates the structural integrity of skill directories under `.github/skills/`.
 ./scripts/linting/Validate-SkillStructure.ps1 -ChangedFilesOnly
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/skill-validation.yml`
 * Artifacts: `skill-validation-results` (JSON)
@@ -298,9 +298,9 @@ Validates the structural integrity of skill directories under `.github/skills/`.
 
 Validates copyright and SPDX license headers in source files.
 
-**Purpose**: Ensure all PowerShell and shell scripts include the required Microsoft copyright notice and MIT SPDX license identifier in their first 15 lines.
+Purpose: Ensure all PowerShell and shell scripts include the required Microsoft copyright notice and MIT SPDX license identifier in their first 15 lines.
 
-**Features**:
+##### Features
 
 * Scans `.ps1`, `.psm1`, `.psd1`, and `.sh` files recursively
 * Checks for `Copyright (c) Microsoft Corporation` header
@@ -309,7 +309,7 @@ Validates copyright and SPDX license headers in source files.
 * Exports JSON results with per-file compliance details
 * Calculates compliance percentage across all scanned files
 
-**Parameters**:
+##### Parameters
 
 * `-Path` (string) - Root path to scan (default: repository root via `git rev-parse --show-toplevel`)
 * `-FileExtensions` (string[]) - File extensions to check (default: `@('*.ps1', '*.psm1', '*.psd1', '*.sh')`)
@@ -317,7 +317,7 @@ Validates copyright and SPDX license headers in source files.
 * `-FailOnMissing` (switch) - Exit with code 1 if any files lack required headers
 * `-ExcludePaths` (string[]) - Directories to exclude (default: `@('node_modules', '.git', 'vendor', 'logs')`)
 
-**Usage**:
+##### Usage
 
 ```powershell
 # Check all source files (report only)
@@ -330,7 +330,7 @@ Validates copyright and SPDX license headers in source files.
 ./scripts/linting/Test-CopyrightHeaders.ps1 -Path ./scripts -FailOnMissing -Verbose
 ```
 
-**GitHub Actions Integration**:
+##### GitHub Actions Integration
 
 * Workflow: `.github/workflows/copyright-headers.yml`
 * Artifacts: `copyright-header-results` (JSON)
@@ -342,20 +342,20 @@ Validates copyright and SPDX license headers in source files.
 
 Common helper functions for file discovery and git operations.
 
-**Exported Functions**:
+#### Exported Functions
 
 #### `Get-ChangedFilesFromGit`
 
 Detects files changed in current branch compared to main.
 
-**Parameters**:
+##### Parameters
 
 * `-BaseBranch` (string) - Base branch to compare against (default: `origin/main`)
 * `-FileExtensions` (string[]) - Array of file patterns to filter (e.g., `@('*.ps1', '*.md')`)
 
-**Returns**: Array of changed file paths
+Returns: Array of changed file paths
 
-**Fallbacks**:
+##### Fallbacks
 
 1. `git merge-base` with specified base branch
 2. `git diff HEAD~1` when merge-base fails
@@ -365,15 +365,15 @@ Detects files changed in current branch compared to main.
 
 Finds files matching patterns using `git ls-files` with a `Get-ChildItem` fallback.
 
-**Parameters**:
+##### Parameters
 
 * `-Path` (string, required) - Root directory to search from
 * `-Include` (string[], required) - File patterns to include (e.g., `@('*.ps1', '*.psm1')`)
 * `-GitIgnorePath` (string) - Path to `.gitignore` file for exclusion patterns (fallback path only)
 
-**Returns**: Array of FileInfo objects
+Returns: Array of FileInfo objects
 
-**Behavior**:
+##### Behavior
 
 * Inside a git repository, uses `git ls-files --cached --others --exclude-standard` scoped to the given path. Git natively handles `.gitignore` exclusions.
 * Outside a git repository (or when `git` is unavailable), falls back to `Get-ChildItem -Recurse` with optional `-GitIgnorePath` filtering.
@@ -382,23 +382,23 @@ Finds files matching patterns using `git ls-files` with a `Get-ChildItem` fallba
 
 Parses `.gitignore` into PowerShell wildcard patterns.
 
-**Parameters**:
+##### Parameters
 
 * `-GitIgnorePath` (string, required) - Path to `.gitignore` file
 
-**Returns**: Array of wildcard patterns using platform-appropriate separators
+Returns: Array of wildcard patterns using platform-appropriate separators
 
 ### `scripts/lib/Modules/CIHelpers.psm1`
 
 CI helper functions for annotations, outputs, environment flags, and summaries.
 
-**Exported Functions**:
+#### Exported Functions
 
 #### `Write-CIAnnotation`
 
 Creates a CI annotation.
 
-**Parameters**:
+##### Parameters
 
 * `-Level` ('Error'|'Warning'|'Notice') - Annotation severity
 * `-Message` (string) - Annotation text
@@ -406,13 +406,13 @@ Creates a CI annotation.
 * `-Line` (int, optional) - Line number
 * `-Column` (int, optional) - Column number
 
-**Output**: CI annotation command
+Output: CI annotation command
 
 #### `Write-CIAnnotations`
 
 Writes CI annotations from a validation summary.
 
-**Parameters**:
+##### Parameters
 
 * `-Summary` (ValidationSummary) - Validation results to annotate
 
@@ -420,7 +420,7 @@ Writes CI annotations from a validation summary.
 
 Sets a CI output variable.
 
-**Parameters**:
+##### Parameters
 
 * `-Name` (string) - Variable name
 * `-Value` (string) - Variable value
@@ -429,7 +429,7 @@ Sets a CI output variable.
 
 Sets a CI environment variable.
 
-**Parameters**:
+##### Parameters
 
 * `-Name` (string) - Variable name
 * `-Value` (string) - Variable value
@@ -438,11 +438,11 @@ Sets a CI environment variable.
 
 Appends content to the CI step summary.
 
-**Parameters**:
+##### Parameters
 
 * `-Content` (string) - Markdown content
 
-**Usage Example**:
+#### Usage Example
 
 ```powershell
 Import-Module ./Modules/LintingHelpers.psm1
@@ -466,7 +466,7 @@ Write-CIStepSummary -Content "## Results`n`nAnalyzed $($files.Count) files"
 
 PSScriptAnalyzer rule configuration.
 
-**Key Settings**:
+#### Key Settings
 
 * Severity: Error, Warning
 * IncludeRules: Best practices, security, performance
@@ -476,7 +476,7 @@ PSScriptAnalyzer rule configuration.
 
 Markdown link checker configuration.
 
-**Key Settings**:
+#### Key Settings
 
 * Retry attempts: 3
 * Timeout: 10 seconds
@@ -525,13 +525,13 @@ To add a new linting script:
 1. **Create wrapper script** following `Invoke-*.ps1` naming convention
 2. **Import LintingHelpers and CIHelpers modules** for file discovery and CI integration
 3. **Implement core validation logic** with clear error reporting
-4. **Support common parameters**: `-Verbose`, `-Debug`, `-ChangedFilesOnly` (if applicable)
+4. Support common parameters: `-Verbose`, `-Debug`, `-ChangedFilesOnly` (if applicable)
 5. **Create GitHub Actions workflow** in `.github/workflows/`
 6. **Add to PR validation** in `.github/workflows/pr-validation.yml`
 7. **Document** in this README and workflows README
 8. **Test locally** before creating PR
 
-**Template**:
+### Template
 
 ```powershell
 #!/usr/bin/env pwsh

--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -35,10 +35,10 @@ The security scripts share common modules and follow a consistent pattern:
 
 Verifies SHA pinning compliance for all dependencies in GitHub Actions workflows.
 
-**Purpose**: Detect unpinned or improperly pinned dependencies to maintain
+Purpose: Detect unpinned or improperly pinned dependencies to maintain
 supply chain security.
 
-**Features**:
+#### Features
 
 * Scans workflow files for GitHub Actions, Docker images, and other dependency
   types
@@ -48,7 +48,7 @@ supply chain security.
 * Supports auto-remediation with `-Remediate`
 * Configurable compliance threshold
 
-**Parameters**:
+#### Parameters
 
 * `-Path` - Root path to scan (defaults to repository root)
 * `-Recursive` (switch) - Scan subdirectories
@@ -60,7 +60,7 @@ supply chain security.
 * `-Threshold` - Minimum compliance percentage
 * `-Remediate` (switch) - Attempt automatic remediation
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Scan all workflows with table output
@@ -78,17 +78,17 @@ supply chain security.
 Monitors SHA-pinned dependencies for staleness by checking whether newer
 versions are available.
 
-**Purpose**: Identify pinned dependencies that have fallen behind upstream
+Purpose: Identify pinned dependencies that have fallen behind upstream
 releases.
 
-**Features**:
+#### Features
 
 * Queries GitHub API for latest releases of pinned actions
 * Supports multiple output formats (JSON, Azure DevOps, GitHub, console)
 * Configurable maximum age threshold
 * Batch GraphQL queries for efficient API usage
 
-**Parameters**:
+#### Parameters
 
 * `-OutputFormat` - Output format: `json`, `azdo`, `github`, `console`
 * `-MaxAge` - Maximum age in days before a pin is considered stale
@@ -97,7 +97,7 @@ releases.
 * `-FailOnStale` (switch) - Exit with non-zero code when stale pins exist
 * `-GraphQLBatchSize` - Number of repositories per GraphQL batch query
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Check for stale SHAs with console output
@@ -115,16 +115,16 @@ releases.
 Validates that GitHub Actions version comments match their corresponding SHA
 pins across workflow files.
 
-**Purpose**: Detect mismatches between version comments and pinned SHAs that
+Purpose: Detect mismatches between version comments and pinned SHAs that
 could indicate incomplete updates.
 
-**Features**:
+#### Features
 
 * Compares version comment annotations with resolved SHA references
 * Outputs results in table, JSON, or SARIF format
 * Integrates with `lint:version-consistency` npm script
 
-**Parameters**:
+#### Parameters
 
 * `-Path` - Root path containing workflow files
 * `-Format` - Output format: `Table`, `Json`, `Sarif`
@@ -132,7 +132,7 @@ could indicate incomplete updates.
 * `-FailOnMismatch` (switch) - Exit with non-zero code when mismatches exist
 * `-FailOnMissingComment` (switch) - Fail when SHA pins lack version comments
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Check version consistency
@@ -150,24 +150,24 @@ could indicate incomplete updates.
 Updates GitHub Actions workflow files to use SHA-pinned references. Supports
 `WhatIf` via `SupportsShouldProcess`.
 
-**Purpose**: Automate the process of resolving and updating SHA pins for GitHub
+Purpose: Automate the process of resolving and updating SHA pins for GitHub
 Actions dependencies.
 
-**Features**:
+#### Features
 
 * Resolves current SHA for each action reference
 * Supports dry-run via `-WhatIf`
 * Updates stale pins with `-UpdateStale`
 * Generates update reports
 
-**Parameters**:
+#### Parameters
 
 * `-WorkflowPath` - Path to workflow file(s) to update
 * `-OutputReport` - Path for the update report
 * `-OutputFormat` - Report format
 * `-UpdateStale` (switch) - Update only stale pins rather than all
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Preview changes without modifying files

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -22,10 +22,10 @@ production `scripts/` structure.
 
 Pester test runner that writes structured output to `logs/`.
 
-**Purpose**: Provide a consistent entry point for running Pester tests in both
+Purpose: Provide a consistent entry point for running Pester tests in both
 local and CI environments.
 
-**Features**:
+#### Features
 
 * Writes `logs/pester-summary.json` with overall pass/fail counts and duration
 * Writes `logs/pester-failures.json` with failure details including test name,
@@ -33,13 +33,13 @@ local and CI environments.
 * Supports code coverage reporting
 * Integrates with CI for exit codes and NUnit output
 
-**Parameters**:
+#### Parameters
 
 * `-TestPath` - Path to specific test file(s) or directory
 * `-CI` (switch) - Enable CI mode with exit codes and NUnit output
 * `-CodeCoverage` (switch) - Enable code coverage analysis
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Run all tests
@@ -63,23 +63,23 @@ npm run test:ps -- -TestPath "scripts/tests/security/"
 
 Detects changed PowerShell files and resolves corresponding Pester test paths.
 
-**Purpose**: Enable targeted test runs by identifying which tests correspond to
+Purpose: Enable targeted test runs by identifying which tests correspond to
 changed production scripts.
 
-**Features**:
+#### Features
 
 * Compares the current branch against a base branch using `git diff`
 * Maps changed production files to their mirror test files
 * Supports custom file filters and alternate root paths
 
-**Parameters**:
+#### Parameters
 
 * `-BaseBranch` - Git branch to compare against (defaults to `main`)
 * `-FileFilter` - Glob pattern for filtering changed files
 * `-SkillsRoot` - Root path for skill scripts
 * `-TestRoot` - Root path for test files
 
-**Usage**:
+#### Usage
 
 ```powershell
 # Get test files for all changed scripts


### PR DESCRIPTION
This PR addresses writing-style convention violations across the hve-core documentation. It systematically remediates three violation patterns (em dashes, bolded-prefix list items, and pseudo-headings) across 52 files while adding markdownlint rules that prevent future regressions. All changes are documentation and configuration only; no functional code was modified.

## Changes

### Linting Infrastructure

Two new **custom markdownlint rules** were added via `markdownlint-rule-search-replace` (v1.2.0) to catch future writing-style violations at lint time.

- Added `no-em-dash` rule to *`.markdownlint.json`* detecting U+2014 em dash characters in prose
- Added `no-bolded-prefix-list` rule to *`.markdownlint.json`* detecting `**Term:** description` patterns in list items
- Both rules include `information` URLs pointing back to *writing-style.instructions.md* for contributor guidance
- Registered the search-replace plugin in *`.markdownlint-cli2.jsonc`*
- Changed `MD024.siblings_only` from `false` to `true` to accommodate new headings introduced by pseudo-heading conversions
- Added `markdownlint-rule-search-replace` as a dev dependency in *package.json*

### Em Dash Remediation

Replaced 41 em dash instances across documentation with context-appropriate punctuation following the writing-style convention.

- Substituted colons where the em dash introduced an explanation or elaboration
- Substituted parentheses where the em dash framed a parenthetical aside
- Applied across contributing guides, architecture docs, RPI workflow documentation, extension templates, getting-started guides, and customization content

### Bolded-Prefix and Pseudo-Heading Conversions

Converted 370+ instances of bolded-prefix list items and pseudo-headings into convention-compliant formatting using three remediation strategies matched to content type.

- Converted bolded text used as section headers into proper markdown headings (`###`, `####`, `#####`) based on document hierarchy
- Replaced `**Term:** description` patterns with plain `Term: description` for inline definitions
- Restructured metadata-style lists into definition tables where the content warranted tabular presentation
- Added an inline `<!-- markdownlint-disable-next-line search-replace -->` comment in *writing-style.instructions.md* to suppress a false-positive lint hit on the instructional em dash example

### Documentation Updates

Applied writing-style fixes across all major documentation areas.

- *docs/architecture/*: Heading conversions and em dash replacements in workflow and testing docs
- *docs/contributing/*: Bolded-prefix remediation across instructions, prompts, agents, and release process guides
- *docs/getting-started/*: Consistent fixes across all six installation method guides
- *docs/rpi/*: Pseudo-heading conversions in researcher, planner, and implementor docs
- *docs/security/*: Heading and list-item formatting in security planning documentation
- *docs/customization/* and *docs/design-thinking/*: Em dash and bolded-prefix fixes
- *scripts/*: README heading conversions across extension, lib, linting, security, and tests directories
- *extension/*: Pseudo-heading fixes in *PACKAGING.md* and em dash replacement in *README.template.md*
- *.devcontainer/README.md* and *SUPPORT.md*: Writing-style compliance fixes

## Related Issues

Closes #504

## Notes

- The 662 remaining lint violations (158 em dash + 504 bolded-prefix) are in out-of-scope files (instructions, agents, prompts, skills) and represent the expected baseline documented in Issue #504
- Content meaning and structure are preserved through all conversions; only formatting changed