### PR TITLE
feat(agents): replace hve-core-specific references with portable discovery-based language

### DIFF
--- a/.github/agents/coding-standards/code-review-full.agent.md
+++ b/.github/agents/coding-standards/code-review-full.agent.md
@@ -205,7 +205,7 @@ Read all findings, the review-artifacts protocol, and the output format template
 * `<findingsFolder>/functional-findings.json`
 * `<findingsFolder>/standards-findings.json`
 * #file:../../instructions/coding-standards/code-review/review-artifacts.instructions.md (for the persistence protocol — read exactly once here; do not re-read later)
-* `docs/templates/full-review-output-format.md` (for the JSON schema, report skeleton, and persist-and-present rules — read exactly once here)
+* `docs/templates/full-review-output-format.md` (for the JSON schema, report skeleton, and persist-and-present rules — read exactly once here). If the file is not found, apply a best-effort structure using the section names and field definitions in this agent as guidance and note: "⚠️ Report template not found — output structure may vary."
 
 Issue all four `read_file` calls in one tool-call block. Do not read any of these files a second time during this step. Do not read source files, diff content, diff-state.json, or agent definition files during Step 3 — all information needed for the merge is contained in the findings JSON files, the review-artifacts protocol, and the output format template.
 
@@ -213,7 +213,7 @@ For L or XL batch reviews, read `functional-findings-batch-N.json` and `standard
 
 #### Output Format Reference
 
-Read `docs/templates/full-review-output-format.md` for the Subagent Findings JSON Schema, Report Skeleton, and Persist and Present protocol. This file is loaded in the Read Findings parallel batch — do not read it separately.
+Read `docs/templates/full-review-output-format.md` for the Subagent Findings JSON Schema, Report Skeleton, and Persist and Present protocol. This file is loaded in the Read Findings parallel batch — do not read it separately. If the file was not found during the parallel read, apply a best-effort report structure.
 
 #### Transformation Rules
 

--- a/.github/agents/hve-core/doc-ops.agent.md
+++ b/.github/agents/hve-core/doc-ops.agent.md
@@ -35,18 +35,18 @@ The main agent executes directly only for:
 
 ### Included Files
 
-| Pattern              | Description                                  |
-|----------------------|----------------------------------------------|
-| `docs/**/*.md`       | User-facing documentation, tutorials, guides |
-| `README.md`          | Repository root README                       |
-| `CONTRIBUTING.md`    | Contribution guidelines                      |
-| `CHANGELOG.md`       | Release history                              |
-| `CODE_OF_CONDUCT.md` | Community standards                          |
-| `GOVERNANCE.md`      | Project governance                           |
-| `SECURITY.md`        | Security policy                              |
-| `SUPPORT.md`         | Support information                          |
-| `LICENSE`            | License file                                 |
-| `scripts/**/*.md`    | Script documentation and READMEs             |
+| Pattern                                      | Description                                                            |
+|----------------------------------------------|------------------------------------------------------------------------|
+| `docs/**/*.md`                               | User-facing documentation, tutorials, guides                           |
+| `README.md`                                  | Repository root README                                                 |
+| `CONTRIBUTING.md`                            | Contribution guidelines                                                |
+| `CHANGELOG.md`                               | Release history                                                        |
+| `CODE_OF_CONDUCT.md`                         | Community standards                                                    |
+| `GOVERNANCE.md`                              | Project governance                                                     |
+| `SECURITY.md`                                | Security policy                                                        |
+| `SUPPORT.md`                                 | Support information                                                    |
+| `LICENSE`                                    | License file                                                           |
+| Top-level directories containing `.md` files | Script documentation, tool READMEs, and other markdown outside `docs/` |
 
 ### Excluded Files
 
@@ -84,9 +84,9 @@ Verify documentation matches implementation:
 
 Discover undocumented functionality:
 
-* Scan `scripts/` for scripts without corresponding documentation.
-* Check `extension/` for undocumented features or commands.
-* Identify `.github/skills/` entries without adequate documentation.
+* Scan top-level directories for scripts, tools, or modules without corresponding documentation.
+* Check for undocumented features or commands in build, packaging, or extension directories if they exist.
+* Identify `.github/skills/` entries without adequate documentation if the repository uses skills.
 * Find exported functions or APIs lacking usage documentation.
 
 ## Tracking Integration
@@ -157,7 +157,7 @@ Run `Researcher Subagent` with:
 Run `Researcher Subagent` with:
 
 * Task: Compare documentation claims against actual implementation.
-* Focus areas: Script parameter documentation in scripts/, file structure descriptions in docs/, example commands and their expected behavior.
+* Focus areas: Script parameter documentation, file structure descriptions in documentation directories, example commands and their expected behavior.
 * Response format: List each discrepancy with documentation file, implementation file, discrepancy type, and current vs. documented values.
 * Requirement: Indicate whether additional passes are needed.
 
@@ -166,7 +166,7 @@ Run `Researcher Subagent` with:
 Run `Researcher Subagent` with:
 
 * Task: Identify undocumented functionality.
-* Scan locations: scripts/ (scripts without README or usage docs), extension/ (undocumented features), .github/skills/ (skills without adequate documentation).
+* Scan locations: Top-level directories containing scripts or tools (look for missing README or usage docs), packaging or extension directories if present (undocumented features), .github/skills/ if the repository uses skills (inadequate documentation).
 * Response format: List each gap with location, functionality type, and suggested documentation approach.
 * Requirement: Indicate whether additional passes are needed.
 
@@ -225,10 +225,7 @@ After implementation subagents complete:
 
 Run validation scripts and verify work completion.
 
-* Execute available validation commands:
-  * `npm run lint:md` for markdown linting.
-  * `npm run lint:frontmatter` for frontmatter validation.
-  * `npm run lint:md-links` for link checking.
+* Execute available validation commands from `package.json` (common examples: markdown linting, frontmatter validation, link checking). If no validation scripts are defined, rely on manual review against the repository's instructions files.
 * Parse validation output for remaining issues.
 * Compare against baseline from Phase 1.
 
@@ -355,21 +352,15 @@ All subagents return responses containing:
 
 ## Validation Integration
 
-Use available npm scripts for automated validation:
+Check `package.json` for available validation scripts. Common validation types include markdown linting, frontmatter schema validation, and link checking.
 
-| Script                     | Purpose                       |
-|----------------------------|-------------------------------|
-| `npm run lint:md`          | Markdownlint validation       |
-| `npm run lint:frontmatter` | Frontmatter schema validation |
-| `npm run lint:md-links`    | Link validity checking        |
-
-If validation scripts are unavailable, rely on manual review against instructions files.
+If validation scripts are unavailable, rely on manual review against the repository's instructions files.
 
 Run validation:
 
 * Before Phase 1 to establish baseline.
 * After Phase 3 to verify fixes.
-* Parse JSON output from logs/ when available.
+* Parse structured output from the repository's log or output directory when available.
 
 ## Error Handling
 

--- a/.github/agents/hve-core/rpi-agent.agent.md
+++ b/.github/agents/hve-core/rpi-agent.agent.md
@@ -6,8 +6,6 @@ disable-model-invocation: true
 agents:
   - Researcher Subagent
   - Phase Implementor
-  - RPI Validator
-  - Implementation Validator
 handoffs:
   - label: Compact
     agent: RPI Agent

--- a/.github/agents/project-planning/adr-creation.agent.md
+++ b/.github/agents/project-planning/adr-creation.agent.md
@@ -44,7 +44,7 @@ Create a working draft only after understanding the core decision well enough to
 
 After identifying the core decision and before creating the working draft, establish the final ADR location. This enables checking for related decisions and ensures consistent organization.
 
-Recommended placement for HVE Core is `docs/decisions/`. This follows industry standards (adr.github.io, AWS guidance, GitHub ADR community), uses accessible language, and scales to include non-architecture decisions.
+Recommended placement is `docs/decisions/`. This follows industry standards (adr.github.io, AWS guidance, GitHub ADR community), uses accessible language, and scales to include non-architecture decisions.
 
 File naming uses ISO date prefix with version: `YYYY-MM-DD-descriptive-topic-v01.md`
 
@@ -131,4 +131,4 @@ Apply Socratic methods throughout:
 
 Adapt communication to match energy levels, technical depth, and time constraints. Acknowledge growth and note insights as understanding evolves.
 
-Reference `docs/templates/adr-template-solutions.md` when helpful, but let structure emerge from good decision-making rather than forcing template sections. The ADR is the artifact, but the learning and confidence are the real outcomes.
+Reference `docs/templates/adr-template-solutions.md` when helpful. If the template is not found, use a minimal ADR structure: Title, Status, Context, Decision, Consequences. Let structure emerge from good decision-making rather than forcing template sections. The ADR is the artifact, but the learning and confidence are the real outcomes.

--- a/.github/agents/project-planning/brd-builder.agent.md
+++ b/.github/agents/project-planning/brd-builder.agent.md
@@ -41,12 +41,12 @@ File locations:
 
 * BRD file: `docs/brds/<kebab-case-name>-brd.md`
 * State file: `.copilot-tracking/brd-sessions/<kebab-case-name>.state.json`
-* Template: `docs/templates/brd-template.md`
+* Template: `docs/templates/brd-template.md` (if available in the repository or extension/plugin context)
 
 File creation process:
 
-1. Read the BRD template from `docs/templates/brd-template.md`.
-2. Create BRD file at `docs/brds/<kebab-case-name>-brd.md` using the template structure.
+1. Read the BRD template from `docs/templates/brd-template.md`. If the template is not found, use the section structure defined in this agent as the BRD skeleton.
+2. Create BRD file at `docs/brds/<kebab-case-name>-brd.md` using the template structure (or the agent-defined skeleton if the template was unavailable).
 3. Create state file at `.copilot-tracking/brd-sessions/<kebab-case-name>.state.json`.
 4. Initialize BRD by replacing `{{placeholder}}` values with known content.
 5. Announce creation to user and explain next steps.

--- a/.github/agents/project-planning/system-architecture-reviewer.agent.md
+++ b/.github/agents/project-planning/system-architecture-reviewer.agent.md
@@ -22,7 +22,7 @@ Architecture review specialist focused on design trade-offs, well-architected al
 * Drive toward clear architectural recommendations with documented trade-offs.
 * Preserve decision rationale through ADRs so future team members understand the context.
 * Escalate security-specific concerns to the `security-planner` agent.
-* Reference `docs/templates/adr-template-solutions.md` for ADR structure.
+* Reference `docs/templates/adr-template-solutions.md` for ADR structure, if available. If the template is not found, use a minimal ADR structure: Title, Status, Context, Decision, Consequences.
 * Follow repository conventions from `.github/copilot-instructions.md`.
 
 ## Required Steps
@@ -133,7 +133,7 @@ For each trade-off, document the decision drivers, options considered, and ratio
 
 ### Step 5: Document Architecture Decisions
 
-Create an Architecture Decision Record for each significant architectural choice. Use the ADR template at `docs/templates/adr-template-solutions.md` as the structural foundation.
+Create an Architecture Decision Record for each significant architectural choice. Use the ADR template at `docs/templates/adr-template-solutions.md` as the structural foundation, if available. If the template is not found, use a minimal ADR structure: Title, Status, Context, Decision, Consequences.
 
 ADR creation criteria: document decisions when they involve:
 

--- a/.github/agents/project-planning/ux-ui-designer.agent.md
+++ b/.github/agents/project-planning/ux-ui-designer.agent.md
@@ -71,7 +71,7 @@ Analyze the incumbent solution:
 
 Tag each element of the JTBD analysis with its evidence basis: observed (from user research), reported (from stakeholder or user feedback), or assumed (team hypothesis). Journey maps built primarily on assumptions should include a recommendation to validate through user interviews before influencing design.
 
-Document the JTBD analysis using the Jobs-to-be-Done Analysis section of the [user journey template](../../../docs/templates/user-journey-template.md).
+Document the JTBD analysis using the Jobs-to-be-Done Analysis section of the user journey template at `docs/templates/user-journey-template.md` in repo, extension or plugin context. If the template is not found, structure the JTBD analysis with: Job Statement, Context, Functional/Emotional/Social dimensions, and Success Metrics.
 
 ### Step 3: User Journey Mapping
 
@@ -85,7 +85,7 @@ Structure each journey around sequential stages (awareness, exploration, action,
 * Pain points that create friction, confusion, or abandonment.
 * Design opportunities that address the identified pain points.
 
-Use the [user journey template](../../../docs/templates/user-journey-template.md) as the structural foundation.
+Use the user journey template at `docs/templates/user-journey-template.md` as the structural foundation. If the template is not found, structure journey maps with: Persona, Scenario, Phases (with steps, touchpoints, emotions, pain points, opportunities per phase), and Key Insights.
 
 ### Step 4: Accessibility Requirements
 
@@ -128,7 +128,7 @@ When collaborating with the product manager, provide journey maps and JTBD analy
 
 ## Documentation Output
 
-Save research artifacts using the [user journey template](../../../docs/templates/user-journey-template.md) structure. Place completed journey maps in a location appropriate to the project's documentation conventions.
+Save research artifacts using the user journey template at `docs/templates/user-journey-template.md` if available. Place completed journey maps in a location appropriate to the project's documentation conventions. If the template is not found, use the structural patterns described in this agent.
 
 Each research cycle produces:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,18 @@ By convention, skills are self-contained packages organized under `.github/skill
 * Contributing (`docs/contributing/`) - Guidelines for instructions, prompts, agents, and AI artifacts.
 * Templates (`docs/templates/`) - Templates for custom agents, instructions, and prompts.
 
