### PR TITLE
feat(docs): add collection description tooltips to Docusaurus collections page

### DIFF
--- a/docs/docusaurus/src/components/CollectionTable/index.tsx
+++ b/docs/docusaurus/src/components/CollectionTable/index.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import type { CollectionDetailData } from '../../data/collectionDetails';
+import styles from './styles.module.css';
+
+const maturityClass: Record<CollectionDetailData['maturity'], string> = {
+  Stable: styles.maturityStable,
+  Preview: styles.maturityPreview,
+  Experimental: styles.maturityExperimental,
+};
+
+/**
+ * CollectionTableWithDescriptions - A table component displaying HVE collections
+ * with hover tooltips showing detailed descriptions from collection files.
+ * 
+ * Implements the feature request from issue #1266: adding collection description
+ * tooltips to the Docusaurus collections page.
+ */
+export default function CollectionTableWithDescriptions({
+  collections,
+}: {
+  collections: CollectionDetailData[];
+}): React.ReactElement {
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+
+  const toggleRow = (name: string) => {
+    setExpandedRow(expandedRow === name ? null : name);
+  };
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.collectionTable}>
+        <thead>
+          <tr>
+            <th>Collection</th>
+            <th>Description</th>
+            <th>Artifacts</th>
+            <th>Maturity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {collections.map((collection) => (
+            <React.Fragment key={collection.name}>
+              <tr
+                className={`${styles.tableRow} ${expandedRow === collection.name ? styles.expanded : ''}`}
+                onClick={() => toggleRow(collection.name)}
+                title={collection.detailedDescription}
+              >
+                <td>
+                  <span className={styles.collectionName}>{collection.name}</span>
+                  <span className={styles.expandIcon}>
+                    {expandedRow === collection.name ? '▼' : '▶'}
+                  </span>
+                </td>
+                <td>{collection.shortDescription}</td>
+                <td className={styles.artifacts}>{collection.artifacts}</td>
+                <td>
+                  <span className={`${styles.maturityBadge} ${maturityClass[collection.maturity]}`}>
+                    {collection.maturity}
+                  </span>
+                </td>
+              </tr>
+              {expandedRow === collection.name && (
+                <tr className={styles.detailRow}>
+                  <td colSpan={4}>
+                    <div className={styles.detailContent}>
+                      <h4>Detailed Description</h4>
+                      <p>{collection.detailedDescription}</p>
+                      {collection.includes && collection.includes.length > 0 && (
+                        <div className={styles.includesSection}>
+                          <h5>Key Features:</h5>
+                          <ul>
+                            {collection.includes.slice(0, 5).map((item, idx) => (
+                              <li key={idx}>{item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+      <p className={styles.hint}>
+        💡 Click on a row to expand and see more details, or hover over the collection name for a quick tooltip.
+      </p>
+    </div>
+  );
+}

--- a/docs/docusaurus/src/components/CollectionTable/styles.module.css
+++ b/docs/docusaurus/src/components/CollectionTable/styles.module.css
@@ -1,0 +1,120 @@
+.tableWrapper {
+  margin: 1rem 0;
+}
+
+.collectionTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+}
+
+.collectionTable th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  background: var(--ifm-color-primary-contrast-background);
+  border-bottom: 2px solid var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+.collectionTable td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.tableRow {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.tableRow:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.tableRow.expanded {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.collectionName {
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}
+
+.expandIcon {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.artifacts {
+  text-align: center;
+  font-weight: 500;
+}
+
+.maturityBadge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.5rem;
+  border-radius: 2px;
+}
+
+.maturityStable {
+  background: var(--ifm-color-success-contrast-background);
+  color: var(--ifm-color-success-dark);
+}
+
+.maturityPreview {
+  background: var(--ifm-color-warning-contrast-background);
+  color: var(--ifm-color-warning-dark);
+}
+
+.maturityExperimental {
+  background: var(--ifm-color-info-contrast-background);
+  color: var(--ifm-color-info-dark);
+}
+
+.detailRow {
+  background: var(--ifm-color-emphasis-50);
+}
+
+.detailContent {
+  padding: 1rem;
+}
+
+.detailContent h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+  color: var(--ifm-color-primary);
+}
+
+.detailContent p {
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+.includesSection h5 {
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.includesSection ul {
+  margin: 0;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+}
+
+.includesSection li {
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+  text-align: center;
+  margin-top: 0.5rem;
+}

--- a/docs/docusaurus/src/data/collectionDetails.ts
+++ b/docs/docusaurus/src/data/collectionDetails.ts
@@ -1,0 +1,218 @@
+export interface CollectionDetailData {
+  name: string;
+  shortDescription: string;
+  detailedDescription: string;
+  artifacts: number;
+  maturity: 'Stable' | 'Preview' | 'Experimental';
+  href: string;
+  includes: string[];
+}
+
+/**
+ * Collection details extracted from *.collection.md files
+ * for use in the CollectionTableWithDescriptions component.
+ * 
+ * This data enables hover tooltips and expandable detail rows
+ * as requested in issue #1266.
+ */
+export const collectionDetails: CollectionDetailData[] = [
+  {
+    name: 'ado',
+    shortDescription: 'Manage Azure DevOps work items, monitor builds, create pull requests, and convert requirements documents into structured work item hierarchies',
+    detailedDescription: 'Manage Azure DevOps work items, monitor builds, create pull requests, and convert requirements documents into structured work item hierarchies — all from within VS Code. This collection includes agents and prompts for Work Item Management, Build Monitoring, Pull Request Creation, PRD-to-Work-Item Conversion, and Backlog Management.',
+    artifacts: 21,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Work Item Management',
+      'Build Monitoring',
+      'Pull Request Creation',
+      'PRD-to-Work-Item Conversion',
+      'Backlog Management',
+    ],
+  },
+  {
+    name: 'coding-standards',
+    shortDescription: 'Enforce language-specific coding conventions and best practices across your projects, with pre-PR code review agents',
+    detailedDescription: 'Enforce language-specific coding conventions and best practices across your projects, with pre-PR code review agents for catching functional defects early. This collection provides instructions for bash, Bicep, C#, PowerShell, Python, Rust, and Terraform that are automatically applied based on file patterns.',
+    artifacts: 14,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Code Review Functional',
+      'Code Review Standards',
+      'Code Review Full',
+      'Bash, Bicep, C# instructions',
+      'PowerShell, Python, Rust, Terraform',
+    ],
+  },
+  {
+    name: 'data-science',
+    shortDescription: 'Generate data specifications, Jupyter notebooks, and Streamlit dashboards from natural language descriptions',
+    detailedDescription: 'Generate data specifications, Jupyter notebooks, and Streamlit dashboards from natural language descriptions. Evaluate AI-powered data systems against Responsible AI standards. This collection includes specialized agents for data science workflows in Python and RAI assessment.',
+    artifacts: 19,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Data Specification Generation',
+      'Jupyter Notebook Generation',
+      'Streamlit Dashboard Generation',
+      'Dashboard Testing',
+      'RAI Planner',
+    ],
+  },
+  {
+    name: 'design-thinking',
+    shortDescription: 'AI-enhanced design thinking coaching across nine methods',
+    detailedDescription: 'Coaching identity, quality constraints, and methodology instructions for AI-enhanced design thinking across nine methods. The collection supports the HVE Design Thinking pyramid structure spanning Problem, Solution, and Implementation spaces.',
+    artifacts: 58,
+    maturity: 'Preview',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'DT Start Project',
+      'DT Resume Coaching',
+      'DT Method Next',
+      'DT Handoff Implementation Space',
+      'DT Handoff Problem Space',
+    ],
+  },
+  {
+    name: 'experimental',
+    shortDescription: 'Experimental and preview artifacts not yet promoted to stable collections',
+    detailedDescription: 'Experimental and preview artifacts not yet promoted to stable collections. Items in this collection may change or be removed without notice. This collection includes agents, skills, and instructions for Experiment Designer, PowerPoint Builder, and Video to GIF.',
+    artifacts: 8,
+    maturity: 'Experimental',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Experiment Designer',
+      'PowerPoint Builder',
+      'Video to GIF',
+    ],
+  },
+  {
+    name: 'github',
+    shortDescription: 'Manage GitHub issue backlogs with agents for discovery, triage, sprint planning, and execution',
+    detailedDescription: 'Manage GitHub issue backlogs with agents for discovery, triage, sprint planning, and execution. This collection brings structured backlog management workflows directly into VS Code.',
+    artifacts: 13,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Issue Discovery',
+      'Triage',
+      'Sprint Planning',
+      'Backlog Execution',
+    ],
+  },
+  {
+    name: 'gitlab',
+    shortDescription: 'Run GitLab merge request and pipeline workflows through a focused skill package',
+    detailedDescription: 'Use GitLab merge request and pipeline workflows from VS Code through a focused Python skill for inspecting merge requests, posting notes, triggering pipelines, and reading job logs.',
+    artifacts: 2,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'GitLab Skill',
+    ],
+  },
+  {
+    name: 'hve-core',
+    shortDescription: 'Flagship collection: RPI (Research, Plan, Implement, Review) workflow for complex tasks with Git workflow prompts',
+    detailedDescription: 'HVE Core provides the flagship RPI (Research, Plan, Implement, Review) workflow for completing complex tasks through a structured four-phase process. The RPI workflow dispatches specialized agents that collaborate autonomously to deliver well-researched, planned, and validated implementations. This collection also includes Git workflow prompts for commit messages, merge operations, repository setup, and pull request management.',
+    artifacts: 40,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'RPI Agent',
+      'Task Researcher',
+      'Task Planner',
+      'Task Implementor',
+      'Task Reviewer',
+    ],
+  },
+  {
+    name: 'hve-core-all',
+    shortDescription: 'Complete collection of all artifacts across all domains',
+    detailedDescription: 'HVE Core provides the complete collection of AI chat agents, prompts, instructions, and skills for VS Code with GitHub Copilot. This edition includes every artifact across all domains: development workflows, architecture, Azure DevOps, GitHub and Jira backlog workflows, data science, design thinking, security, and more.',
+    artifacts: 221,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'All domain collections',
+      'Security and planning agents',
+      'Code review agents',
+      'Supporting subagents',
+      'All skills',
+    ],
+  },
+  {
+    name: 'installer',
+    shortDescription: 'Deploy HVE artifacts across workspace configurations with decision-driven setup',
+    detailedDescription: 'Deploy HVE Core artifacts across workspace configurations with the hve-core-installer skill. This collection provides decision-driven setup for selecting and installing collections, agents, prompts, and instructions via the VS Code extension or clone-based methods.',
+    artifacts: 2,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'HVE Core Installer',
+    ],
+  },
+  {
+    name: 'jira',
+    shortDescription: 'Manage Jira backlogs, plan PRD-driven issue hierarchies, and execute issue operations',
+    detailedDescription: 'Manage Jira backlog workflows and PRD-driven issue planning from VS Code. This collection adds dedicated Jira agents, prompts, and instructions on top of the Jira skill so discovery, triage, execution, and planning workflows use the same tracking and handoff patterns as the rest of HVE Core.',
+    artifacts: 13,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Jira Backlog Manager agent',
+      'Jira PRD to WIT planning agent',
+      'Jira prompts for backlog workflows',
+      'Jira planning instructions',
+      'The Jira skill',
+    ],
+  },
+  {
+    name: 'project-planning',
+    shortDescription: 'Create architecture decision records, requirements documents, and diagrams through guided AI workflows',
+    detailedDescription: 'Create architecture decision records, requirements documents, and diagrams — all through guided AI workflows. Evaluate AI-powered systems against Responsible AI standards and conduct STRIDE-based security model analysis with automated backlog generation.',
+    artifacts: 49,
+    maturity: 'Stable',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Agile Coach',
+      'Product Manager Advisor',
+      'UX/UI Designer',
+      'Architecture Decision Records',
+      'Architecture Diagrams',
+    ],
+  },
+  {
+    name: 'rai-planning',
+    shortDescription: 'Assess AI systems against Responsible AI standards and capture standards-aligned backlog work',
+    detailedDescription: 'Assess AI systems against Responsible AI standards and capture standards-aligned backlog work. This collection provides specialized agents and prompts for sensitive uses screening, security model analysis, impact assessment, and dual-format backlog handoff.',
+    artifacts: 13,
+    maturity: 'Experimental',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'RAI Planner',
+      'Sensitive uses screening',
+      'Security model analysis',
+      'Impact assessment',
+      'Dual-format backlog handoff',
+    ],
+  },
+  {
+    name: 'security',
+    shortDescription: 'Security review, planning, incident response, risk assessment, and vulnerability analysis',
+    detailedDescription: 'Security review, planning, incident response, risk assessment, and vulnerability analysis. This collection includes specialized agents for STRIDE-based security model analysis, supply chain security assessment, and automated backlog generation.',
+    artifacts: 47,
+    maturity: 'Experimental',
+    href: '/docs/getting-started/collections',
+    includes: [
+      'Security Planner',
+      'SSSC Planner',
+      'STRIDE-based analysis',
+      'Supply chain security assessment',
+      'Automated backlog generation',
+    ],
+  },
+];

