### PR TITLE
fix(agents): add parallel subagent dispatch and structured JSON contracts to code-review-full

### DIFF
--- a/.github/agents/coding-standards/code-review-full.agent.md
+++ b/.github/agents/coding-standards/code-review-full.agent.md
@@ -18,80 +18,228 @@ Orchestrator that runs a two-phase code review on code changes by delegating to 
 
 * Story reference (optional): a work item ID matching patterns like `AIAA-123` or `AB#456`. When provided, forward to the standards subagent so it can prompt for the story definition and include an Acceptance Criteria Coverage table.
 
+## Response Format
+
+Emit these announcements at the specified moments. Include them in the conversation response so the user sees live progress.
+
+### Step 1 Announcement
+
+Emit after diff computation completes:
+
+```markdown
+**🔍 Code Review Full, Step 1: Diff computed**
+
+| Field  | Value                       |
+|--------|-----------------------------|
+| Branch | `<branch>` → `<base>`       |
+| Files  | <N> source files in scope   |
+| Status | ✅ Ready for parallel review |
+```
+
+### Step 2a Announcement
+
+Emit immediately after subagents are dispatched. When a subagent is unavailable, show `⏭️ Skipped` instead of `⏳ Running`:
+
+```markdown
+**🔍 Code Review Full, Step 2: Parallel reviews dispatched**
+
+| Reviewer   | Status                 |
+|------------|------------------------|
+| Functional | ⏳ Running / ⏭️ Skipped |
+| Standards  | ⏳ Running / ⏭️ Skipped |
+```
+
+### Step 2b Announcement
+
+Emit after both subagents complete:
+
+```markdown
+**🔍 Code Review Full, Step 2: Both reviews complete**
+
+| Reviewer   | Findings                                       | Verdict |
+|------------|------------------------------------------------|---------|
+| Functional | <N> Critical · <N> High · <N> Medium · <N> Low | <emoji> |
+| Standards  | <N> Critical · <N> High · <N> Medium · <N> Low | <emoji> |
+```
+
+### L/XL Batch Announcement Variant
+
+For L or XL reviews, replace the two-reviewer rows in Step 2a/2b with one row per batch. Emit ⏳ when the batch is dispatched and ✅ when it completes.
+
+Step 2a (all batches dispatched):
+
+```markdown
+**🔍 Code Review Full, Step 2: Batch reviews dispatched**
+
+| Batch   | Status    |
+|---------|-----------|
+| Batch 1 | ⏳ Running |
+| Batch 2 | ⏳ Running |
+```
+
+Step 2b (all batches complete): replace the running table with a 3-column summary:
+
+```markdown
+**🔍 Code Review Full, Step 2: All batches complete**
+
+| Batch   | Findings                                       | Verdict |
+|---------|------------------------------------------------|---------|
+| Batch 1 | <N> Critical · <N> High · <N> Medium · <N> Low | <emoji> |
+| Batch 2 | <N> Critical · <N> High · <N> Medium · <N> Low | <emoji> |
+| Total   | <N> Critical · <N> High · <N> Medium · <N> Low | <emoji> |
+```
+
+## Read Discipline
+
+Read every external file exactly once using a single full-range `read_file` call. Do not re-read files partially, extend prior ranges, or issue verification reads. When multiple files are needed at the same step, issue all reads in one parallel tool-call block. This rule applies to diff content, instructions files, findings JSON, and review-artifact protocols throughout all steps.
+
 ## Required Steps
 
 ### Step 1: Compute Diff
 
 Run the diff a single time so both review phases operate on the same input without redundant git operations.
 
-Follow the complete protocol in #file:../../instructions/coding-standards/code-review/diff-computation.instructions.md to detect the diff type, run the appropriate git commands, filter non-source artifacts, and handle large diffs.
+Use the Decision Tree in #file:../../instructions/coding-standards/code-review/diff-computation.instructions.md to determine the diff type. Apply the Non-Source Artifact Skip List and Large Diff Handling rules from that file.
 
-Store the resulting **diff content** and **changed file list** for use in Steps 2 and 3. Do not embed full file contents in subagent prompts; pass only the diff output and the changed file list. Subagents read source files from disk when they need additional context beyond the diff.
+#### Pre-clean findings folder
 
-### Step 2: Functional Code Review
+Before writing any review artifacts, remove stale outputs from prior runs. Using the branch name already determined by the Decision Tree, derive the findings folder path (replacing `/` with `-`) and recreate it:
 
-Invoke `Code Review Functional` subagent via `runSubagent`, providing the pre-computed diff, changed file list, and this instruction: `"A pre-computed diff and changed file list are provided — skip diff computation. Skip artifact persistence; the orchestrator handles it via rule 12."`
+* **Bash/Zsh**: `rm -rf ".copilot-tracking/reviews/code-reviews/<sanitized-branch>" && mkdir -p ".copilot-tracking/reviews/code-reviews/<sanitized-branch>"`
+* **PowerShell**: `Remove-Item -Recurse -Force ".copilot-tracking/reviews/code-reviews/<sanitized-branch>" -ErrorAction SilentlyContinue; New-Item -ItemType Directory -Path ".copilot-tracking/reviews/code-reviews/<sanitized-branch>" -Force`
 
-The subagent returns findings in its native format. If the subagent returns clarifying questions instead of findings, surface the questions to the user, collect answers, and re-invoke the subagent with the answers included. If the subagent returns questions a second time, skip the step.
+Use whichever variant matches the active terminal.
 
-If the subagent is not available, skip this step and note: "Code Review Functional agent not available, skipping Step 2."
+#### Generate PR reference
 
-### Step 3: Standards Code Review
+Invoke the `pr-reference` skill to produce the structured XML diff following the Feature Branch Diff section in diff-computation.instructions.md:
 
-Invoke `Code Review Standards` subagent via `runSubagent`, providing the pre-computed diff, changed file list, and this instruction: `"A pre-computed diff and changed file list are provided — skip diff computation. Skip Step 4 artifact persistence; the orchestrator handles it via rule 12."` Forward any story reference from the original user input.
+1. Generate the structured diff: `generate.sh --base-branch auto --merge-base --exclude-ext min.js,min.css,map`
+2. Get the changed file list: `list-changed-files.sh --exclude-type deleted --format plain`
+3. For large diffs, use chunk planning: `read-diff.sh --info` then `read-diff.sh --chunk N`
 
-The subagent returns findings in its native format. Handle clarifying questions the same way as Step 2.
+#### Working-tree supplement
 
-If the subagent is not available, skip this step and note: "Code Review Standards agent not available, skipping Step 3."
+After generating the PR reference, apply the working-tree supplement from the Feature Branch Diff case in diff-computation.instructions.md. This captures untracked, unstaged, and staged files that the committed diff does not cover. Merge the surviving paths into the changed file list produced by `list-changed-files.sh`, deduplicating entries that already appear in the committed diff.
 