+### Documentation Templates
+
+Templates for agent and prompt outputs are stored in `docs/templates/`:
+
+* `docs/templates/full-review-output-format.md` - Code review full output format.
+* `docs/templates/standards-review-output-format.md` - Standards review output format.
+* `docs/templates/engineering-fundamentals.md` - Engineering fundamentals reference.
+* `docs/templates/brd-template.md` - Business requirements document template.
+* `docs/templates/user-journey-template.md` - User journey template.
+* `docs/templates/adr-template-solutions.md` - Architecture decision record template.
+* `docs/templates/rca-template.md` - Root cause analysis template.
+
 ### Copilot Tracking
 
 The `.copilot-tracking/` directory (gitignored) contains AI-assisted workflow artifacts:
@@ -117,6 +129,52 @@ Collection manifests in `collections/` define bundles of agents, prompts, instru
 * Artifacts at the root of `.github/agents/`, `.github/instructions/`, `.github/prompts/`, or `.github/skills/` (without a subdirectory) are repo-specific and excluded from collection manifests, plugin generation, and extension packaging. Validation enforces this rule.
 
 PowerShell scripts follow PSScriptAnalyzer rules from `scripts/linting/PSScriptAnalyzer.psd1` and include proper comment-based help. Validation runs via `npm run lint:ps` with results output to `logs/`.
