### PR TITLE
fix(build): override Linguist vendored flag for Python skill files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,10 @@
 *.docx binary
 *.jpg binary
 *.png binary
+
+# Override Linguist vendored classification for Python skill files.
+# GitHub Linguist excludes .github/ via its vendor.yml regex, hiding Python
+# from the Languages API. OSSF Scorecard only checks fuzz specs for languages
+# that appear in that API, so without this override the Atheris harness is
+# invisible and Fuzzing scores 0/10.
+.github/skills/**/*.py linguist-vendored=false

--- a/.gitignore
+++ b/.gitignore
@@ -346,9 +346,7 @@ paket-files/
 **/__pycache__/
 **/.hypothesis/
 **/.pytest_cache/
-**/.hypothesis/
 **/.ruff_cache/
-**/.hypothesis/
 *.pyc
 venv/
 .venv/


### PR DESCRIPTION
## Description

GitHub Linguist's *vendor.yml* classifies the entire `.github/` directory as vendored, which excluded all Python skill files from the repository's Languages API. OSSF Scorecard's Fuzzing check only evaluates languages that appear in that API, so the Atheris fuzz harness merged in PR #1102 remained invisible and **Fuzzing scored 0/10** despite correct test infrastructure.

> The root cause was a mismatch between where skills live (`.github/skills/`) and Linguist's vendored-path regex. The fix adds a targeted `.gitattributes` override rather than relocating files.

- Added **`linguist-vendored=false`** for `.github/skills/**/*.py` in *.gitattributes*, overriding the vendored classification so Python appears in language statistics
- Included an explanatory comment documenting the Linguist vendor.yml interaction with OSSF Scorecard for future maintainers
- Removed two duplicate `**/.hypothesis/` entries from *.gitignore* (the file contained three identical lines; one remains)

## Related Issue(s)

None

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

- Verified `git check-attr linguist-vendored -- .github/skills/experimental/powerpoint/tests/fuzz_harness.py` returns `false`, confirming the override is active.
- Confirmed the `.github/skills/**/*.py` glob covers all 35 Python files (427,782 bytes), approximately 3.5x the Linguist prominence threshold.
- Ran `npm run validate:skills` — all 9 skills passed with 0 errors.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

- The 35 Python files under `.github/skills/` total approximately 427,782 bytes, which is well above the Linguist prominence threshold (~122,000 bytes). Even if small files are added or removed, Python visibility in the Languages API remains stable.
- No new dependencies were introduced. The change is purely metadata (`.gitattributes` and `.gitignore`).