-### Step 4: Merged Report
+#### Write diff-state.json
+
+After diff computation completes, extract the branch name, base branch, changed file list, and diff line count from the pr-reference output and terminal results. Write a single `diff-state.json` to the findings folder:
+
+```json
+{
+  "branch": "<branch-name>",
+  "base": "<base-branch>",
+  "files": ["<file1>", "<file2>"],
+  "untrackedFiles": ["<path1>", "<path2>"],
+  "extensions": ["<ext1>", "<ext2>"],
+  "tshirtSize": "<XS|S|M|L|XL>",
+  "diffPatchPath": ".copilot-tracking/pr/pr-reference.xml",
+  "findingsFolder": ".copilot-tracking/reviews/code-reviews/<sanitized-branch>/"
+}
+```
+
+The `untrackedFiles` array lists paths that have no committed diff. Subagents read these files in full and treat all lines as in-scope for findings. Omit the field or use an empty array when no untracked files exist.
+
+#### T-Shirt Size Classification
+
+Classify the review size and record it in `diff-state.json`:
+
+| T-Shirt | Files | Diff Lines  | Strategy                                                |
+|---------|-------|-------------|---------------------------------------------------------|
+| XS      | <5    | <100        | File path to diff; single parallel pair                 |
+| S       | 5–19  | 100–399     | File path to diff; single parallel pair                 |
+| M       | 20–49 | 400–999     | File path to diff; single parallel pair                 |
+| L       | 50–99 | 1,000–2,999 | File path to diff; batches of ≤30 files per pair        |
+| XL      | 100+  | 3,000+      | File path to diff; multi-round batches, high-risk first |
+
+For L and XL reviews, split the file list into batches and create one `diff-state-batch-N.json` per batch in the same findings folder. Each batch JSON carries its subset of files in `files` (the reporting scope), references the **same full `diffPatchPath`** as the root `diff-state.json`, and includes a `findingsFile` field set to `findings-batch-N.json`. Subagents report findings only for their batch files but may read the full diff for cross-file context.
+
+When files and lines fall in different tiers, use the **smaller** tier.
+
+Emit the **Step 1 Announcement** defined in Response Format before proceeding.
+
+### Step 2: Parallel Code Reviews
+
+Check agent availability before invoking:
+
+* If `Code Review Functional` is not available, skip the functional review and note: "Code Review Functional agent not available, skipping functional review."
+* If `Code Review Standards` is not available, skip the standards review and note: "Code Review Standards agent not available, skipping standards review."
+
+#### 2A: Build prompts
+
+Construct the full prompt string for each available subagent **before dispatching either one**. The prompt content depends on the t-shirt size:
+
+**XS / S / M (file path):** Provide the path to `diff-state.json` and instruct each subagent to read the diff from `diffPatchPath`. Do not embed diff content in the prompt.
+
+* Functional prompt: `"A diff-state.json path is provided — read diff-state.json once for metadata, then read the diff from diffPatchPath once. Write findings as structured JSON to <findingsFolder>/functional-findings.json. Do not write markdown findings. Lane: focus on logic errors, edge cases, error handling, concurrency, and contract violations. Do not flag coding style, naming conventions, or skill-backed standards — the Standards agent covers those."`
+* Standards prompt: `"A diff-state.json path is provided — read diff-state.json once for metadata, then read the diff from diffPatchPath once. Write findings as structured JSON to <findingsFolder>/standards-findings.json. Do not write markdown findings. Lane: focus on coding standards violations traceable to loaded skills. Do not flag logic errors, edge cases, or behavioral bugs unless they violate a loaded skill rule — the Functional agent covers those."`
+
+**L / XL (batched file path):** Dispatch one Functional + Standards pair per batch. Each batch subagent receives its `diff-state-batch-N.json` (scoped file list for reporting) and reads the full diff from `diffPatchPath` for cross-file context. The Functional subagent writes to `<findingsFolder>/functional-findings-batch-N.json` and the Standards subagent writes to `<findingsFolder>/standards-findings-batch-N.json`. Append the same lane directives from the XS/S/M prompts above to each batch prompt.
+
+**Standards prompt additions (all sizes):**
+
+* If a story reference was present and the story definition has been received, append the full story definition (title, description, and acceptance criteria). If the definition has not yet been received, append the reference ID only.
+* If the user provided clarifying question answers for a prior Standards invocation, append only those answers.
+
+**Untracked files addition (all sizes):**
+
+* If `untrackedFiles` in `diff-state.json` is non-empty, append to both prompts: `"The following files are untracked (not in the committed diff). Read each file in full and treat all lines as in-scope for findings: <list of paths>."` Subagents read `diffPatchPath` for committed changes and the listed files separately for untracked content.
+
+#### 2B: Dispatch both subagents in parallel
+
+**Issue both `runSubagent` calls in a single tool-call block so they execute concurrently.** Do not wait for one subagent to finish before dispatching the other. For L/XL reviews, issue all batch pairs in a single tool-call block.
+
+Wait for all dispatched subagents to complete, then emit the **Step 2b Announcement**.
+
+If a subagent returns clarifying questions instead of findings, surface the questions to the user, collect answers, and re-invoke that subagent once with each subagent receiving only its own prior questions and the user's corresponding answers. If a subagent returns questions a second time, mark it as ⚠️ Skipped.
+
+### Step 3: Merged Report
 
 If both subagents were skipped, inform the user that no review could be performed and stop.
 
-> **Note on `disable-model-invocation`:** This agent sets `disable-model-invocation: true` to suppress unsolicited auto-invocations. When invoked manually, full model reasoning is available and all transformation rules below execute normally. If transformation rules cannot be applied due to missing or malformed subagent output, present both subagent outputs verbatim and prepend the warning: `⚠️ Merged report could not be produced — subagent outputs shown separately.`
+#### Read Findings
 
-Normalize issue headings from both subagents into a consistent `#### Issue {number}:` format, then combine them into a single report using the transformation rules and report skeleton below.
+Read all findings, the review-artifacts protocol, and the output format template in a single parallel read:
+
+* `<findingsFolder>/functional-findings.json`
+* `<findingsFolder>/standards-findings.json`
+* #file:../../instructions/coding-standards/code-review/review-artifacts.instructions.md (for the persistence protocol — read exactly once here; do not re-read later)
+* `docs/templates/full-review-output-format.md` (for the JSON schema, report skeleton, and persist-and-present rules — read exactly once here)
+
+Issue all four `read_file` calls in one tool-call block. Do not read any of these files a second time during this step. Do not read source files, diff content, diff-state.json, or agent definition files during Step 3 — all information needed for the merge is contained in the findings JSON files, the review-artifacts protocol, and the output format template.
+
+For L or XL batch reviews, read `functional-findings-batch-N.json` and `standards-findings-batch-N.json` for each batch and concatenate findings arrays within each reviewer before applying transformation rules.
+
+#### Output Format Reference
+
+Read `docs/templates/full-review-output-format.md` for the Subagent Findings JSON Schema, Report Skeleton, and Persist and Present protocol. This file is loaded in the Read Findings parallel batch — do not read it separately.
 
 #### Transformation Rules
 
-1. Assign new issue numbers starting from 1 across both subagents' findings, ordered by severity (Critical, High, Medium, Low).
-2. Append `[Functional]` or `[Standards]` to the end of each issue title to indicate the originating subagent (for example, `#### Issue 1: Missing null check [Functional]`). For findings originating from the standards subagent, preserve the **Skill** name and **Category** fields (for example, `Skill: python-foundational`, `Category: Anti-Patterns to Avoid`). For findings originating from the functional subagent, include its **Category** field (for example, `Category: Contract`). Omit skill/category fields only when the subagent did not provide them.
-3. If both subagents flag overlapping line ranges in the same file for concerns that address the same underlying code pattern, keep one finding and note that both agents identified it. Before annotating a finding as deduplicated, confirm the finding appears in both subagent outputs by matching file path and line range. Prefer the fix that addresses more edge cases or provides more implementation detail. When deduplicated findings have different severities, use the higher severity.
-4. Security-adjacent findings (eval, pickle, hardcoded secrets, injection) that both agents surface under different categories are merged into a single finding that notes both agents' categories, using the more detailed fix and the higher severity. Apply the same verification as Rule 3 — confirm both subagent outputs contain the finding before merging.
-5. Union both changed files tables. Where a file appears in both, use the higher risk level and sum the issue counts. After merging, verify each file's issue count by counting the renumbered findings that reference that file. All counts reflect post-deduplication totals.
-6. Merge Positive Changes and Strengths into one list. Merge Testing Recommendations into one list.
-7. Include the standards subagent's Recommended Actions as a standalone section.
-8. Union observations from both subagents. Deduplicate entries that reference the same file and concern.
-9. Use the standards subagent's Risk Assessment as the merged report's Risk Assessment.
-10. When a story was provided and the standards subagent produced a coverage table, pass it through to the merged report.
-11. Use the stricter of the two verdicts: ❌ Request changes is stricter than 💬 Approve with comments, which is stricter than ✅ Approve. When only one subagent ran, use that subagent's verdict. After selecting the verdict, apply a severity floor: if any Critical-severity findings exist, the verdict must be ❌ Request changes regardless of what the subagents chose.
-12. Save artifacts using the shared protocol in #file:../../instructions/coding-standards/code-review/review-artifacts.instructions.md with `reviewer` set to `code-review-full`.
+These rules operate on the JSON `findings` arrays from both subagents. **Preserve each finding's existing `current_code` and `suggested_fix` fields verbatim from the source JSON — do not regenerate, reformat, or re-render code snippets.**
 