+
+### Commit Message Scopes
+
+Commit message scopes map to repository directories:
+
+* `(agents)` = `.github/agents/`
+* `(prompts)` = `.github/prompts/`
+* `(instructions)` = `.github/instructions/`
+* `(skills)` = `.github/skills/`
+* `(templates)` = `.github/ISSUE_TEMPLATE/`
+* `(workflows)` = `.github/workflows/`
+* `(extension)` = `extension/`
+* `(scripts)` = `scripts/`
+* `(docs)` = `docs/`
+* `(collections)` = `collections/`
+* `(adrs)` = Architecture Decision Records
+* `(settings)` = Configuration files (`.vscode/`, linter configs)
+* `(build)` = Build system and dependencies
+* `(ci)` = CI/CD configuration changes
+
+### Frontmatter Schema Validation
+
+Frontmatter schemas are stored in `scripts/linting/schemas/`. Schema-to-file mapping is defined in `scripts/linting/schemas/schema-mapping.json`. Run `npm run validate:frontmatter` or `pwsh scripts/linting/Validate-MarkdownFrontmatter.ps1` to validate.
+
+### PowerShell Conventions
+
+* Copyright header validation: `scripts/linting/Test-CopyrightHeaders.ps1` (also used by bash scripts).
+* Shared CI helpers module: `scripts/lib/Modules/CIHelpers.psm1`.
+* Test directories follow the pattern `scripts/tests/{category}/Test-*.Tests.ps1`.
+* Test organization mirrors source: `scripts/linting/` tests live in `scripts/tests/linting/`, `scripts/security/` tests live in `scripts/tests/security/`.
+
+### Documentation Operations
+
+The doc-ops agent scans these directories for documentation coverage analysis:
+
+* `docs/` - Primary documentation tree.
+* `scripts/` - Script-level markdown files and inline documentation.
+* `extension/` - Extension packaging documentation.
+* `.github/` - Agent, prompt, instruction, and skill documentation.
+
+Validation commands for documentation quality:
+
+* `npm run lint:md` - Markdown linting.
+* `npm run lint:frontmatter` - Frontmatter validation.
+* `npm run lint:md-links` - Markdown link checking.
+* Parse JSON output from `logs/` when available for structured validation results.
 <!-- </script-operations> -->
 
 <!-- <coding-agent-environment> -->

