### PR TITLE
fix(skills): resolve ruff lint and format violations in powerpoint skill

### DIFF
--- a/.github/skills/experimental/powerpoint/scripts/build_deck.py
+++ b/.github/skills/experimental/powerpoint/scripts/build_deck.py
@@ -51,61 +51,67 @@ ANS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 
 # Stdlib modules blocked in content-extra.py scripts due to security risk.
 # content-extra.py may only import from pptx and safe standard-library modules.
-_BLOCKED_STDLIB_MODULES = frozenset({
-    "code",
-    "codeop",
-    "compileall",
-    "ctypes",
-    "dbm",
-    "ensurepip",
-    "ftplib",
-    "http",
-    "imaplib",
-    "importlib",
-    "marshal",
-    "multiprocessing",
-    "os",
-    "pickle",
-    "pkgutil",
-    "poplib",
-    "py_compile",
-    "runpy",
-    "shelve",
-    "shutil",
-    "signal",
-    "smtplib",
-    "socket",
-    "sqlite3",
-    "subprocess",
-    "sys",
-    "telnetlib",
-    "tempfile",
-    "threading",
-    "urllib",
-    "venv",
-    "webbrowser",
-    "xmlrpc",
-    "zipimport",
-})
+_BLOCKED_STDLIB_MODULES = frozenset(
+    {
+        "code",
+        "codeop",
+        "compileall",
+        "ctypes",
+        "dbm",
+        "ensurepip",
+        "ftplib",
+        "http",
+        "imaplib",
+        "importlib",
+        "marshal",
+        "multiprocessing",
+        "os",
+        "pickle",
+        "pkgutil",
+        "poplib",
+        "py_compile",
+        "runpy",
+        "shelve",
+        "shutil",
+        "signal",
+        "smtplib",
+        "socket",
+        "sqlite3",
+        "subprocess",
+        "sys",
+        "telnetlib",
+        "tempfile",
+        "threading",
+        "urllib",
+        "venv",
+        "webbrowser",
+        "xmlrpc",
+        "zipimport",
+    }
+)
 
-_DANGEROUS_BUILTINS = frozenset({
-    "__import__",
-    "breakpoint",
-    "compile",
-    "eval",
-    "exec",
-})
+_DANGEROUS_BUILTINS = frozenset(
+    {
+        "__import__",
+        "breakpoint",
+        "compile",
+        "eval",
+        "exec",
+    }
+)
 
 # Builtins that can bypass the import allowlist or execute arbitrary strings
 # when called indirectly through attribute access or introspection.
-_INDIRECT_BYPASS_BUILTINS = frozenset({
-    "delattr",
-    "getattr",
-    "globals",
-    "locals",
-    "setattr",
-    "vars",
-})
+_INDIRECT_BYPASS_BUILTINS = frozenset(
+    {
+        "delattr",
+        "getattr",
+        "globals",
+        "locals",
+        "setattr",
+        "vars",
+    }
+)
 
 
 class ContentExtraError(Exception):