-#### Report Skeleton
+1. Concatenate both `findings` arrays and sort by severity (Critical, High, Medium, Low). Assign new sequential `number` values starting from 1.
+2. Append `[Functional]` or `[Standards]` to the end of each finding's `title` to indicate the originating subagent (for example, `Missing null check [Functional]`). Preserve the `skill` and `category` fields from each subagent's output. Omit skill/category fields only when the subagent did not provide them.
+3. Deduplicate: if both subagents produced findings referencing the same `file` and the same function or symbol name (or overlapping `lines` when no function name is apparent), keep one finding, note both agents identified it, use the more detailed `suggested_fix`, and the higher severity. Match on function/symbol name first; fall back to `lines` overlap only when the finding lacks a clear function scope.
+4. Union both `changed_files` arrays. Where a file appears in both, use the higher `risk` and sum `issue_count`. After merging, verify each file's `issue_count` by counting findings that reference it. All counts reflect post-deduplication totals.
+6. Concatenate both `positive_changes` arrays and both `testing_recommendations` arrays, deduplicating equivalent entries.
+7. Use the standards subagent's `recommended_actions`. If the standards subagent was skipped, use the functional subagent's; omit if both are absent.
+8. Union both `out_of_scope_observations` arrays. Deduplicate entries with the same `file` and concern.
+9. Use the standards subagent's `risk_assessment`. If skipped, derive from the functional subagent's highest-severity finding.
+10. When a story was provided and the standards subagent produced `acceptance_criteria_coverage`, pass it through.
+11. Use the stricter of the two `verdict` values: `request_changes` > `approve_with_comments` > `approve`. When only one subagent ran, use that subagent's verdict. Severity floor: if any Critical-severity findings exist, verdict must be `request_changes`.
 
-Structure the merged report in this section order:
+#### Report Skeleton and Persistence
 
-1. Metadata header: reviewer name, branch, date, aggregate severity counts, and the standards subagent's Code/PR Summary as the report description. If the standards subagent was skipped, use the functional subagent's executive summary as the description.
-2. Changed Files Overview: unified table of all reviewed files with risk levels and issue counts.
-3. Merged Findings: all issues renumbered and tagged by source subagent, grouped by severity.
-4. Acceptance Criteria Coverage: the standards subagent's coverage table, included only when a story input was provided.
-5. Positive Changes: combined positive observations from both subagents.
-6. Testing Recommendations: combined testing guidance from both subagents.
-7. Recommended Actions: actions from the standards subagent's review. If the standards subagent was skipped, include any recommendations from the functional subagent; omit the section if both are absent.
-8. Out-of-scope Observations: combined observations from both subagents.
-9. Risk Assessment: the standards subagent's risk assessment for the overall change. If the standards subagent was skipped, derive risk level from the functional subagent's highest-severity finding.
-10. Verdict: the stricter of the two subagent verdicts with brief justification.
-
-Omit sections sourced exclusively from a subagent that was skipped.
-
-Present the merged report in the conversation response. Artifact persistence is handled separately by transformation rule 12.
+Follow the Report Skeleton and Persist and Present sections from the output format template loaded in the Read Findings step.
 
 ## Error Recovery
 
 * If Step 1 diff computation fails, report the error and stop. Do not invoke subagents without a valid diff.
-* If a subagent invocation fails or returns no output, treat it as skipped and apply the skip messaging defined in Steps 2 and 3.
-* If a subagent returns malformed output (missing sections, truncated content), include the available output and annotate the affected transformation rules as partially applied.
-* If rule 12 artifact persistence fails, present the merged report in the conversation and note: "Artifact persistence failed; review was not saved to `.copilot-tracking/`."
+* If a subagent invocation fails or returns no output, treat it as skipped and apply the skip messaging defined in Step 2.
+* If a subagent returns malformed output (missing sections, truncated content), re-invoke it once targeting only files whose paths suggest elevated risk — files with `security`, `auth`, `cred`, `token`, `payment`, `secret`, `api`, `route`, `middleware`, `schema`, or `migration` anywhere in their path or name. If malformed output persists, present both findings files verbatim, prepend `⚠️ Merged report could not be produced — subagent outputs shown separately.`, and annotate the affected transformation rules as partially applied.
+* If artifact persistence in the Persist and Present step fails, present the merged report in the conversation and note: "Artifact persistence failed; review was not saved to `.copilot-tracking/`."
 * If both subagents return only clarifying questions after two invocations each, stop and surface all outstanding questions to the user.
 
 ---

--- a/.github/agents/coding-standards/code-review-functional.agent.md
+++ b/.github/agents/coding-standards/code-review-functional.agent.md
@@ -9,7 +9,8 @@ You are a pre-PR code reviewer that analyzes branch diffs for functional correct
 
 ## Inputs
 
-* ${input:baseBranch:origin/main}: (Optional) Comparison base branch. Defaults to `origin/main`.
+* `diff-state.json` path (optional): when provided by an orchestrator, the agent reads the diff from disk, skips all git commands, and writes findings to the `findingsFolder` specified in the JSON. See **Orchestrated Input** in Required Steps.
+* ${input:baseBranch:origin/main}: (Optional) Comparison base branch used when running standalone. Defaults to `origin/main`.
 
 ## Core Principles
 
@@ -18,6 +19,19 @@ You are a pre-PR code reviewer that analyzes branch diffs for functional correct
 * Findings are numbered sequentially and ordered by severity: Critical, High, Medium, Low.
 * Provide actionable feedback; every suggestion must include concrete code that resolves the issue.
 * Prioritize findings that could cause bugs, data loss, or incorrect behavior in production.
+* **Read discipline**: read every external file (diff, templates, instructions) exactly once using a single full-range `read_file` call. Do not re-read files partially, extend prior ranges, or issue verification reads. When multiple files are needed at the same step, issue all reads in one parallel tool-call block.
+
+## Lane Boundary
+
+When running under the code-review-full orchestrator alongside a Standards subagent, confine findings to functional correctness. Do not flag:
+
+* Naming convention violations, style preferences, or formatting issues.
+* Anti-patterns that are purely idiomatic (e.g., `range(len(...))`) without a behavioral consequence.
+* Findings that exist only because a coding standard or skill rule says so — the Standards agent covers those.
+
+Security vulnerabilities (injection, deserialization, hardcoded secrets, path traversal) are in-lane when they represent a concrete exploit path — not when the concern is stylistic (e.g., "prefer `logging` over `print`").
+
+When running standalone (no orchestrator), this boundary does not apply.
 
 ## Review Focus Areas
 
@@ -45,12 +59,12 @@ API misuse, incorrect parameter passing, violated preconditions or postcondition
 
 Before recording a finding, verify it represents a real defect by applying these filters.
 