--- a/.github/instructions/coding-standards/bash/bash.instructions.md
+++ b/.github/instructions/coding-standards/bash/bash.instructions.md
@@ -66,7 +66,7 @@ Two required lines:
 
 Placement: after `#!/usr/bin/env bash`, before any other content.
 
-CI validates copyright headers via `npm run validate:copyright` using `scripts/linting/Test-CopyrightHeaders.ps1`.
+CI validates copyright headers through the repository's copyright validation script, if one is configured. Check `package.json` for a copyright validation command.
 
 <!-- <example-copyright-header> -->
 ```bash

--- a/.github/instructions/coding-standards/powershell/pester.instructions.md
+++ b/.github/instructions/coding-standards/powershell/pester.instructions.md
@@ -5,7 +5,7 @@ applyTo: '**/*.Tests.ps1'
 
 # Pester Testing Instructions
 
-Pester 5.x is the testing framework for all PowerShell code. Tests run exclusively through `npm run test:ps`. Never invoke Pester or test scripts directly.
+Pester 5.x is the testing framework for all PowerShell code. Run tests through the repository's test runner (check `package.json` for a test script, or invoke `Invoke-Pester` directly if no runner is configured). Follow the repository's conventions for test execution.
 
 ## Test File Naming
 
@@ -19,25 +19,18 @@ Test files use a `.Tests.ps1` suffix matching the production file name:
 
 ## Test File Location
 
-**Mirror directory pattern**: Test files in `scripts/tests/` mirror the production `scripts/` layout. Each production subdirectory has a corresponding test subdirectory:
+**Mirror directory pattern**: Place test files in a `tests/` directory that mirrors the production directory layout. Each production subdirectory has a corresponding test subdirectory. Discover the repository's test directory structure by examining existing test files.
 
-| Production directory   | Test directory               |
-|------------------------|------------------------------|
-| `scripts/collections/` | `scripts/tests/collections/` |
-| `scripts/linting/`     | `scripts/tests/linting/`     |
-| `scripts/security/`    | `scripts/tests/security/`    |
-| `scripts/lib/`         | `scripts/tests/lib/`         |
-
-**Co-located skill tests**: Skills place tests inside the skill directory rather than the mirror tree:
+**Co-located tests**: Self-contained packages (such as skills or plugins) place tests inside the package directory rather than the mirror tree:
 
 ```text
