### PR TITLE
fix(workflows): add uv.lock dependencies submission have fork-skip condition

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,6 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Submit uv.lock dependencies  # Skipped on fork PRs (read-only token)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927 # v0.1.1
         with:
           detectorArgs: 'UvLock=EnableIfDefaultOff'


### PR DESCRIPTION
## Description

Add a fork-detection `if:` condition to the "Submit uv.lock dependencies" step in the dependency-review workflow. The Dependency Submission API requires `contents: write`, but GitHub automatically downgrades fork PR tokens to read-only, causing the step to fail with `HttpError: Resource not accessible by integration`. The existing code comment indicated the step should be skipped on fork PRs, but no condition enforced this.

The fix adds `if: github.event.pull_request.head.repo.full_name == github.repository` so the step runs only for same-repo PRs. The Dependency Review step (which only needs read access) continues to run for all PRs including forks.

## Related Issue(s)

Closes #1108

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

* YAML lint passes: `npm run lint:yaml`
* Verified the condition syntax matches GitHub Actions expression documentation
* Confirmed all 29 other checks pass on the affected fork PR (#1008); only "Review Dependencies" fails due to this missing condition

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Single-line fix. The `if:` condition uses the standard GitHub Actions fork detection pattern comparing `github.event.pull_request.head.repo.full_name` against `github.repository`. When they differ, the PR originates from a fork and the Dependency Submission API call is skipped. The subsequent Dependency Review step runs unconditionally for all PRs.