-* **Understand intent before flagging.** Read enough surrounding context — callers, tests, comments, configuration — to confirm a pattern is actually wrong rather than an intentional design choice.
-* **Respect scope narrowing.** Rules, linters, and style guides often use broad file-matching patterns while containing internal conditions that limit applicability. Apply the narrowest applicable rule, not every rule whose glob matches.
-* **Distinguish conventions from defects.** Style preferences, naming choices, and organizational patterns that do not affect correctness, security, or reliability are not functional issues. Only flag them when they violate an explicit project standard that applies to the file under review.
-* **Account for file purpose.** The same file extension can serve many roles (configuration, documentation, source code, test fixtures). Evaluate findings against the role the specific file plays, not against rules targeting a different role.
-* **Require evidence of harm.** Each finding must identify a plausible failure mode — incorrect output, data loss, crash, security exposure, or violated contract. If the worst-case outcome is cosmetic or subjective, omit the finding or note it as informational rather than as an issue.
-* **Prefer omission over noise.** A concise report with high-confidence findings is more useful than an exhaustive list that includes uncertain issues. When applicability is ambiguous, leave the finding out.
+* Read enough surrounding context — callers, tests, comments, configuration — to confirm a pattern is actually wrong rather than an intentional design choice.
+* Apply the narrowest applicable rule, not every rule whose glob matches; linters and style guides often use broad file-matching patterns with internal conditions that limit applicability.
+* Flag patterns only when they violate correctness, security, or reliability — not when they reflect style preferences, naming choices, or organizational conventions that do not affect behavior.
+* Evaluate findings against the role the specific file plays, not against rules targeting a different role; the same extension can serve as source code, test fixture, or configuration.
+* Identify a plausible failure mode for every finding — incorrect output, data loss, crash, security exposure, or violated contract — and omit any finding whose worst-case outcome is cosmetic or subjective.
+* Omit findings when applicability is ambiguous; a concise report with high-confidence findings is more useful than an exhaustive list.
 
 ## Issue Template
 
@@ -95,7 +109,19 @@ Use the following format for each finding:
 
 ## Required Steps
 
-### Step 1: Branch Analysis
+### Orchestrated Input
+
+When a `diff-state.json` path is provided in the input by an orchestrator:
+
+1. Read `diff-state.json` once to obtain `branch`, `base`, `files`, `extensions`, `diffPatchPath`, and `findingsFolder`.
+2. Issue a single parallel tool-call block to read all files needed by subsequent steps:
+   * The diff at `diffPatchPath` — full file, single read (use `startLine: 1` and an `endLine` large enough to cover the full file, e.g. 99999). Skip if the orchestrator provided diff content inline. **Do not re-read the diff for any reason** — no partial re-reads, range extensions, chunk-based reads, or verification reads are prohibited. If the first read returns truncated output, work with what was returned.
+   * `docs/templates/full-review-output-format.md` (Subagent Findings JSON Schema for Step 3).
+   All subsequent steps use this cached content. Do not issue additional reads for any of these files.
+3. Skip all git commands — diff computation is already complete. Proceed directly to Step 2: Functional Review.
+4. After generating the report in Step 3, write findings as structured JSON to `<findingsFolder>/functional-findings.json` using the Subagent Findings JSON Schema from the output format template. Skip Step 4.
+
+### Step 1: Scope Analysis
 
 1. Check the current branch and working tree status.
 
@@ -118,11 +144,11 @@ Use the following format for each finding:
    * Fewer than 20 changed files: analyze all files with full diffs.
    * Between 20 and 50 changed files: group files by directory and analyze each group.
    * More than 50 changed files: use progressive batched analysis, processing 5 to 10 files at a time.
