### PR TITLE
chore(ci): add multi-arch support to copilot-setup-steps binary downloads

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -69,11 +69,11 @@ jobs:
             echo "ERROR: Unsupported architecture for actionlint: ${ARCH}" >&2
             exit 1
           fi
-          curl -sLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz"
-          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" | sha256sum -c -
-          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" actionlint
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" -o /tmp/actionlint.tar.gz
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/actionlint.tar.gz actionlint
           sudo install actionlint /usr/local/bin/actionlint
-          rm actionlint "actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz"
+          rm actionlint /tmp/actionlint.tar.gz
           actionlint --version
 
       - name: Install PowerShell modules


### PR DESCRIPTION
## Summary

The `Install actionlint` and `Install uv package manager` steps in *copilot-setup-steps.yml* previously hardcoded `linux_amd64` and `x86_64-unknown-linux-gnu` respectively, making the workflow fail silently or not run at all on aarch64 runners. This PR adds runtime architecture detection to both steps so the workflow functions on either x86_64 or aarch64 hosts without code
changes.

## Changes

### Install actionlint step

- Replaced the single `ACTIONLINT_SHA256` env var with **`ACTIONLINT_AMD64_SHA256`**
  and **`ACTIONLINT_ARM64_SHA256`**, carrying verified checksums for both architectures.
- Added `ARCH=$(uname -m)` as the first line of `run:`, followed by an `if`/`elif`/`else`
  block that sets `ACTIONLINT_ARCH` (`amd64` or `arm64`) and the local `ACTIONLINT_SHA256`
  variable used by the rest of the step.
  - `x86_64` → `amd64` (preserves the previous behavior exactly)
  - `aarch64` → `arm64`
  - Any other value → `echo "ERROR: Unsupported architecture for actionlint: ${ARCH}" >&2; exit 1`
- All `curl`, `sha256sum`, `tar`, and `rm` references now use `${ACTIONLINT_ARCH}` — the
  literal `linux_amd64` string is gone.

### Install uv package manager step

- Replaced the single `UV_SHA256` env var with **`UV_X86_64_SHA256`** and
  **`UV_AARCH64_SHA256`**, carrying verified checksums for both Rust target triples.
- Added the same `ARCH=$(uname -m)` detection block:
  - `x86_64` → `UV_ARCH="x86_64-unknown-linux-gnu"` (preserves previous behavior exactly)
  - `aarch64` → `UV_ARCH="aarch64-unknown-linux-gnu"`
  - Any other value → `echo "ERROR: Unsupported architecture for uv: ${ARCH}" >&2; exit 1`
- `curl` URL, `sha256sum` verification, and both `tar` extraction paths use `"uv-${UV_ARCH}/uv"`
  and `"uv-${UV_ARCH}/uvx"` with proper quoting — the literal `x86_64-unknown-linux-gnu` string
  is gone.

> The arch-detection and branching pattern mirrors `.devcontainer/scripts/on-create.sh`
> (lines 18–29 for actionlint, lines 72–83 for uv), per the *Environment Synchronization*
> guidance in `copilot-instructions.md`.

The skill-sync `find .github/skills -name pyproject.toml -execdir uv sync \;` line at the end of the uv step is unchanged — error propagation for that block is addressed separately in issue #946.

## Related Issues

Closes #945

## Notes

- SHA256 values were sourced from the official GitHub release pages for actionlint v1.7.10
  and uv v0.10.8 and cross-referenced against the existing devcontainer checksums.
- No changes were made to any other workflow files or scripts.

## Follow-up Tasks

- fix: align actionlint curl download with uv step pattern -- replace `curl -sLO` with `curl -sSfL -o /tmp/actionlint.tar.gz` to match the uv step, eliminating the misleading sha256 mismatch on HTTP errors and CWD archive leaks on failure