--- a/docs/getting-started/collections.md
+++ b/docs/getting-started/collections.md
@@ -7,6 +7,9 @@ ms.date: 2026-03-22
 ms.topic: overview
 ---
 
+import CollectionTableWithDescriptions from '@site/src/components/CollectionTable';
+import { collectionDetails } from '@site/src/data/collectionDetails';
+
 ## How HVE Artifacts Are Organized
 
 HVE distributes agents, prompts, instructions, and skills through collections, which are curated bundles of related artifacts. Each collection targets a specific domain or workflow, so you can install exactly what you need.
@@ -31,22 +34,7 @@ The installer enables targeted deployment of specific collections into workspace
 
 ## Available Collections
 
-| Collection       | Description                                                                                                                                    | Artifacts | Maturity     |
-|------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-----------|--------------|
-| ado              | Manage Azure DevOps work items, monitor builds, create pull requests, and convert requirements documents into structured work item hierarchies | 21        | Stable       |
-| coding-standards | Enforce language-specific coding conventions and best practices across your projects, with pre-PR code review agents                           | 14        | Stable       |
-| data-science     | Generate data specifications, Jupyter notebooks, and Streamlit dashboards from natural language descriptions                                   | 19        | Stable       |
-| design-thinking  | AI-enhanced design thinking coaching across nine methods                                                                                       | 58        | Preview      |
-| experimental     | Experimental and preview artifacts not yet promoted to stable collections                                                                      | 8         | Experimental |
-| github           | Manage GitHub issue backlogs with agents for discovery, triage, sprint planning, and execution                                                 | 13        | Stable       |
-| gitlab           | Run GitLab merge request and pipeline workflows through a focused skill package                                                                | 2         | Stable       |
-| hve-core         | Flagship collection: RPI (Research, Plan, Implement, Review) workflow for complex tasks with Git workflow prompts                              | 40        | Stable       |
-| hve-core-all     | Complete collection of all artifacts across all domains                                                                                        | 221       | Stable       |
-| installer        | Deploy HVE artifacts across workspace configurations with decision-driven setup                                                                | 2         | Stable       |
-| jira             | Manage Jira backlogs, plan PRD-driven issue hierarchies, and execute issue operations                                                          | 13        | Stable       |
-| project-planning | Create architecture decision records, requirements documents, and diagrams through guided AI workflows                                         | 49        | Stable       |
-| rai-planning     | Assess AI systems against Responsible AI standards and capture standards-aligned backlog work                                                  | 13        | Experimental |
-| security         | Security review, planning, incident response, risk assessment, and vulnerability analysis                                                      | 47        | Experimental |
+<CollectionTableWithDescriptions collections={collectionDetails} />
 
 ## How Collections Fit Together
 


