### PR TITLE
fix(workflows): propagate uv sync errors in copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -109,14 +109,14 @@ jobs:
           echo "Syncing Python environments for skills..."
           failed=0
           while IFS= read -r -d '' f; do
-            dir="$(dirname "$f")"
-            echo "Installing dependencies in $dir"
-            if ! (cd "$dir" && uv sync); then
-              echo "::error::uv sync failed in $dir"
+            dir="$(dirname "${f}")"
+            echo "Installing dependencies in ${dir}"
+            if ! (cd "${dir}" && uv sync); then
+              echo "::error::uv sync failed in ${dir}"
               failed=1
             fi
           done < <(find .github/skills -name pyproject.toml -type f -print0)
-          if [[ "$failed" -ne 0 ]]; then
+          if [[ "${failed}" -ne 0 ]]; then
             echo "::error::One or more skill dependency installations failed"
             exit 1
           fi


### PR DESCRIPTION
## Description

- Replace silent `find -execdir uv sync` in the Install uv package manager step with an error propagating while loop.

- Adds -type f flag for parity with on-create.sh, uses -print0/read -d '' for safe path handling, emits ::error:: annotations per failing directory, processes all skills before aborting, and exits non-zero if any sync fails.
 
## Related Issue(s)

Closes #946

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Ran workflow in forked repository in `main` -- producing the following output for the relevant step:

```
Syncing Python environments for skills...
Installing dependencies in .github/skills/experimental/powerpoint
Using CPython 3.11.14 interpreter at: /opt/hostedtoolcache/Python/3.11.14/x64/bin/python3
Creating virtual environment at: .venv
Resolved 33 packages in 0.61ms
Downloading pygments (1.2MiB)
Downloading pymupdf (23.8MiB)
Downloading lxml (5.0MiB)
Downloading pillow (6.7MiB)
Downloading ruff (10.7MiB)
Downloading github-copilot-sdk (56.5MiB)
Downloading pydantic-core (2.0MiB)
 Downloaded pydantic-core
 Downloaded ruff
 Downloaded pillow
 Downloaded lxml
 Downloaded pygments
 Downloaded pymupdf
 Downloaded github-copilot-sdk
Prepared 30 packages in 1.73s
Installed 30 packages in 24ms
 + annotated-types==0.7.0
 + cairocffi==1.7.1
 + cairosvg==2.8.2
 + cffi==2.0.0
 + coverage==7.13.4
 + cssselect2==0.9.0
 + defusedxml==0.7.1
 + github-copilot-sdk==0.1.30
 + iniconfig==2.3.0
 + lxml==6.0.2
 + packaging==26.0
 + pillow==12.1.1
 + pluggy==1.6.0
 + pycparser==3.0
 + pydantic==2.12.5
 + pydantic-core==2.41.5
 + pygments==2.19.2
 + pymupdf==1.27.1
 + pytest==9.0.2
 + pytest-cov==7.0.0
 + python-dateutil==2.9.0.post0
 + python-pptx==1.0.2
 + pyyaml==6.0.3
 + ruff==0.15.4
 + six==1.17.0
 + tinycss2==1.5.1
 + typing-extensions==4.15.0
 + typing-inspection==0.4.2
 + webencodings==0.5.1
 + xlsxwriter==3.2.9
```

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`
* [ ] YAML linting: `npm run lint:yaml`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

The same `-type f` parity and error-propagation improvements could be applied here in a follow-on task.