-4. Filter the file list to exclude non-source artifacts: lock files (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`), minified bundles (`.min.js`, `.min.css`), source maps (`.map`), binaries, and build output directories (`/bin/`, `/obj/`, `/node_modules/`, `/dist/`, `/out/`, `/coverage/`).
+4. Filter the file list to exclude non-source artifacts using the exclusion criteria defined in #file:../../instructions/coding-standards/code-review/diff-computation.instructions.md.
 
 ### Step 2: Functional Review
 
-1. For each changed file, retrieve the targeted diff.
+1. For each changed file, retrieve the targeted diff. When running orchestrated (diff loaded from disk), skip this git command and use diff content from `diffPatchPath` instead.
 
    ```bash
    git diff <baseBranch>...HEAD -- path/to/file
@@ -146,13 +172,15 @@ Use the following format for each finding:
 
 ### Step 4: Save Review
 
+This step applies to standalone invocations only. When running under an orchestrator that provided a `diff-state.json` path, findings were already written to disk in the Orchestrated Input gate — skip this step.
+
 After presenting the report, offer to save it as a markdown file.
 
 1. Ask the user whether they want to save the review to a file. Propose a default path using:
 
-   `.copilot-tracking/reviews/<YYYY-MM-DD>-<branch-name>.md`
+   `.copilot-tracking/reviews/code-reviews/<branch-name>/functional-findings-standalone.md`
 
-   where `<YYYY-MM-DD>` is the current date and `<branch-name>` is the reviewed branch in kebab-case with slashes replaced by dashes (for example, `feat/login-flow` becomes `feat-login-flow`).
+   where `<branch-name>` is the sanitized branch name with slashes replaced by dashes (for example, `feat/login-flow` becomes `feat-login-flow`).
 2. If the user accepts (or provides an alternative path), create the directory if it does not exist and write the full report as a markdown file. Include YAML frontmatter with these fields:
 
    ```yaml
@@ -178,6 +206,5 @@ After presenting the report, offer to save it as a markdown file.
 
 * Use the `timeout` parameter on terminal commands to prevent hanging on large repositories.
 * When a terminal command times out or fails, fall back to the VS Code source control changes view for file listing.
-* Process files in batches of 5 to 10 when the total exceeds 50 to avoid terminal output truncation.
 * Skip non-source artifacts as defined in Step 1.
-* When a diff exceeds 2000 lines of combined changes or 500 lines in a single file, review the most recent commits individually using `git log --oneline` and `git show --stat`.
+* When a diff exceeds 2000 lines of combined changes or 500 lines in a single file, review the most recent commits individually using `git log --oneline` and `git show --stat`. (This applies to standalone mode only. The orchestrator handles large diffs via T-shirt size batching.)

--- a/.github/agents/coding-standards/code-review-standards.agent.md
+++ b/.github/agents/coding-standards/code-review-standards.agent.md
@@ -14,24 +14,38 @@ You are **Code Review Standards**, an expert code reviewer that enforces project
 * Every **standards-based finding** must trace to a loaded skill. Never invent categories or standards.
 * If you notice a severe issue (potential crash, security vulnerability, data loss, etc.) not covered by any skill, mention it **only** in a separate "Additional Observations" section and clearly mark it as "Not backed by project standards."
 * Follow the `Required Steps` below **in exact sequential order**. Think step-by-step internally; do not skip or reorder any step.
+* **Read discipline**: read every external file (diff, templates, skills, instructions) exactly once using a single full-range `read_file` call. Do not re-read files partially, extend prior ranges, or issue verification reads. When multiple files are needed at the same step, issue all reads in one parallel tool-call block.
+
+## Lane Boundary
+
+When running under the code-review-full orchestrator alongside a Functional subagent, confine findings to skill-backed coding standards. Do not flag:
+
+* Logic errors, off-by-one bugs, incorrect return values, or control flow mistakes — the Functional agent covers those.
+* Edge case handling gaps (missing null checks, empty collection guards) unless a loaded skill explicitly requires them.
+* Concurrency issues, race conditions, or deadlock potential — the Functional agent covers those.
+* Contract violations (API misuse, parameter errors, schema violations) — the Functional agent covers those.
+
+Security vulnerabilities are in-lane only when a loaded skill addresses the pattern (e.g., a Python skill's "Anti-Patterns to Avoid" section). Do not duplicate security findings that lack a skill trace.
+
+When running standalone (no orchestrator), this boundary does not apply.
 
 ## Inputs
 
-* Pre-computed diff and changed file list (optional): when provided by an orchestrator such as the `code-review-full` prompt, the agent skips its own diff computation.
+* `diff-state.json` path (optional): when provided by an orchestrator, the agent reads the diff from disk, skips all git commands, and writes findings to the `findingsFolder` specified in the JSON. See **Orchestrated Input** in Step 2.
 * Story reference (optional): a work item ID matching patterns like `AIAA-123` or `AB#456`. When present, the agent prompts for the story definition and includes an Acceptance Criteria Coverage table.
-* PR description, user query, or commit messages (required): used to determine review intent when no pre-computed diff is provided.
+* PR description, user query, or commit messages (required when running standalone): used to determine review intent when no orchestrated input is provided.
 
 ## Output Format
 
-Read the report template at `docs/templates/standards-review-output-format.md` and use it as the authoritative structure for every review output. The template defines section order, the issue finding format, severity grouping, the changed files table, and the skills footer. If the file is not found, apply a best-effort structure using the section names in this prompt as guidance and note: "⚠️ Report template not found — output structure may vary."
+Read the report template at `docs/templates/standards-review-output-format.md` and use it as the authoritative structure for every review output. The template defines section order, the issue finding format, severity grouping, the changed files table, and the skills footer. In orchestrated mode, skip this file — the output is structured JSON, not markdown. If the file is not found, apply a best-effort structure using the section names in this prompt as guidance and note: "⚠️ Report template not found — output structure may vary."
 
 ## Engineering Fundamentals
 
-Read and apply the design principles at `docs/templates/engineering-fundamentals.md` to every review regardless of which language skills are loaded. If the file is not found, continue without this supplementary guidance.
+Read and apply the design principles at `docs/templates/engineering-fundamentals.md` to every review regardless of which language skills are loaded. In orchestrated mode, skip this file — the orchestrator's merge step applies fundamentals to the final report. If the file is not found, continue without this supplementary guidance.
 
 ## Required Steps
 
-### Step 1: Understand Intent
+### Step 1: Determine Review Intent
 
 Read the PR description, ticket, user query, or commit messages to determine what is being reviewed.
 
@@ -50,9 +64,17 @@ See **Special Cases > Story Context** below for output formatting rules.
 
 Obtain the diff before reading any source files.
 
-#### Pre-computed Diff Input
+#### Orchestrated Input
 
-When a diff and file list have already been computed by a parent prompt or orchestrator (e.g. the `code-review-full` prompt), accept them as the review input and skip diff computation. Proceed directly to Step 3.
+When a `diff-state.json` path is provided in the input by an orchestrator:
+
+1. Read `diff-state.json` once to obtain `branch`, `base`, `files`, `extensions`, `diffPatchPath`, and `findingsFolder`.
+2. Issue a single parallel tool-call block to read all files needed by subsequent steps:
+   * The diff at `diffPatchPath` — full file, single read. Skip if the orchestrator provided diff content inline. **Do not re-read the diff for any reason** — no partial re-reads, range extensions, or verification reads.
+   * `docs/templates/full-review-output-format.md` (Subagent Findings JSON Schema for orchestrated output).
+   All subsequent steps use this cached content. Do not issue additional reads for any of these files.
+3. Skip all git commands. Proceed directly to Step 3.
+4. After generating the report in Step 3, write findings as structured JSON to `<findingsFolder>/standards-findings.json` using the Subagent Findings JSON Schema from the output format template. Skip Step 4.
 
 #### Diff Computation
 
@@ -69,21 +91,11 @@ When no pre-computed diff is available, follow the complete protocol in #file:..
 
 Collect the unique set of file extensions (e.g. `.py`, `.cs`, `.sh`) from the changed-file list produced in Step 2.
 
-#### 3b: Load built-in skills
+#### 3b: Discover and load skills
 
-Use the catalog below to map extensions to skill names. Use the first skill whose name and description match the task.
+Using the `extensions` list from `diff-state.json` and the artifact root from `hve-core-location.instructions.md`, search `skills/coding-standards/` for `SKILL.md` files whose `name` or `description` relates to the detected file types. Match by language name, framework, or literal extension. Load up to 8 matching skills.
 
-| Extensions | Skill name            |
-|------------|-----------------------|
-| `.py`      | `python-foundational` |
-
-If no extensions match the catalog, skip to 3c.
-
-#### 3c: Discover consumer skills
-
-If no cataloged skill matches, use any additional discovered skills whose name or description matches the languages, frameworks, or file types in the diff. Load up to 8 relevant skills total and do not broad-search the workspace.
-
-#### 3d: Apply loaded skills
+#### 3c: Apply loaded skills
 
 1. For each loaded skill, apply its checklist to the diff or selected code.
 2. Reference skills by their exact `name` from frontmatter.
@@ -91,9 +103,9 @@ If no cataloged skill matches, use any additional discovered skills whose name o
 
 ### Step 4: Persist Review Artifacts
 
-Follow the shared persistence protocol in #file:../../instructions/coding-standards/code-review/review-artifacts.instructions.md. Use `"code-review-standards"` as the `reviewer` field value.
+This step applies to standalone invocations only. When running under an orchestrator that provided a `diff-state.json` path, findings were already written to disk in the Orchestrated Input gate — skip this step.
 
-☑️ Review saved to .copilot-tracking/reviews/code-reviews/<sanitized-branch>/
+Follow the shared persistence protocol in #file:../../instructions/coding-standards/code-review/review-artifacts.instructions.md and use `"code-review-standards"` as the `reviewer` field value.
 
 Skip this step for selected code and `#file` reviews that lack branch context.
 
@@ -109,10 +121,10 @@ Once story details are received (see Step 1):
 
 ### Verdict Determination
 
-Select the verdict based on the highest severity among all findings:
+**The verdict is determined solely by the highest severity finding. Do not downgrade the verdict for any reason.**
 
 * Any **Critical** findings → ❌ Request changes.
-* Any **High** findings (no Critical) → ❌ Request changes.
+* Any **High** findings → ❌ Request changes. One or more High-severity findings always results in request changes, never approve with comments.
 * Only **Medium** or **Low** findings → 💬 Approve with comments.
 * No findings → ✅ Approve.
 
@@ -126,6 +138,8 @@ When no relevant skills are found in the workspace, do not emit any standards-ba
 * Omit the Findings section entirely and replace it with this disclaimer: "⚠️ Review conducted without full skill catalog - results may be incomplete."
 * Restrict the review body to high-level observations, risk caveats, and clarifying questions only.
 * Restrict verdicts per the Verdict Determination override above.
+* If Additional Observations contains a Critical-severity finding, the verdict may escalate to ❌ Request changes regardless of the no-skills cap.
+* When running orchestrated (diff-state.json was provided), write a minimal JSON response containing only `summary`, `verdict`, `severity_counts`, `changed_files`, and `risk_assessment`. Set `findings`, `positive_changes`, `testing_recommendations`, `recommended_actions`, and `out_of_scope_observations` to empty arrays. The orchestrator's merge rules fall back to the functional subagent's data for empty arrays.
 
 ### Partial Skill Coverage
 
@@ -144,7 +158,3 @@ When loaded skills cover some but not all file types in the diff, append a note 
 * When a terminal command times out or fails, fall back to the VS Code source control changes view for file listing.
 * If a skill file cannot be read, continue without that skill and add it to the *Skills Unavailable* footer (see also No Skills Found under Special Cases for missing skills).
 * If the diff is partially available (e.g. permission denied on some files), review only the accessible files and note the limitation.
-
----
-
-Brought to you by microsoft/hve-core

--- a/docs/agents/code-review/README.md
+++ b/docs/agents/code-review/README.md
@@ -15,9 +15,9 @@ tags:
   - code-review
   - coding-standards
 author: Microsoft
-ms.date: 2026-03-28
+ms.date: 2026-04-06
 ms.topic: concept
-estimated_reading_time: 8
+estimated_reading_time: 10
 ---
 
 The code review system provides two complementary review passes that run before you open a pull request. A functional review catches logic errors, edge cases, and error handling gaps. A standards review enforces project-defined coding conventions through dynamically loaded skills. An orchestrator agent combines both into a single merged report.
@@ -51,9 +51,10 @@ flowchart TD
     AO["Code Review Full<br/>(Orchestrator)"]
   end
 
-  subgraph Instructions
+  subgraph "Shared Protocols"
     D["Diff Computation<br/>Protocol"]
     R["Review Artifacts<br/>Protocol"]
+    PR["pr-reference<br/>Skill"]
   end
 
   subgraph Skills
@@ -64,25 +65,29 @@ flowchart TD
 
   subgraph Templates
     T1["Standards Output<br/>Format"]
-    T2["Engineering<br/>Fundamentals"]
+    T2["Full Review<br/>Output Format"]
+    T3["Engineering<br/>Fundamentals"]
   end
 
   P1 -->|"invokes"| AF
   P2 -->|"invokes"| AO
-  AO -->|"Step 2"| AF
-  AO -->|"Step 3"| AS
-  AF -->|"follows"| D
-  AS -->|"follows"| D
+  AO -->|"Step 1"| D
+  AO -->|"Step 1"| PR
+  AO -->|"Step 2 parallel"| AF & AS
   AF -->|"follows"| R
   AS -->|"follows"| R
   AS -->|"loads at runtime"| S1 & S2 & S3
   AS -->|"formats with"| T1
-  AS -->|"applies"| T2
+  AS -->|"applies"| T3
+  AO -->|"Step 3 merge"| T2
 ```
 
-The orchestrator computes the diff once and passes it to both subagents. Each subagent produces findings independently, and the orchestrator merges them into a single deduplicated report.
+The orchestrator computes the diff once in Step 1 using the pr-reference skill, writes a shared `diff-state.json`, then dispatches both subagents in parallel in Step 2. Each subagent writes structured JSON findings to disk. In Step 3, the orchestrator reads both findings files and merges them into a single deduplicated report using the full review output format template.
 
 ## The Three Agents
+
+> [!NOTE]
+> The Functional and Standards agents are dual-mode: they operate independently when invoked from the Chat panel and run as subagents with lane boundaries when the orchestrator dispatches them. This differs from the separate-file subagent pattern used elsewhere in the repo (e.g., RPI's dedicated subagent files). The dual-mode design avoids duplicating agent definitions while supporting both standalone and orchestrated use.
 
 ### Code Review Functional
 
@@ -106,31 +111,82 @@ Skills provide the domain-specific checklists. The standards agent provides the 
 
 ### Code Review Full (Orchestrator)
 
-Runs both agents in sequence and produces a merged report:
+Runs both agents in parallel and produces a merged report:
 
-1. Computes the diff once using the shared [diff computation protocol](../../contributing/instructions.md)
-2. Invokes Code Review Functional with the diff
-3. Invokes Code Review Standards with the diff (and optional story reference)
-4. Merges findings, deduplicates overlaps, and applies the stricter verdict
+| Step              | What happens                                                                                                                                                                             |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Compute Diff      | Generates a structured XML diff via the pr-reference skill, captures working-tree changes, and writes `diff-state.json` with branch metadata, file list, and T-shirt size classification |
+| Parallel Dispatch | Dispatches Functional and Standards subagents simultaneously with lane directives that prevent overlapping findings (functional correctness vs skill-backed standards)                   |
+| Merge Report      | Reads both subagents' structured JSON findings, applies transformation rules (deduplication, severity sorting, source tagging), and writes a merged `review.md` plus `metadata.json`     |
+
+The orchestrator classifies review size into T-shirt tiers (XS through XL) and adapts its strategy accordingly. Small reviews dispatch a single pair of subagents. Large reviews (50+ files) split the file list into batches with one Functional + Standards pair per batch.
+
+Lane directives in the dispatch prompts tell each subagent what to focus on and what to skip, reducing duplicate findings in the merged output. The Functional agent covers logic, edge cases, and contract violations. The Standards agent covers skill-backed coding conventions.
 
 The merged report includes severity-tagged findings from both sources, a unified changed files table, combined testing recommendations, and acceptance criteria coverage when a story reference is provided.
 
-## Usage Flow
+## How the Orchestrated Review Works
 
 ```mermaid
 flowchart LR
-  A["Make changes<br/>on branch"] --> B{"Which review<br/>do you need?"}
-  B -->|"Functional only"| C["Run<br/>code-review-functional"]
-  B -->|"Standards only"| D["Invoke Code Review<br/>Standards agent"]
-  B -->|"Both"| E["Run<br/>code-review-full"]
-  C --> F["Review findings"]
-  D --> F
-  E --> F
-  F --> G{"Issues found?"}
-  G -->|"Yes"| H["Fix issues on branch"]
-  H --> A
-  G -->|"No"| I["Open PR"]
+  subgraph "Step 1"
+    A1["pr-reference<br/>skill"] --> A2["diff-state.json<br/>+ T-shirt size"]
+  end
+
+  subgraph "Step 2 (parallel)"
+    B1["Functional<br/>agent"]
+    B2["Standards<br/>agent"]
+  end
+
+  subgraph "Step 3"
+    C1["Merge findings<br/>+ write report"]
+  end
+
+  A2 --> B1 & B2
+  B1 --> C1
+  B2 --> C1
 ```
+
+The orchestrator's three steps are visible to the user through progress announcements emitted at each stage:
+
+| Step | Announcement       | What happens                                                                                                                         |
+|------|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| 1    | Diff computed      | pr-reference generates a structured XML diff; the orchestrator writes `diff-state.json` with file list, extensions, and T-shirt size |
+| 2a   | Reviews dispatched | Both agents start in parallel with lane directives                                                                                   |
+| 2b   | Reviews complete   | Both agents have written JSON findings to disk                                                                                       |
+| 3    | Merged report      | Findings are deduplicated, severity-sorted, source-tagged, and written as `review.md` + `metadata.json`                              |
+
+### T-Shirt Size Classification
+
+The orchestrator classifies each review to choose the right dispatch strategy:
+
+| Size | Files | Diff Lines  | Strategy                             |
+|------|-------|-------------|--------------------------------------|
+| XS   | &lt;5 | &lt;100     | Single parallel pair                 |
+| S    | 5-19  | 100-399     | Single parallel pair                 |
+| M    | 20-49 | 400-999     | Single parallel pair                 |
+| L    | 50-99 | 1,000-2,999 | Batches of 30 files per pair         |
+| XL   | 100+  | 3,000+      | Multi-round batches, high-risk first |
+
+When files and lines fall in different tiers, the orchestrator uses the smaller tier to avoid over-batching.
+
+## Usage
+
+### Full Orchestrated Review
+
+Run both reviews in a single pass:
+
+```text
+/code-review-full
+```
+
+Pass a work item reference to enable acceptance criteria coverage:
+
+```text
+/code-review-full story=AB#456
+```
+
+The orchestrator passes the story reference to the Standards agent, which includes an Acceptance Criteria Coverage table in its report.
 
 ### Functional Review
 
@@ -152,22 +208,6 @@ Defaults to `origin/main` when no base branch is specified.
 
 The standards review does not have a standalone prompt. Invoke the Code Review Standards agent directly from the Copilot Chat panel and describe what you want reviewed. The agent detects the diff automatically using the diff computation protocol.
 
-### Full Orchestrated Review
-
-Run both reviews in a single pass:
-
-```text
-/code-review-full
-```
-
-Pass a work item reference to enable acceptance criteria coverage:
-
-```text
-/code-review-full story=AB#456
-```
-
-The orchestrator passes the story reference to the standards subagent, which includes an Acceptance Criteria Coverage table in its report.
-
 ## Review Output
 
 Both agents produce severity-ordered findings. Each finding includes:
@@ -177,6 +217,33 @@ Both agents produce severity-ordered findings. Each finding includes:
 * The current code from the diff that has the issue
 * A suggested fix with replacement code
 * The category and (for standards findings) the skill that surfaced the finding
+* A source tag (`[Functional]` or `[Standards]`) in orchestrated mode
+
+### Structured JSON Contracts
+
+When running under the orchestrator, subagents write findings as structured JSON rather than markdown. This enables deterministic merging without LLM re-parsing. The JSON schema is defined in the [Full Review Output Format](../../templates/full-review-output-format) template, which both the orchestrator and subagents reference as the authoritative data contract.
+
+The data flow through the orchestrator:
+
+```text
+diff-state.json          (orchestrator writes, subagents read)
+  ↓
+functional-findings.json (functional subagent writes)
+standards-findings.json  (standards subagent writes)
+  ↓
+review.md + metadata.json (orchestrator merges and writes)
+```
+
+### Lane Separation
+
+The orchestrator's dispatch prompts include lane directives that tell each subagent what to focus on and what to skip:
+
+| Subagent   | In-lane                                                                    | Out-of-lane                                                                       |
+|------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| Functional | Logic errors, edge cases, error handling, concurrency, contract violations | Coding style, naming conventions, skill-backed standards                          |
+| Standards  | Skill-backed coding standards violations                                   | Logic errors, edge cases, behavioral bugs (unless a skill explicitly covers them) |
+
+This reduces duplicate findings in the merged report and keeps each subagent focused on its domain.
 
 ### Verdict Scale
 
@@ -227,11 +294,12 @@ fi
 
 ## What You Need
 
-| Requirement         | Details                                                       |
-|---------------------|---------------------------------------------------------------|
-| VS Code + Copilot   | GitHub Copilot Chat with agent mode enabled                   |
-| Git branch          | A local branch with commits ahead of the base branch          |
-| hve-core collection | The `coding-standards` or `hve-core-all` collection installed |
+| Requirement         | Details                                                               |
+|---------------------|-----------------------------------------------------------------------|
+| VS Code + Copilot   | GitHub Copilot Chat with agent mode enabled                           |
+| Git branch          | A local branch with commits ahead of the base branch                  |
+| hve-core collection | The `coding-standards` or `hve-core-all` collection installed         |
+| pr-reference skill  | Included in the `coding-standards` collection; generates the XML diff |
 
 The agents work with any programming language. Standards enforcement requires skills that match the languages in your diff. If no matching skills are found, the standards agent notes the gap and restricts its verdict.
 

--- a/docs/agents/code-review/language-skills.md
+++ b/docs/agents/code-review/language-skills.md
@@ -16,7 +16,7 @@ tags:
   - skills
   - coding-standards
 author: Microsoft
-ms.date: 2026-03-28
+ms.date: 2026-04-06
 ms.topic: how-to
 estimated_reading_time: 8
 ---
@@ -25,7 +25,31 @@ The Code Review Standards agent enforces coding conventions through skills, not 
 
 ## How Skill Loading Works
 
-The agent uses a two-layer approach: a built-in catalog for known skills and a scoped search for consumer-authored skills.
+The skill loading path depends on whether the Standards agent is running standalone or under the Code Review Full orchestrator.
+
+### Orchestrated Mode (via Code Review Full)
+
+When the orchestrator dispatches the Standards agent, it provides a `diff-state.json` containing the file extensions from the diff. The Standards agent uses those extensions to discover and load skills itself.
+
+```mermaid
+flowchart LR
+  A["Orchestrator:<br/>write diff-state.json"] --> B["Standards agent:<br/>read extensions"]
+  B --> C["Search skills/<br/>coding-standards/"]
+  C --> D["Load matched skills"]
+  D --> E["Apply checklists"]
+  E --> F["Write JSON findings"]
+```
+
+1. The orchestrator extracts file extensions from the diff during Step 1 and writes them to the `extensions` array in `diff-state.json`.
+2. The Standards agent reads `diff-state.json`, extracts the extensions, and searches `skills/coding-standards/` for matching `SKILL.md` files.
+3. It loads up to 8 matching skills and applies each skill's checklist to the diff.
+4. It writes structured JSON findings for the orchestrator to merge.
+
+Skill discovery is owned entirely by the Standards agent. The orchestrator supplies the extensions; the Standards agent decides which skills to load.
+
+### Standalone Mode
+
+When invoked directly (without an orchestrator), the agent uses a two-layer approach: a built-in catalog for known skills and a scoped search for consumer-authored skills.
 
 ```mermaid
 flowchart LR
@@ -37,15 +61,16 @@ flowchart LR
   F --> G["Produce findings\nciting skill by name"]
 ```
 
+In standalone mode:
+
 1. The agent extracts unique file extensions from the diff's changed-file list.
-2. It looks up extensions in a built-in catalog that maps extensions to skill names and resolves each name to `.github/skills/coding-standards/{name}/SKILL.md`.
-3. It searches `.github/skills/` (not the entire workspace) for additional `SKILL.md` files, reads the `name` and `description` frontmatter from each, and loads those whose description mentions a language or framework present in the diff.
-4. It selects up to 8 skills total (built-in + consumer), preferring those whose domain appears most frequently in the changed files.
-5. It loads the full `SKILL.md` body for each selected skill and applies its checklist to the diff.
-6. Every finding traces back to the skill that surfaced it, cited by the skill's exact `name` from frontmatter.
+2. It normalizes each extension to language tokens (for example, `.py` to `python`, `.cs` to `csharp`, `.sh` to `bash`) and searches `skills/coding-standards/` for `SKILL.md` files whose `name` or `description` matches those tokens. Literal extension matches also count.
+3. It selects up to 8 matching skills, preferring those whose domain appears most frequently in the changed files.
+4. It loads the full `SKILL.md` body for each selected skill and applies its checklist to the diff.
+5. Every finding traces back to the skill that surfaced it, cited by the skill's exact `name` from frontmatter.
 
 > [!NOTE]
-> Built-in skills are loaded deterministically by extension match and naming convention; no search or frontmatter parsing required. Consumer skills rely on a scoped search under `.github/skills/` and accurate `description` frontmatter for activation.
+> Both orchestrated and standalone modes use the same skill discovery logic inside the Standards agent. The only difference is the input source: in orchestrated mode, extensions come from `diff-state.json`; in standalone mode, the agent extracts them from the diff itself. Discovery normalizes file extensions to language tokens before matching against skill metadata.
 
 ## Built-in Skills
 
@@ -204,6 +229,7 @@ A frontend team authors `.github/skills/northwind/react-standards/SKILL.md` with
 |-----------------------------|----------------------------------------------------------------|
 | python-foundational skill   | `.github/skills/coding-standards/python-foundational/SKILL.md` |
 | Standards output format     | `docs/templates/standards-review-output-format.md`             |
+| Full review output format   | `docs/templates/full-review-output-format.md`                  |
 | Engineering fundamentals    | `docs/templates/engineering-fundamentals.md`                   |
 | Skill authoring guide       | [Authoring Custom Skills](../../customization/skills.md)       |
 | Contributing skills         | [Contributing: Skills](../../contributing/skills.md)           |

--- a/docs/templates/full-review-output-format.md
+++ b/docs/templates/full-review-output-format.md
@@ -1,0 +1,85 @@
+---
+title: Code Review Full Output Format
+description: Shared data contracts, report structure, and persistence rules for the Code Review Full orchestrator and its subagents
+sidebar_position: 10
+author: microsoft/hve-core
+ms.date: 2026-04-06
+ms.topic: reference
+---
+
+## Subagent Findings JSON Schema
+
+Both subagents write findings in this format. The structured format enables deterministic merging without LLM re-parsing.
+
+```json
+{
+  "summary": "<executive summary text>",
+  "verdict": "approve | approve_with_comments | request_changes",
+  "severity_counts": { "critical": 0, "high": 0, "medium": 0, "low": 0 },
+  "changed_files": [
+    { "file": "<path>", "lines_changed": "<description>", "risk": "High|Medium|Low", "issue_count": 0 }
+  ],
+  "findings": [
+    {
+      "number": 1,
+      "title": "<brief title>",
+      "severity": "Critical|High|Medium|Low",
+      "category": "<category name>",
+      "skill": "<skill name or null>",
+      "file": "<path>",
+      "lines": "<line range, e.g. 45-52>",
+      "problem": "<description>",
+      "current_code": "<code snippet or null>",
+      "suggested_fix": "<code snippet or null>"
+    }
+  ],
+  "positive_changes": ["<observation>"],
+  "testing_recommendations": ["<recommendation>"],
+  "recommended_actions": ["<action>"],
+  "out_of_scope_observations": [
+    { "file": "<path>", "observation": "<text>" }
+  ],
+  "risk_assessment": "<risk level and explanation>",
+  "acceptance_criteria_coverage": [
+    { "ac": "<AC text>", "status": "Implemented|Partial|Not found", "notes": "<explanation>" }
+  ]
+}
+```
+
+Fields that do not apply may be omitted or set to `null` / empty array. The `acceptance_criteria_coverage` field is present only when the standards subagent received a story definition.
+
+## Report Skeleton
+
+Structure the merged report in this section order:
+
+1. Metadata header: reviewer name, branch, date, aggregate severity counts, and the standards subagent's Code/PR Summary as the report description. If the standards subagent was skipped, use the functional subagent's executive summary as the description.
+2. Changed Files Overview: unified table of all reviewed files with risk levels and issue counts.
+3. Merged Findings: all issues renumbered and tagged by source subagent, grouped by severity.
+4. Acceptance Criteria Coverage: the standards subagent's coverage table, included only when a story input was provided.
+5. Positive Changes: combined positive observations from both subagents.
+6. Testing Recommendations: combined testing guidance from both subagents.
+7. Recommended Actions: actions from the standards subagent's review. If the standards subagent was skipped, include any recommendations from the functional subagent; omit the section if both are absent.
+8. Out-of-scope Observations: combined observations from both subagents.
+9. Risk Assessment: the standards subagent's risk assessment for the overall change. If the standards subagent was skipped, derive risk level from the functional subagent's highest-severity finding.
+10. Verdict: the stricter of the two subagent verdicts with brief justification.
+
+Omit sections sourced exclusively from a subagent that was skipped.
+
+## Persist and Present
+
+**Do not present the report until both `review.md` and `metadata.json` have been successfully written to disk.**
+
+1. Write the merged report and metadata to disk using the review-artifacts protocol with `reviewer` set to `code-review-full`.
+2. Confirm both files exist before proceeding.
+3. Present a **compact summary** in the conversation, not the full report. The summary contains:
+   * Metadata table (reviewer, branch, date, severity counts)
+   * Changed Files Overview table
+   * One-line-per-finding table: `| # | Title [Source] | Severity | File:Lines |` where File:Lines is a single markdown link with a line range anchor (for example, `[review-test-sample.py](review-test-sample.py#L134-L136)`). For single-line findings use `#L<N>`; for ranges use `#L<start>-L<end>`.
+   * Verdict with brief justification
+   * Link to the full `review.md` on disk
+
+   Do not reproduce problem descriptions, code snippets, or suggested fixes in the conversation response; those exist in `review.md`.
+
+---
+
+*🤖 Crafted with precision by ✨Copilot following brilliant human instruction, then carefully refined by our team of discerning human reviewers.*


### PR DESCRIPTION
# Pull Request

## Related Issue(s)

Fixes #1303 

## Description

Refactors the `code-review-full` orchestrator from a sequential single-agent prompt into a parallel two-subagent architecture with structured JSON contracts, deterministic merge heuristics, and consolidated read discipline.

### Architecture

The orchestrator classifies diffs by T-shirt size (S/M/L/XL) and dispatches two parallel subagents — **Code Review Functional** and **Code Review Standards** — with lane boundary directives that prevent finding overlap. Each subagent writes structured JSON findings to disk; the orchestrator merges results using symbol-name-first deduplication.

### Key changes

- **Parallel subagent dispatch**: orchestrator computes the diff, writes `diff-state.json`, and launches functional + standards subagents concurrently with structured JSON output contracts
- **T-shirt size classification**: S/M diffs reviewed inline; L/XL diffs use batched subagent strategies with corrected non-overlapping tier boundaries
- **Lane directives**: functional agent owns logic/correctness findings; standards agent owns skill-backed convention findings — each agent includes an explicit lane boundary section
- **Read discipline**: all three agents enforce single full-range `read_file` per external file with parallel batching — eliminates 5+ redundant reads per execution
- **Skill discovery ownership**: removed pre-discovery from orchestrator; standards agent owns its own discovery using `extensions` from `diff-state.json`
- **Template extraction**: extracted Subagent Findings JSON Schema, Report Skeleton, and persistence rules into `docs/templates/full-review-output-format.md` to reduce orchestrator token overhead
- **Writing style compliance**: replaced all em dashes with colons and commas per repository writing-style conventions
- **Documentation rewrite**: updated `docs/agents/code-review/README.md` for parallel architecture and updated `language-skills.md` with orchestrated mode flow

### Files changed (6)

| File | Change |
|---|---|
| `.github/agents/coding-standards/code-review-full.agent.md` | Parallel dispatch, T-shirt sizing, JSON contracts, lane directives, read discipline |
| `.github/agents/coding-standards/code-review-functional.agent.md` | Orchestrated input gate, lane boundary, read discipline |
| `.github/agents/coding-standards/code-review-standards.agent.md` | Orchestrated input gate, lane boundary, consolidated skill discovery, read discipline |
| `docs/agents/code-review/README.md` | Full rewrite for parallel subagent architecture |
| `docs/agents/code-review/language-skills.md` | Updated orchestrated mode flow and reference table |
| `docs/templates/full-review-output-format.md` | New template extracted from orchestrator |

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [x] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

Invoke the full code review via the `code-review-full` agent on a feature branch, or run one of the subagents standalone:

- `@Code Review Full` — runs the parallel orchestrator on the current branch diff
- `@Code Review Standards` — runs skill-backed standards review standalone
- `@Code Review Functional` — runs functional correctness review standalone

**Execution Flow:**

1. Orchestrator detects branch, computes diff, classifies T-shirt size
2. Writes `diff-state.json` with branch metadata, file list, extensions, and diff path
3. Dispatches functional and standards subagents in parallel via `runSubagent`
4. Each subagent reads diff once, applies its review lens, writes JSON findings to `findingsFolder`
5. Orchestrator reads both findings files, merges using symbol-name deduplication (Rule 3), assembles final report

**Output Artifacts:**

- `.copilot-tracking/reviews/code-reviews/<branch>/diff-state.json` — diff metadata
- `.copilot-tracking/reviews/code-reviews/<branch>/functional-findings.json` — functional subagent output
- `.copilot-tracking/reviews/code-reviews/<branch>/standards-findings.json` — standards subagent output
- `.copilot-tracking/reviews/code-reviews/<branch>/review.md` — merged final report
- `.copilot-tracking/reviews/code-reviews/<branch>/metadata.json` — review run metadata

**Success Indicators:**

- Both subagent JSON files exist and contain valid `findings` arrays
- Merged report contains findings from both lanes without duplicates
- Verdict follows severity escalation rules (Critical/High → request changes)

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

- Ran full orchestrated review (Run 10) on `review-test-sample.py` with intentional code smells — 19 merged findings across both subagents, verdict: request_changes
- Verified lane boundary enforcement: functional agent did not produce skill-backed findings; standards agent did not flag logic errors
- Verified finding deduplication: no duplicate findings in merged report
- Manual file verification: all 7 changed files confirmed present and correct

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [x] Used `/prompt-analyze` to review contribution
* [x] Addressed all feedback from `prompt-builder` review
* [x] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`
* [x] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security script changes)

## Additional Notes

None