-.github/skills/shared/pr-reference/
+package-root/
 ├── scripts/
-│   ├── generate.ps1
-│   └── shared.psm1
+│   ├── action.ps1
+│   └── helpers.psm1
 └── tests/
-    ├── generate.Tests.ps1
-    └── shared.Tests.ps1
+    ├── action.Tests.ps1
+    └── helpers.Tests.ps1
 ```
 
 ## Test File Header
@@ -244,20 +237,23 @@ AfterAll {
 
 ## Running Tests
 
-Run all tests:
+Check `package.json` for a test runner script (common name: `test:ps`). If a runner is configured, use it to execute tests:
 
 ```bash
+# Example: run all tests via the repository's test runner
 npm run test:ps
+
+# Example: run tests for a specific directory or file
+npm run test:ps -- -TestPath "path/to/tests/"
 ```
 
-Run tests for a specific directory or file:
+If no runner is configured, invoke Pester directly:
 
-```bash
-npm run test:ps -- -TestPath "scripts/tests/linting/"
-npm run test:ps -- -TestPath "scripts/tests/security/Test-DependencyPinning.Tests.ps1"
+```powershell
+Invoke-Pester -Path './tests/' -Output Detailed
 ```
 
-After execution, check `logs/pester-summary.json` for overall status and `logs/pester-failures.json` for failure details.
+After execution, check the repository's log or output directory for structured test results (such as summary and failure JSON files) when available.
 
 ## Complete Test Example
 