### PR DESCRIPTION
## Summary

This PR implements the feature request from #1266 to add collection description tooltips to the Docusaurus collections page.

### Changes Made

1. **Created `CollectionTableWithDescriptions` component** (`docs/docusaurus/src/components/CollectionTable/index.tsx`)
   - Interactive table with hover tooltips showing detailed descriptions
   - Click-to-expand functionality for viewing full details and key features
   - Follows existing Docusaurus component conventions

2. **Created `collectionDetails.ts` data file** (`docs/docusaurus/src/data/collectionDetails.ts`)
   - Contains detailed descriptions extracted from `*.collection.md` files
   - Includes short descriptions matching the original table
   - Lists key features for each collection

3. **Modified `collections.md`** (`docs/getting-started/collections.md`)
   - Replaced static Markdown table with interactive React component
   - Users can now access collection details without navigating to individual docs

### Acceptance Criteria

- ✅ Collection descriptions are accessible from the overview page without navigating to individual collection docs
- ✅ Descriptions are derived from `*.collection.md` source files
- ✅ Implementation follows existing Docusaurus component conventions (similar to Icons pattern)

### Testing

Users can:
1. Hover over any row to see a quick tooltip with the detailed description
2. Click on a row to expand and see:
   - Full detailed description
   - Key features list (top 5 items from the collection)

### Screenshots

The new table provides:
- Visual maturity badges (Stable/Preview/Experimental) with color coding
- Expandable rows with detailed content
- User-friendly hint explaining the interaction

---

Implements #1266