### PR TITLE
fix(extension): inline agent content instead of path stubs in packaged plugins

### DIFF
--- a/scripts/plugins/Modules/PluginHelpers.psm1
+++ b/scripts/plugins/Modules/PluginHelpers.psm1
@@ -460,23 +460,23 @@ function Test-SymlinkCapability {
 function New-PluginLink {
     <#
     .SYNOPSIS
-    Links a source path into a plugin destination via symlink or text stub.
+    Links a source path into a plugin destination via symlink or inlined content.
 
     .DESCRIPTION
     When SymlinkCapable is set, creates a relative symbolic link from
-    DestinationPath to SourcePath. Otherwise writes a text stub file
-    containing the relative path, matching the format git produces when
-    core.symlinks is false. Text stubs keep git status clean on Windows
-    without Developer Mode or elevated privileges.
+    DestinationPath to SourcePath. Otherwise copies the actual file content
+    to the destination. This ensures agent files have valid YAML frontmatter
+    in the installed plugin rather than path references that Copilot CLI
+    cannot parse.
 
     .PARAMETER SourcePath
     Absolute path to the real file or directory.
 
     .PARAMETER DestinationPath
-    Absolute path where the link or text stub will be created.
+    Absolute path where the link or copied content will be created.
 
     .PARAMETER SymlinkCapable
-    When set, create a symbolic link; otherwise write a text stub.
+    When set, create a symbolic link; otherwise copy the file content.
     #>
     [CmdletBinding()]
     param(
@@ -501,7 +501,9 @@ function New-PluginLink {
         New-Item -ItemType SymbolicLink -Path $DestinationPath -Value $relativePath -Force | Out-Null
     }
     else {
-        [System.IO.File]::WriteAllText($DestinationPath, $relativePath)
+        # Copy the actual file content instead of writing a path reference
+        # This ensures agent files have valid YAML frontmatter in installed plugins
+        Copy-Item -Path $SourcePath -Destination $DestinationPath -Force
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

When plugins are packaged in non-symlink environments (e.g., Windows without Developer Mode, or when Copilot CLI installs plugins), agent files were being written as single-line relative path references instead of actual YAML frontmatter content. This caused Copilot CLI to fail with 'frontmatter is malformed' errors on all agent files.

### Root Cause

The `New-PluginLink` function was writing text stubs containing relative paths when symlinks were not supported. The Copilot CLI expects agent `.md` files to begin with valid YAML frontmatter (`---` delimited block with at least a `description` field), but received single-line path strings instead.

### Fix

Changed `New-PluginLink` to copy the actual file content when symlinks are not supported, ensuring agent files have valid YAML frontmatter in installed plugins.

**Before:**

```powershell
else {
    [System.IO.File]::WriteAllText($DestinationPath, $relativePath)
}
```

**After:**

```powershell
else {
    # Copy the actual file content instead of writing a path reference
    # This ensures agent files have valid YAML frontmatter in installed plugins
    Copy-Item -Path $SourcePath -Destination $DestinationPath -Force
}
```

## Related Issue(s)

Fixes #785

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

This fix ensures:
- Agent files have valid YAML frontmatter when installed via `copilot plugin install`
- Commands, instructions, and skills continue to work correctly
- Plugin packaging works in both symlink and non-symlink environments

### Validation

- Local testing shows agent files now contain actual content instead of path references
- The fix maintains the same directory structure and behavior for symlink environments
- No changes to symlink behavior when supported

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`

## Security Considerations

* [ ] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes
<!-- Any additional information that reviewers should know -->