@@ -122,9 +128,7 @@ def _check_module_allowed(
         return
 
     if top_level in _BLOCKED_STDLIB_MODULES:
-        raise ContentExtraError(
-            f"Blocked import '{module_name}' in {script_path}"
-        )
+        raise ContentExtraError(f"Blocked import '{module_name}' in {script_path}")
 
     if top_level in stdlib_names:
         return
@@ -146,9 +150,7 @@ def _validate_content_extra(script_path: Path) -> None:
     try:
         tree = ast.parse(source, filename=str(script_path))
     except SyntaxError as exc:
-        raise ContentExtraError(
-            f"Syntax error in {script_path}: {exc}"
-        ) from exc
+        raise ContentExtraError(f"Syntax error in {script_path}: {exc}") from exc
 
     stdlib_names = sys.stdlib_module_names
 
@@ -645,8 +647,14 @@ MAX_GROUP_DEPTH = 20
 
 
 def add_group_element(
-    slide, elem: dict, colors: dict, typography: dict, content_dir: Path,
-    *, _depth: int = 0, max_depth: int = MAX_GROUP_DEPTH,
+    slide,
+    elem: dict,
+    colors: dict,
+    typography: dict,
+    content_dir: Path,
+    *,
+    _depth: int = 0,
+    max_depth: int = MAX_GROUP_DEPTH,
 ):
     """Add a group element containing nested child elements.
 
@@ -674,9 +682,7 @@ def add_group_element(
           text: "Group Title"
     """
     if _depth >= max_depth:
-        raise ValueError(
-            f"Group nesting depth {_depth} exceeds limit of {max_depth}"
-        )
+        raise ValueError(f"Group nesting depth {_depth} exceeds limit of {max_depth}")
     group = slide.shapes.add_group_shape()
 
     group.left = Inches(elem["left"])
@@ -686,8 +692,13 @@ def add_group_element(
 
     for child_elem in elem.get("elements", []):
         build_element_in_group(
-            group, child_elem, colors, typography, content_dir,
-            _depth=_depth + 1, max_depth=max_depth,
+            group,
+            child_elem,
+            colors,
+            typography,
+            content_dir,
+            _depth=_depth + 1,
+            max_depth=max_depth,
         )
 
     if "name" in elem:
@@ -697,8 +708,14 @@ def add_group_element(
 
 
 def build_element_in_group(
-    group, elem: dict, colors: dict, typography: dict, content_dir: Path,
-    *, _depth: int = 0, max_depth: int = MAX_GROUP_DEPTH,
+    group,
+    elem: dict,
+    colors: dict,
+    typography: dict,
+    content_dir: Path,
+    *,
+    _depth: int = 0,
+    max_depth: int = MAX_GROUP_DEPTH,
 ):
     """Dispatch a child element build within a group shape.
 
@@ -717,8 +734,13 @@ def build_element_in_group(
         add_image_element(group, elem, content_dir)
     elif elem_type == "group":
         add_group_element(
-            group, elem, colors, typography, content_dir,
-            _depth=_depth, max_depth=max_depth,
+            group,
+            elem,
+            colors,
+            typography,
+            content_dir,
+            _depth=_depth,
+            max_depth=max_depth,
         )
 
 
@@ -1010,13 +1032,11 @@ def build_slide(
         if not allow_scripts:
             # __import__ is kept because the import machinery needs it;
             # the AST checker already blocks direct __import__() calls.
-            stripped = (
-                _DANGEROUS_BUILTINS | _INDIRECT_BYPASS_BUILTINS
-            ) - {"__import__"}
+            stripped = (_DANGEROUS_BUILTINS | _INDIRECT_BYPASS_BUILTINS) - {
+                "__import__"
+            }
             safe_builtins = {
-                k: v
-                for k, v in builtins.__dict__.items()
-                if k not in stripped
+                k: v for k, v in builtins.__dict__.items() if k not in stripped
             }
             mod.__builtins__ = safe_builtins
         spec.loader.exec_module(mod)
@@ -1111,7 +1131,10 @@ def main():
         for num, slide_dir in slides_data:
             slide_content = load_yaml(slide_dir / "content.yaml")
             build_slide(
-                prs, slide_content, style, slide_dir,
+                prs,
+                slide_content,
+                style,
+                slide_dir,
                 allow_scripts=args.allow_scripts,
             )
             print(f"Built slide {num}: {slide_content.get('title', 'Untitled')}")
@@ -1135,7 +1158,10 @@ def main():
             if idx < len(prs.slides):
                 existing_slide = prs.slides[idx]
                 build_slide(
-                    prs, slide_content, style, slide_dir,
+                    prs,
+                    slide_content,
+                    style,
+                    slide_dir,
                     existing_slide=existing_slide,
                     allow_scripts=args.allow_scripts,
                 )
@@ -1169,7 +1195,10 @@ def main():
         for num, slide_dir in slides_data:
             slide_content = load_yaml(slide_dir / "content.yaml")
             build_slide(
-                prs, slide_content, style, slide_dir,
+                prs,
+                slide_content,
+                style,
+                slide_dir,
                 allow_scripts=args.allow_scripts,
             )
             print(f"Built slide {num}: {slide_content.get('title', 'Untitled')}")

--- a/.github/skills/experimental/powerpoint/scripts/extract_content.py
+++ b/.github/skills/experimental/powerpoint/scripts/extract_content.py
@@ -170,7 +170,12 @@ MAX_GROUP_DEPTH = 20
 
 
 def extract_group(
-    shape, slide_num: int, output_dir, img_count: int, *, _depth: int = 0,
+    shape,
+    slide_num: int,
+    output_dir,
+    img_count: int,
+    *,
+    _depth: int = 0,
     max_depth: int = MAX_GROUP_DEPTH,
 ) -> dict:
     """Extract a group shape and its nested child elements.
@@ -178,9 +183,7 @@ def extract_group(
     Raises ValueError when nesting exceeds *max_depth*.
     """
     if _depth >= max_depth:
-        raise ValueError(
-            f"Group nesting depth {_depth} exceeds limit of {max_depth}"
-        )
+        raise ValueError(f"Group nesting depth {_depth} exceeds limit of {max_depth}")
     elem = {
         "type": "group",
         "left": emu_to_inches(shape.left),
@@ -192,8 +195,12 @@ def extract_group(
     }
     for child in shape.shapes:
         child_elem = extract_child_shape(
-            child, slide_num, output_dir, img_count,
-            _depth=_depth + 1, max_depth=max_depth,
+            child,
+            slide_num,
+            output_dir,
+            img_count,
+            _depth=_depth + 1,
+            max_depth=max_depth,
         )
         if child_elem:
             elem["elements"].append(child_elem)
@@ -201,8 +208,13 @@ def extract_group(
 
 
 def _extract_shape_by_type(
-    shape, slide_num: int, output_dir, img_count: int,
-    *, _depth: int = 0, max_depth: int = MAX_GROUP_DEPTH,
+    shape,
+    slide_num: int,
+    output_dir,
+    img_count: int,
+    *,
+    _depth: int = 0,
+    max_depth: int = MAX_GROUP_DEPTH,
 ) -> dict | None:
     """Dispatch extraction based on shape_type, table/chart, or freeform."""
     shape_type = shape.shape_type
@@ -221,8 +233,12 @@ def _extract_shape_by_type(
         return extract_image(shape, output_dir, slide_num, img_count)
     if shape_type == 6:  # GROUP
         return extract_group(
-            shape, slide_num, output_dir, img_count,
-            _depth=_depth, max_depth=max_depth,
+            shape,
+            slide_num,
+            output_dir,
+            img_count,
+            _depth=_depth,
+            max_depth=max_depth,
         )
 
     # Table and chart detection via attribute check
@@ -237,13 +253,22 @@ def _extract_shape_by_type(
 
 
 def extract_child_shape(
-    shape, slide_num: int, output_dir, img_count: int,
-    *, _depth: int = 0, max_depth: int = MAX_GROUP_DEPTH,
+    shape,
+    slide_num: int,
+    output_dir,
+    img_count: int,
+    *,
+    _depth: int = 0,
+    max_depth: int = MAX_GROUP_DEPTH,
 ) -> dict | None:
     """Extract a single child shape within a group."""
     result = _extract_shape_by_type(
-        shape, slide_num, output_dir, img_count,
-        _depth=_depth, max_depth=max_depth,
+        shape,
+        slide_num,
+        output_dir,
+        img_count,
+        _depth=_depth,
+        max_depth=max_depth,
     )
     if result is not None:
         return result
@@ -1020,7 +1045,10 @@ MAX_THEME_REF_DEPTH = 50
 
 
 def _resolve_theme_refs_in_content(
-    content: dict, theme_colors: dict, *, max_depth: int = MAX_THEME_REF_DEPTH,
+    content: dict,
+    theme_colors: dict,
+    *,
+    max_depth: int = MAX_THEME_REF_DEPTH,
 ) -> dict:
     """Replace @theme_name references with resolved hex values in content.
 

--- a/.github/skills/experimental/powerpoint/scripts/pptx_colors.py
+++ b/.github/skills/experimental/powerpoint/scripts/pptx_colors.py
@@ -31,8 +31,11 @@ MAX_COLOR_DEPTH = 10
 
 
 def resolve_color(
-    value: str | dict, colors: dict | None = None,
-    *, _depth: int = 0, max_depth: int = MAX_COLOR_DEPTH,
+    value: str | dict,
+    colors: dict | None = None,
+    *,
+    _depth: int = 0,
+    max_depth: int = MAX_COLOR_DEPTH,
 ) -> dict:
     """Resolve a color value to an RGB or theme color specification.
 
@@ -63,7 +66,8 @@ def resolve_color(
             return result
         return resolve_color(
             value.get("color", "#000000"),
-            _depth=_depth + 1, max_depth=max_depth,
+            _depth=_depth + 1,
+            max_depth=max_depth,
         )
 
     if not isinstance(value, str):

--- a/.github/skills/experimental/powerpoint/tests/test_build_deck.py
+++ b/.github/skills/experimental/powerpoint/tests/test_build_deck.py
@@ -917,7 +917,9 @@ class TestAddGroupElement:
             "elements": [],
         }
         with pytest.raises(ValueError, match="exceeds limit"):
-            add_group_element(blank_slide, elem, {}, {}, tmp_path, _depth=5, max_depth=5)
+            add_group_element(
+                blank_slide, elem, {}, {}, tmp_path, _depth=5, max_depth=5
+            )
 
     def test_nested_group_within_depth_limit(self, blank_slide, tmp_path):
         """Nested groups within the limit build successfully."""
@@ -937,7 +939,9 @@ class TestAddGroupElement:
                 },
             ],
         }
-        group = add_group_element(blank_slide, elem, {}, {}, tmp_path, _depth=0, max_depth=20)
+        group = add_group_element(
+            blank_slide, elem, {}, {}, tmp_path, _depth=0, max_depth=20
+        )
         assert group is not None
 
     def test_build_element_in_group_dispatches_group(self, blank_slide, tmp_path):
@@ -951,7 +955,9 @@ class TestAddGroupElement:
             "height": 1.0,
             "elements": [],
         }
-        build_element_in_group(parent_group, child_elem, {}, {}, tmp_path, _depth=0, max_depth=20)
+        build_element_in_group(
+            parent_group, child_elem, {}, {}, tmp_path, _depth=0, max_depth=20
+        )
 
 
 class TestAddImageElementExtended:
@@ -1330,9 +1336,7 @@ class TestMain:
         content_dir = tmp_path / "content"
         slide_dir = content_dir / "slide-001"
         slide_dir.mkdir(parents=True)
-        (slide_dir / "content.yaml").write_text(
-            "slide: 1\ntitle: Test\nelements: []\n"
-        )
+        (slide_dir / "content.yaml").write_text("slide: 1\ntitle: Test\nelements: []\n")
         style_file = tmp_path / "style.yaml"
         style_yaml = "dimensions:\n  width_inches: 13.333\n  height_inches: 7.5\n"
         style_file.write_text(style_yaml)
@@ -1352,9 +1356,12 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
             ],
         ):
             main()
@@ -1376,15 +1383,21 @@ class TestMain:
 
         mock_prs_cls.return_value = MagicMock()
 
-        with patch(
-            "sys.argv",
-            [
-                "build_deck.py",
-                "--content-dir", str(empty_content),
-                "--style", str(style_file),
-                "--output", str(output),
-            ],
-        ), pytest.raises(SystemExit) as exc_info:
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "build_deck.py",
+                    "--content-dir",
+                    str(empty_content),
+                    "--style",
+                    str(style_file),
+                    "--output",
+                    str(output),
+                ],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
             main()
 
         assert exc_info.value.code == 1
@@ -1411,9 +1424,12 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
             ],
         ):
             main()
@@ -1440,10 +1456,14 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
-                "--template", str(template),
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
+                "--template",
+                str(template),
             ],
         ):
             main()
@@ -1466,16 +1486,23 @@ class TestMain:
         mock_prs.slides._sldIdLst = []
         mock_prs_cls.return_value = mock_prs
 
-        with patch(
-            "sys.argv",
-            [
-                "build_deck.py",
-                "--content-dir", str(empty_content),
-                "--style", str(style_file),
-                "--output", str(output),
-                "--template", str(template),
-            ],
-        ), pytest.raises(SystemExit) as exc_info:
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "build_deck.py",
+                    "--content-dir",
+                    str(empty_content),
+                    "--style",
+                    str(style_file),
+                    "--output",
+                    str(output),
+                    "--template",
+                    str(template),
+                ],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
             main()
 
         assert exc_info.value.code == 1
@@ -1497,11 +1524,16 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
-                "--source", str(source),
-                "--slides", "1",
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
+                "--source",
+                str(source),
+                "--slides",
+                "1",
             ],
         ):
             main()
@@ -1528,11 +1560,16 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
-                "--source", str(source),
-                "--slides", "99",
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
+                "--source",
+                str(source),
+                "--slides",
+                "99",
             ],
         ):
             main()
@@ -1558,11 +1595,16 @@ class TestMain:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
-                "--source", str(source),
-                "--slides", "1",
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
+                "--source",
+                str(source),
+                "--slides",
+                "1",
             ],
         ):
             main()
@@ -1681,9 +1723,7 @@ class TestContentExtraValidation:
         with pytest.raises(ContentExtraError, match="Syntax error"):
             _validate_content_extra(script)
 
-    def test_build_slide_runs_valid_content_extra(
-        self, blank_presentation, tmp_path
-    ):
+    def test_build_slide_runs_valid_content_extra(self, blank_presentation, tmp_path):
         """build_slide executes a valid content-extra.py render function."""
         content_dir = tmp_path / "slide-001"
         content_dir.mkdir()
@@ -1698,14 +1738,10 @@ class TestContentExtraValidation:
         )
 
         slide_content = {"layout": "Blank", "elements": []}
-        build_slide(
-            blank_presentation, slide_content, {}, content_dir
-        )
+        build_slide(blank_presentation, slide_content, {}, content_dir)
         assert marker_file.read_text() == "yes"
 
-    def test_build_slide_rejects_bad_content_extra(
-        self, blank_presentation, tmp_path
-    ):
+    def test_build_slide_rejects_bad_content_extra(self, blank_presentation, tmp_path):
         """build_slide refuses to execute a content-extra.py with blocked imports."""
         content_dir = tmp_path / "slide-001"
         content_dir.mkdir()
@@ -1716,22 +1752,26 @@ class TestContentExtraValidation:
 
         slide_content = {"layout": "Blank", "elements": []}
         with pytest.raises(ContentExtraError, match="Blocked import 'subprocess'"):
-            build_slide(
-                blank_presentation, slide_content, {}, content_dir
-            )
+            build_slide(blank_presentation, slide_content, {}, content_dir)
 
     def test_dangerous_breakpoint(self, tmp_path):
         """Script calling breakpoint() is rejected."""
         script = tmp_path / "content-extra.py"
         script.write_text("breakpoint()\n")
-        with pytest.raises(
-            ContentExtraError, match="Dangerous builtin 'breakpoint'"
-        ):
+        with pytest.raises(ContentExtraError, match="Dangerous builtin 'breakpoint'"):
             _validate_content_extra(script)
 
-    @pytest.mark.parametrize("builtin_name", [
-        "delattr", "getattr", "globals", "locals", "setattr", "vars",
-    ])
+    @pytest.mark.parametrize(
+        "builtin_name",
+        [
+            "delattr",
+            "getattr",
+            "globals",
+            "locals",
+            "setattr",
+            "vars",
+        ],
+    )
     def test_indirect_bypass_builtins(self, builtin_name, tmp_path):
         """Indirect bypass builtins are rejected."""
         script = tmp_path / "content-extra.py"
@@ -1742,9 +1782,7 @@ class TestContentExtraValidation:
         ):
             _validate_content_extra(script)
 
-    def test_allow_scripts_skips_validation(
-        self, blank_presentation, tmp_path
-    ):
+    def test_allow_scripts_skips_validation(self, blank_presentation, tmp_path):
         """build_slide skips validation when allow_scripts is True."""
         content_dir = tmp_path / "slide-001"
         content_dir.mkdir()
@@ -1769,9 +1807,7 @@ class TestContentExtraValidation:
         )
         assert marker_file.read_text() == "bypassed"
 
-    def test_allow_scripts_false_still_validates(
-        self, blank_presentation, tmp_path
-    ):
+    def test_allow_scripts_false_still_validates(self, blank_presentation, tmp_path):
         """build_slide validates when allow_scripts is explicitly False."""
         content_dir = tmp_path / "slide-001"
         content_dir.mkdir()
@@ -1790,9 +1826,7 @@ class TestContentExtraValidation:
                 allow_scripts=False,
             )
 
-    def test_restricted_namespace_blocks_eval(
-        self, blank_presentation, tmp_path
-    ):
+    def test_restricted_namespace_blocks_eval(self, blank_presentation, tmp_path):
         """Runtime namespace strips dangerous builtins even after AST pass."""
         content_dir = tmp_path / "slide-001"
         content_dir.mkdir()
@@ -1852,21 +1886,16 @@ class TestAllowScriptsCLI:
         content_dir = tmp_path / "content"
         slide_dir = content_dir / "slide-001"
         slide_dir.mkdir(parents=True)
-        (slide_dir / "content.yaml").write_text(
-            "slide: 1\ntitle: Test\nelements: []\n"
-        )
+        (slide_dir / "content.yaml").write_text("slide: 1\ntitle: Test\nelements: []\n")
         (slide_dir / "content-extra.py").write_text(extra_code)
         style_file = tmp_path / "style.yaml"
         style_file.write_text(
-            "dimensions:\n  width_inches: 13.333\n"
-            "  height_inches: 7.5\n"
+            "dimensions:\n  width_inches: 13.333\n  height_inches: 7.5\n"
         )
         return content_dir, style_file
 
     @patch("build_deck.Presentation")
-    def test_allow_scripts_flag_propagates(
-        self, mock_prs_cls, tmp_path
-    ):
+    def test_allow_scripts_flag_propagates(self, mock_prs_cls, tmp_path):
         """--allow-scripts lets a blocked-import script run via main()."""
         marker = tmp_path / "executed"
         extra = (
@@ -1875,21 +1904,15 @@ class TestAllowScriptsCLI:
             f"def render(slide, style, d): "
             f"Path(r'{marker}').write_text('ok')\n"
         )
-        content_dir, style_file = self._setup_with_extra(
-            tmp_path, extra
-        )
+        content_dir, style_file = self._setup_with_extra(tmp_path, extra)
         output = tmp_path / "deck.pptx"
 
         mock_prs = MagicMock()
         mock_prs.slides.__len__ = MagicMock(return_value=1)
         mock_prs.slide_layouts = MagicMock()
         layout = MagicMock()
-        mock_prs.slide_layouts.__getitem__ = MagicMock(
-            return_value=layout
-        )
-        mock_prs.slide_layouts.__iter__ = MagicMock(
-            return_value=iter([layout])
-        )
+        mock_prs.slide_layouts.__getitem__ = MagicMock(return_value=layout)
+        mock_prs.slide_layouts.__iter__ = MagicMock(return_value=iter([layout]))
         layout.name = "Blank"
         slide = MagicMock()
         mock_prs.slides.add_slide.return_value = slide
@@ -1899,9 +1922,12 @@ class TestAllowScriptsCLI:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
                 "--allow-scripts",
             ],
         ):
@@ -1910,26 +1936,18 @@ class TestAllowScriptsCLI:
         assert marker.read_text() == "ok"
 
     @patch("build_deck.Presentation")
-    def test_no_allow_scripts_rejects_blocked_import(
-        self, mock_prs_cls, tmp_path
-    ):
+    def test_no_allow_scripts_rejects_blocked_import(self, mock_prs_cls, tmp_path):
         """Without --allow-scripts, a blocked-import script fails."""
         extra = "import os\ndef render(s, st, d): pass\n"
-        content_dir, style_file = self._setup_with_extra(
-            tmp_path, extra
-        )
+        content_dir, style_file = self._setup_with_extra(tmp_path, extra)
         output = tmp_path / "deck.pptx"
 
         mock_prs = MagicMock()
         mock_prs.slides.__len__ = MagicMock(return_value=1)
         mock_prs.slide_layouts = MagicMock()
         layout = MagicMock()
-        mock_prs.slide_layouts.__getitem__ = MagicMock(
-            return_value=layout
-        )
-        mock_prs.slide_layouts.__iter__ = MagicMock(
-            return_value=iter([layout])
-        )
+        mock_prs.slide_layouts.__getitem__ = MagicMock(return_value=layout)
+        mock_prs.slide_layouts.__iter__ = MagicMock(return_value=iter([layout]))
         layout.name = "Blank"
         slide = MagicMock()
         mock_prs.slides.add_slide.return_value = slide
@@ -1939,9 +1957,12 @@ class TestAllowScriptsCLI:
             "sys.argv",
             [
                 "build_deck.py",
-                "--content-dir", str(content_dir),
-                "--style", str(style_file),
-                "--output", str(output),
+                "--content-dir",
+                str(content_dir),
+                "--style",
+                str(style_file),
+                "--output",
+                str(output),
             ],
         ):
             with pytest.raises(ContentExtraError):

--- a/.github/skills/experimental/powerpoint/tests/test_render_pdf_images.py
+++ b/.github/skills/experimental/powerpoint/tests/test_render_pdf_images.py
@@ -298,15 +298,18 @@ class TestMainRenderPdf:
 
     @patch("render_pdf_images.run", side_effect=BrokenPipeError)
     def test_main_broken_pipe(self, mock_run, tmp_path):
-        with patch(
-            "sys.argv",
-            [
-                "render_pdf_images.py",
-                "--input",
-                str(tmp_path / "test.pdf"),
-                "--output-dir",
-                str(tmp_path / "out"),
-            ],
-        ), patch.object(sys, "stderr", MagicMock()):
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "render_pdf_images.py",
+                    "--input",
+                    str(tmp_path / "test.pdf"),
+                    "--output-dir",
+                    str(tmp_path / "out"),
+                ],
+            ),
+            patch.object(sys, "stderr", MagicMock()),
+        ):
             result = main()
         assert result == EXIT_FAILURE

--- a/.github/skills/experimental/powerpoint/tests/test_validate_deck.py
+++ b/.github/skills/experimental/powerpoint/tests/test_validate_deck.py
@@ -353,7 +353,5 @@ class TestCreateParserPerSlideDir:
 
     def test_per_slide_dir_arg(self):
         parser = create_parser()
-        args = parser.parse_args(
-            ["--input", "test.pptx", "--per-slide-dir", "output/"]
-        )
+        args = parser.parse_args(["--input", "test.pptx", "--per-slide-dir", "output/"])
         assert str(args.per_slide_dir) == "output"

--- a/.github/skills/experimental/powerpoint/tests/test_validate_slides.py
+++ b/.github/skills/experimental/powerpoint/tests/test_validate_slides.py
@@ -177,9 +177,7 @@ class TestCreateParser:
 
     def test_required_image_dir_and_prompt(self):
         parser = create_parser()
-        args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check slides"]
-        )
+        args = parser.parse_args(["--image-dir", "images/", "--prompt", "Check slides"])
         assert str(args.image_dir) == "images"
         assert args.prompt == "Check slides"
 
@@ -195,15 +193,12 @@ class TestCreateParser:
         parser = create_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(
-                ["--image-dir", "images/",
-                 "--prompt", "A", "--prompt-file", "B"]
+                ["--image-dir", "images/", "--prompt", "A", "--prompt-file", "B"]
             )
 
     def test_defaults(self):
         parser = create_parser()
-        args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check"]
-        )
+        args = parser.parse_args(["--image-dir", "images/", "--prompt", "Check"])
         assert args.model == "claude-haiku-4.5"
         assert args.output is None
         assert args.slides is None
@@ -212,39 +207,32 @@ class TestCreateParser:
     def test_model_override(self):
         parser = create_parser()
         args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check",
-             "--model", "gpt-4o"]
+            ["--image-dir", "images/", "--prompt", "Check", "--model", "gpt-4o"]
         )
         assert args.model == "gpt-4o"
 
     def test_output_arg(self):
         parser = create_parser()
         args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check",
-             "--output", "results.json"]
+            ["--image-dir", "images/", "--prompt", "Check", "--output", "results.json"]
         )
         assert str(args.output) == "results.json"
 
     def test_slides_arg(self):
         parser = create_parser()
         args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check",
-             "--slides", "1,3,5"]
+            ["--image-dir", "images/", "--prompt", "Check", "--slides", "1,3,5"]
         )
         assert args.slides == "1,3,5"
 
     def test_verbose_flag(self):
         parser = create_parser()
-        args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check", "-v"]
-        )
+        args = parser.parse_args(["--image-dir", "images/", "--prompt", "Check", "-v"])
         assert args.verbose is True
 
     def test_no_concurrency_arg(self):
         parser = create_parser()
-        args = parser.parse_args(
-            ["--image-dir", "images/", "--prompt", "Check"]
-        )
+        args = parser.parse_args(["--image-dir", "images/", "--prompt", "Check"])
         assert not hasattr(args, "concurrency")
 
 
@@ -267,9 +255,7 @@ class TestLoadPrompt:
         assert load_prompt(args) == "File prompt content"
 
     def test_exits_on_missing_file(self, tmp_path):
-        args = argparse.Namespace(
-            prompt=None, prompt_file=tmp_path / "missing.txt"
-        )
+        args = argparse.Namespace(prompt=None, prompt_file=tmp_path / "missing.txt")
         with pytest.raises(SystemExit):
             load_prompt(args)
 
@@ -288,9 +274,7 @@ class TestValidateSlide:
         image = tmp_path / "slide-001.jpg"
         image.write_bytes(b"img")
 
-        result = asyncio.run(
-            validate_slide(session, 1, image, "Check")
-        )
+        result = asyncio.run(validate_slide(session, 1, image, "Check"))
         assert result["slide_number"] == 1
         assert result["response"] == "No issues"
         assert "error" not in result
@@ -305,9 +289,7 @@ class TestValidateSlide:
         image = tmp_path / "slide-002.jpg"
         image.write_bytes(b"img")
 
-        result = asyncio.run(
-            validate_slide(session, 2, image, "Check", max_retries=2)
-        )
+        result = asyncio.run(validate_slide(session, 2, image, "Check", max_retries=2))
         assert result["response"] == "OK"
         assert session.send_and_wait.call_count == 2
 
@@ -317,9 +299,7 @@ class TestValidateSlide:
         image = tmp_path / "slide-003.jpg"
         image.write_bytes(b"img")
 
-        result = asyncio.run(
-            validate_slide(session, 3, image, "Check", max_retries=2)
-        )
+        result = asyncio.run(validate_slide(session, 3, image, "Check", max_retries=2))
         assert "error" in result
         assert "2 attempts" in result["error"]
         assert result["slide_number"] == 3
@@ -349,9 +329,7 @@ class TestRun:
         args = _make_args(image_dir=tmp_path)
 
         mock_session = AsyncMock()
-        mock_session.send_and_wait.return_value = _make_session_response(
-            "No issues"
-        )
+        mock_session.send_and_wait.return_value = _make_session_response("No issues")
         mock_client = AsyncMock()
         mock_client.create_session.return_value = mock_session
         mock_client_cls.return_value = mock_client
@@ -371,9 +349,7 @@ class TestRun:
         args = _make_args(image_dir=tmp_path, output=out_file)
 
         mock_session = AsyncMock()
-        mock_session.send_and_wait.return_value = _make_session_response(
-            "All good"
-        )
+        mock_session.send_and_wait.return_value = _make_session_response("All good")
         mock_client = AsyncMock()
         mock_client.create_session.return_value = mock_session
         mock_client_cls.return_value = mock_client
@@ -390,9 +366,7 @@ class TestRun:
         args = _make_args(image_dir=tmp_path)
 
         mock_session = AsyncMock()
-        mock_session.send_and_wait.return_value = _make_session_response(
-            "Finding text"
-        )
+        mock_session.send_and_wait.return_value = _make_session_response("Finding text")
         mock_client = AsyncMock()
         mock_client.create_session.return_value = mock_session
         mock_client_cls.return_value = mock_client

--- a/scripts/linting/Invoke-PythonLint.ps1
+++ b/scripts/linting/Invoke-PythonLint.ps1
@@ -35,7 +35,7 @@ function Invoke-PythonLint {
     Push-Location $RepoRoot
     try {
         # Find all directories with pyproject.toml
-        $pythonSkills = Get-ChildItem -Path . -Filter 'pyproject.toml' -Recurse -File |
+        $pythonSkills = Get-ChildItem -Path . -Filter 'pyproject.toml' -Recurse -Force -File |
             Where-Object { $_.FullName -notmatch 'node_modules' } |
             ForEach-Object { $_.Directory.FullName }
 

--- a/scripts/linting/Invoke-PythonTests.ps1
+++ b/scripts/linting/Invoke-PythonTests.ps1
@@ -41,7 +41,7 @@ function Invoke-PythonTests {
     Push-Location $RepoRoot
     try {
         # Find all directories with pyproject.toml
-        $pythonSkills = Get-ChildItem -Path . -Filter 'pyproject.toml' -Recurse -File |
+        $pythonSkills = Get-ChildItem -Path . -Filter 'pyproject.toml' -Recurse -Force -File |
             Where-Object { $_.FullName -notmatch 'node_modules' } |
             ForEach-Object { $_.Directory.FullName }
 


### PR DESCRIPTION
The stable release pipeline failed because pre-existing ruff violations in the experimental powerpoint skill were exposed for the first time after the `-Force` fix in PR #1043 enabled `Get-ChildItem` to traverse hidden directories like `.github/`. This PR applied **ruff format** and **ruff check** fixes across all Python files in the powerpoint skill and added the same `-Force` parameter to two local PowerShell linting scripts that had the same hidden-directory traversal gap.

> The CI difference that masked these violations: *pr-validation.yml* uses `changed-files-only: true`, so PR #1043 (which only changed YAML files) never linted the powerpoint Python files. *release-stable.yml* uses `changed-files-only: false`, which correctly surfaced the violations after merge.

## Description

### PowerShell Script Fix

Added `-Force` to `Get-ChildItem -Recurse` in two local linting scripts so they discover Python skills under hidden directories consistently with CI workflows.

- *scripts/linting/Invoke-PythonLint.ps1* — added `-Force` at line 38 to ensure `.github/` subtree traversal during local ruff runs
- *scripts/linting/Invoke-PythonTests.ps1* — same `-Force` addition at line 44 to keep test discovery aligned with lint discovery

### Python Formatting

Applied **ruff format** to 7 files under `.github/skills/experimental/powerpoint/`. All changes are mechanical whitespace and line-break adjustments with no semantic impact.

- *scripts/build_deck.py* — reformatted `frozenset` literals, expanded multi-argument function signatures to one-parameter-per-line, collapsed short f-string `raise` statements, reformatted dictionary comprehensions
- *scripts/extract_content.py* — expanded multi-argument function signatures to one-parameter-per-line
- *scripts/pptx_colors.py* — expanded `resolve_color` function signature to one-parameter-per-line
- *tests/test_build_deck.py* — reformatted long function calls, converted nested `with` statements to parenthesized context managers, fixed three **E501** line-too-long violations at lines 920, 940, and 954
- *tests/test_render_pdf_images.py* — converted nested `with` statement to parenthesized context manager
- *tests/test_validate_deck.py* — collapsed `parse_args` call onto a single line
- *tests/test_validate_slides.py* — collapsed short `parse_args` and `Namespace` calls onto single lines, removed unnecessary line breaks

## Related Issue(s)

Fixes #1047

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [x] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

- `ruff check .` reported 0 errors after applying fixes
- `ruff format --check .` confirmed all files clean
- `npm run lint:py` discovered 1 Python skill and passed lint and format checks
- `npm run lint:ps` scanned 93 PowerShell files with 0 issues

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`