### PR TITLE
chore(build): add clean:logs npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "plugin:postprocess": "markdownlint-cli2 \"plugins/**/*.md\" \"collections/*.md\" --fix && markdown-table-formatter \"plugins/**/*.md\" && markdown-table-formatter \"collections/*.md\"",
     "plugin:generate": "pwsh -File scripts/plugins/Generate-Plugins.ps1 && npm run plugin:postprocess",
     "plugin:validate": "npm run lint:collections-metadata",
+    "clean:logs": "pwsh -NoProfile -Command \"Get-ChildItem -Path logs -File -Recurse | Remove-Item -Force\"",
     "docs:build": "npm --prefix docs/docusaurus run build",
     "docs:serve": "npm --prefix docs/docusaurus run serve"
   },


### PR DESCRIPTION
## Summary

Add a `clean:logs` npm script to clear generated files from the `logs/` directory.

## Changes

- Add `clean:logs` script to `package.json` using `pwsh -NoProfile` to recursively remove files from `logs/`

The `logs/` directory is gitignored and accumulates validation output files (`pester-summary.json`, `psscriptanalyzer-results.json`, etc.) across runs. This script provides a convenient way to reset them.

## Usage

```bash
npm run clean:logs
```

Closes #988