--- a/.github/instructions/coding-standards/powershell/powershell.instructions.md
+++ b/.github/instructions/coding-standards/powershell/powershell.instructions.md
@@ -39,7 +39,7 @@ Placement varies by file type:
 # SPDX-License-Identifier: MIT
 ```
 
-CI validates copyright headers via `npm run validate:copyright` using `scripts/linting/Test-CopyrightHeaders.ps1`.
+CI validates copyright headers through the repository's copyright validation script, if one is configured. Check `package.json` for a copyright validation command.
 
 ## Script Structure
 
@@ -243,7 +243,7 @@ param(
 
 ## PSScriptAnalyzer Compliance
 
-PSScriptAnalyzer configuration lives at `scripts/linting/PSScriptAnalyzer.psd1`. Run analysis via `npm run lint:ps`.
+Use the repository's PSScriptAnalyzer configuration file (typically a `.psd1` file) for analysis. Check `package.json` for a PowerShell linting command, or run `Invoke-ScriptAnalyzer` directly with the configuration file path.
 
 Key enforced rules:
 

--- a/.github/instructions/hve-core/commit-message.instructions.md
+++ b/.github/instructions/hve-core/commit-message.instructions.md
@@ -28,20 +28,17 @@ Types MUST be one of the following:
 
 ## Scopes
 
-Scopes MUST be one of the following:
+Derive the commit scope from the primary directory affected by the change. Use the directory name in lowercase as the scope. Common scopes include:
 
-* `(agents)` - Custom agent definitions in `.github/agents/`
-* `(prompts)` - Prompt templates in `.github/prompts/`
-* `(instructions)` - Coding guidelines in `.github/instructions/`
-* `(skills)` - Skill packages in `.github/skills/`
-* `(templates)` - Issue and PR templates in `.github/ISSUE_TEMPLATE/`
-* `(workflows)` - GitHub Actions in `.github/workflows/`
-* `(extension)` - VS Code extension in `extension/`
-* `(scripts)` - Automation scripts in `scripts/`
-* `(docs)` - Documentation in `docs/`
-* `(adrs)` - Architecture Decision Records
-* `(settings)` - Configuration files (`.vscode/`, linter configs)
+* `(docs)` - Documentation
+* `(agents)` - Custom agent definitions
+* `(prompts)` - Prompt templates
+* `(instructions)` - Coding guidelines
+* `(workflows)` - CI/CD workflows
 * `(build)` - Build system and dependencies
+* `(settings)` - Configuration files
+
+Use additional scopes matching the repository's directory structure when changes target directories not listed above. If the repository defines a scope list in its project instructions, follow that list.
 
 ## Description
 

--- a/.github/instructions/hve-core/markdown.instructions.md
+++ b/.github/instructions/hve-core/markdown.instructions.md
@@ -76,10 +76,10 @@ These instructions define the Markdown style guide enforced by markdownlint in t
 
 ### Schema Validation
 
-* Schemas are located in `scripts/linting/schemas/`
-* Pattern-based mapping in `schema-mapping.json` determines which schema applies to each file
-* VS Code YAML extension (`redhat.vscode-yaml`) provides in-editor validation
-* Run validation: `npm run validate:frontmatter` or `pwsh scripts/linting/Validate-MarkdownFrontmatter.ps1`
+* Schemas define required and optional frontmatter fields per file type
+* Pattern-based mapping determines which schema applies to each file
+* VS Code YAML extension (`redhat.vscode-yaml`) provides in-editor validation when schemas are configured
+* Run the repository's frontmatter validation if available (check `package.json` for a validation command)
 
 ### Schema Pattern Matching
 
@@ -104,19 +104,18 @@ Pattern examples:
 <!-- <example-frontmatter-docs> -->
 ```yaml
 ---
-title: Getting Started with HVE Core
-description: Quick setup guide for using HVE Core Copilot customizations in your projects
-author: Microsoft
+title: Getting Started Guide
+description: Quick setup guide for configuring your project
+author: Your Team
 ms.date: 2025-11-15
 ms.topic: tutorial
 keywords:
-  - github copilot
   - setup
   - getting started
 estimated_reading_time: 5
 ---
 
-# Getting Started with HVE Core
+## Getting Started
 
 This guide shows you how to configure your project...
 ```

--- a/.github/instructions/hve-core/prompt-builder.instructions.md
+++ b/.github/instructions/hve-core/prompt-builder.instructions.md
@@ -143,7 +143,7 @@ Characteristics:
 
 * Optionally include `user-invocable: false` frontmatter to prevent direct user invocation.
 * Frontmatter includes `tools:` listing the tools available to the subagent.
-* Typically live under a `subagents/` subdirectory within their collection folder (for example, `.github/agents/hve-core/subagents/`) to separate them from user-facing agents.
+* Typically live under a `subagents/` subdirectory within their collection folder (for example, `.github/agents/{collection}/subagents/`) to separate them from user-facing agents.
 * Parent agents declare subagent dependencies in their `agents:` frontmatter using the human-readable name from each subagent's `name:` frontmatter.
 * Referenced using glob paths like `.github/agents/**/name.agent.md` so resolution works regardless of whether the subagent is at the root or in the `subagents/` folder.
 * Cannot run their own subagents; only the parent agent orchestrates subagent calls.
@@ -386,7 +386,7 @@ Skill files also include a standard attribution footer as the last line of body 
 
 Frontmatter field requirements for prompt engineering artifacts follow.
 
-Maturity is tracked in `collections/*.collection.yml` item metadata, not in frontmatter. Do not include a `maturity` field in artifact frontmatter. Set maturity on the artifact's matching collection item entry; when omitted, maturity defaults to `stable`.
+When the repository uses a collection system, maturity is tracked in collection manifest metadata, not in frontmatter. Do not include a `maturity` field in artifact frontmatter. When using collections, set maturity on the artifact's matching collection item entry; when omitted, maturity defaults to `stable`.
 
 ### Required Fields
 

--- a/.github/prompts/security/incident-response.prompt.md
+++ b/.github/prompts/security/incident-response.prompt.md
@@ -146,7 +146,7 @@ Prepare thorough post-incident documentation using the organization's RCA templa
 
 #### RCA Documentation
 
-Use the RCA template located at `docs/templates/rca-template.md` in this repository. This template follows industry best practices including [Google's SRE Postmortem format](https://sre.google/sre-book/example-postmortem/).
+Use the RCA template located at `docs/templates/rca-template.md` if available in this repository, extension or plugin context. If the template is not found, structure the RCA using industry best practices including [Google's SRE Postmortem format](https://sre.google/sre-book/example-postmortem/): Summary, Impact, Root Causes, Trigger, Detection, Resolution, Action Items, Lessons Learned, Timeline.
 
 Key practices:
 


### PR DESCRIPTION
## Description

Distributed AI artifacts contained hardcoded hve-core paths, npm scripts, template references, and branding that broke or confused when installed via extension or plugin in consumer repositories. This PR applied a two-phase migration across 15 files: hve-core-specific content moved into `copilot-instructions.md` as the canonical reference, then hardcoded references in distributed artifacts were replaced with discovery-based patterns and template fallbacks.

> The code-review-standards agent already demonstrated the correct fallback pattern after #1286 — this PR extended that model to the remaining artifacts identified in a portability audit.

### copilot-instructions.md Expansion

Six new subsections were added to `.github/copilot-instructions.md` preserving hve-core-specific details removed from distributed artifacts. **Documentation Templates** catalogs all `docs/templates/*.md` files by consuming agent. **Commit Message Scopes** maps 14 scopes to repository directories. **Frontmatter Schema Validation** records schema paths and validation commands. **PowerShell Conventions** captures the copyright header script, CI helpers module, and test directory patterns. **Documentation Operations** defines doc-ops scanning targets and validation commands. These sections sit within the existing `project-structure` and `script-operations` comment boundaries.

### Agent and Prompt Template Fallbacks

Six agent and prompt files received **template fallback patterns** following the code-review-standards model. Each file now checks template availability and provides a minimal but functional structure when the template is absent.

- *code-review-full.agent.md* added a best-effort fallback for the *full-review-output-format.md* template, annotating output with a "template not found" warning
- *brd-builder.agent.md* made the template path conditional and added a BRD skeleton fallback derived from the agent's own section structure
- *adr-creation.agent.md* removed the "for HVE Core" qualifier and added a minimal ADR fallback (Title, Status, Context, Decision, Consequences)
- *system-architecture-reviewer.agent.md* added template availability conditions with the same minimal ADR structure fallback
- *ux-ui-designer.agent.md* replaced relative template paths with generic `docs/templates/` references and discovery-based fallbacks
- *incident-response.prompt.md* changed the RCA template reference to a conditional with a detailed Google SRE-format fallback structure

### Instruction Discovery Patterns

Seven instruction files replaced hardcoded paths and commands with **discovery-based guidance** that works across any repository structure.

- *doc-ops.agent.md* underwent a major rewrite, replacing hardcoded directory scanning paths and npm script references with guidance to discover directories and validation commands from `package.json`
- *pester.instructions.md* replaced fixed test directory references with discovery patterns and made test execution flexible between npm runners and direct Pester invocation
- *commit-message.instructions.md* converted the fixed 14-item scope list to discovery-based guidance: "Derive the commit scope from the primary directory affected by the change"
- *markdown.instructions.md* generalized schema validation references and replaced HVE Core-specific example frontmatter with generic values
- *powershell.instructions.md* generalized the PSScriptAnalyzer configuration reference to discover `.psd1` files rather than hardcoding a path
- *bash.instructions.md* generalized copyright validation to check `package.json` instead of referencing a specific npm command
- *prompt-builder.instructions.md* genericized the subagent path example to a `{collection}` placeholder and made collection system references conditional

### RPI Agent Cleanup

Removed `RPI Validator` and `Implementation Validator` from the *rpi-agent.agent.md* agents frontmatter list in a separate commit. These subagents were never called by the RPI agent — they belong to *task-reviewer.agent.md* and were leftovers from a prior architecture where the RPI agent had a heavier review phase.

## Related Issue(s)

Related to #741 — overlapping scope on hardcoded `.github/` path references (tracked separately)
Related to #1286 — precursor fix establishing the template fallback pattern for code-review agents
Related to #643 — structural coordination with collection-based subdirectory reorganization
Closes #1334

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [x] Copilot instructions (`.github/instructions/*.instructions.md`)
* [x] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

Install hve-core artifacts into a consumer repository via the VS Code extension. Then invoke the BRD Builder agent, ADR Creation agent, or incident-response prompt in a repository that does not have `docs/templates/` files.

**Execution Flow:**

1. Agent attempts to read the referenced template file (e.g., `docs/templates/brd-template.md`).
2. Template not found — agent applies the fallback structure defined in its own instructions.
3. Agent generates the output using the fallback skeleton with a note indicating the template was unavailable.
4. For instruction files (commit-message, pester, etc.), the agent discovers available tools from `package.json` or repository structure rather than assuming specific npm scripts exist.

**Output Artifacts:**

Output varies by artifact. When templates are present, behavior is identical to before. When templates are absent, agents produce the same document types using embedded fallback structures. Instruction-driven agents discover available validation commands rather than failing on missing npm scripts.

**Success Indicators:**

- No "file not found" errors when template files are absent.
- hve-core agents resolve all paths via `copilot-instructions.md` with no behavior regression.
- Commit message instructions work in any repository by deriving scopes from directory structure.

## Testing

- Diff-based analysis verified all 15 changed files match the portability transformation pattern.
- Confirmed all template fallback patterns follow the model from #1286 (*code-review-standards.agent.md*).
- Verified `copilot-instructions.md` preserves the hve-core-specific content removed from distributed artifacts.
- Security analysis: no sensitive data exposure, no dependency changes, no privilege escalation patterns detected.
- Commit message follows conventional commits format: `feat(agents,instructions,prompts): ...`
- Manual testing was not performed.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable) (N/A — markdown-only changes with no testable code)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [x] Used `/prompt-analyze` to review contribution
* [x] Addressed all feedback from `prompt-builder` review
* [x] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`
* [x] Docusaurus tests: `npm run docs:test`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## GHCP Artifact Maturity

| File | Type | Maturity | Notes |
|---|---|---|---|
| `.github/agents/coding-standards/code-review-full.agent.md` | Agent | ⚠️ experimental | Pre-release only |
| `.github/agents/project-planning/brd-builder.agent.md` | Agent | ✅ stable | All builds |
| `.github/agents/project-planning/adr-creation.agent.md` | Agent | ✅ stable | All builds |
| `.github/agents/project-planning/system-architecture-reviewer.agent.md` | Agent | ✅ stable | All builds |
| `.github/agents/project-planning/ux-ui-designer.agent.md` | Agent | ✅ stable | All builds |
| `.github/agents/hve-core/doc-ops.agent.md` | Agent | ✅ stable | All builds |
| `.github/agents/hve-core/rpi-agent.agent.md` | Agent | ✅ stable | All builds |
| `.github/instructions/coding-standards/bash/bash.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/instructions/coding-standards/powershell/pester.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/instructions/coding-standards/powershell/powershell.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/instructions/hve-core/commit-message.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/instructions/hve-core/markdown.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/instructions/hve-core/prompt-builder.instructions.md` | Instructions | ✅ stable | All builds |
| `.github/prompts/security/incident-response.prompt.md` | Prompt | ⚠️ experimental | Pre-release only |

> [!WARNING]
> This PR includes **experimental** GHCP artifacts that may have breaking changes.
> - `.github/agents/coding-standards/code-review-full.agent.md`
> - `.github/prompts/security/incident-response.prompt.md`

### GHCP Maturity Acknowledgment
- [x] I acknowledge this PR includes non-stable GHCP artifacts
- [x] Non-stable artifacts are intentional for this change

