### PR TITLE
Add JSON log output to Validate-Marketplace.ps1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:md-links": "pwsh -File scripts/linting/Markdown-Link-Check.ps1",
     "lint:frontmatter": "pwsh -NoProfile -Command \"& './scripts/linting/Validate-MarkdownFrontmatter.ps1' -WarningsAsErrors -EnableSchemaValidation\"",
     "lint:collections-metadata": "pwsh -File scripts/collections/Validate-Collections.ps1",
-    "lint:marketplace": "pwsh -File scripts/plugins/Validate-Marketplace.ps1",
+    "lint:marketplace": "pwsh -File scripts/plugins/Validate-Marketplace.ps1 -OutputPath logs/marketplace-validation-results.json",
     "lint:version-consistency": "pwsh -NoProfile -Command \"./scripts/security/Test-ActionVersionConsistency.ps1 -FailOnMismatch -Format Json -OutputPath logs/action-version-consistency-results.json\"",
     "lint:permissions": "pwsh -NoProfile -Command \"& './scripts/security/Test-WorkflowPermissions.ps1' -FailOnViolation\"",
     "lint:dependency-pinning": "pwsh -NoProfile -Command \"& './scripts/security/Test-DependencyPinning.ps1' -FailOnUnpinned\"",

--- a/scripts/plugins/Validate-Marketplace.ps1
+++ b/scripts/plugins/Validate-Marketplace.ps1
@@ -18,13 +18,74 @@
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$OutputPath = 'logs/marketplace-validation-results.json'
+)
 
 $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot '../lib/Modules/CIHelpers.psm1') -Force
 
 #region Validation Helpers
+
+function Write-MarketplaceValidationReport {
+    <#
+    .SYNOPSIS
+        Writes marketplace validation results to a JSON report.
+
+    .PARAMETER RepoRoot
+        Absolute path to the repository root directory.
+
+    .PARAMETER OutputPath
+        Output report path, absolute or relative to RepoRoot.
+
+    .PARAMETER ErrorCount
+        Total number of validation errors.
+
+    .PARAMETER Results
+        Validation results grouped by plugin or manifest scope.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OutputPath = 'logs/marketplace-validation-results.json',
+
+        [Parameter(Mandatory = $true)]
+        [int]$ErrorCount,
+
+        [Parameter(Mandatory = $false)]
+        [array]$Results = @()
+    )
+
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+        return
+    }
+
+    $resolvedOutputPath = if ([System.IO.Path]::IsPathRooted($OutputPath)) {
+        $OutputPath
+    }
+    else {
+        Join-Path -Path $RepoRoot -ChildPath $OutputPath
+    }
+
+    $outputDirectory = Split-Path -Path $resolvedOutputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -Path $outputDirectory -PathType Container)) {
+        New-Item -Path $outputDirectory -ItemType Directory -Force | Out-Null
+    }
+
+    $report = [ordered]@{
+        Timestamp  = (Get-Date).ToUniversalTime().ToString('o')
+        ErrorCount = $ErrorCount
+        Results    = @($Results)
+    }
+
+    $report | ConvertTo-Json -Depth 10 | Set-Content -Path $resolvedOutputPath -Encoding UTF8
+}
 
 function Test-PluginSourceDirectory {
     <#
@@ -112,20 +173,32 @@ function Invoke-MarketplaceValidation {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$RepoRoot
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OutputPath = 'logs/marketplace-validation-results.json'
     )
 
     $manifestPath = Join-Path -Path $RepoRoot -ChildPath '.github' -AdditionalChildPath 'plugin', 'marketplace.json'
 
     if (-not (Test-Path -Path $manifestPath)) {
         Write-Host '  FAIL marketplace.json not found' -ForegroundColor Red
+        $results = @(
+            @{
+                PluginName = 'marketplace'
+                IsValid    = $false
+                Errors     = @('marketplace.json not found')
+                Warnings   = @()
+            }
+        )
+        Write-MarketplaceValidationReport -RepoRoot $RepoRoot -OutputPath $OutputPath -ErrorCount 1 -Results $results
         return @{ Success = $false; ErrorCount = 1 }
     }
 
     Write-Host 'Validating marketplace.json...'
 
-    $errorCount = 0
     $errors = @()
+    $results = @()
 
     # Parse JSON
     try {
@@ -137,6 +210,13 @@ function Invoke-MarketplaceValidation {
         foreach ($err in $errors) {
             Write-Host "    x $err" -ForegroundColor Red
         }
+        $results += @{
+            PluginName = 'marketplace'
+            IsValid    = $false
+            Errors     = @($errors)
+            Warnings   = @()
+        }
+        Write-MarketplaceValidationReport -RepoRoot $RepoRoot -OutputPath $OutputPath -ErrorCount 1 -Results $results
         return @{ Success = $false; ErrorCount = 1 }
     }
 
@@ -152,6 +232,13 @@ function Invoke-MarketplaceValidation {
         foreach ($err in $errors) {
             Write-Host "    x $err" -ForegroundColor Red
         }
+        $results += @{
+            PluginName = 'marketplace'
+            IsValid    = $false
+            Errors     = @($errors)
+            Warnings   = @()
+        }
+        Write-MarketplaceValidationReport -RepoRoot $RepoRoot -OutputPath $OutputPath -ErrorCount $errors.Count -Results $results
         return @{ Success = $false; ErrorCount = $errors.Count }
     }
 
@@ -189,18 +276,20 @@ function Invoke-MarketplaceValidation {
 
         foreach ($plugin in $manifest.plugins) {
             $pluginName = $plugin.name
+            $pluginErrors = @()
+            $pluginWarnings = @()
 
             # Required plugin fields
             $pluginRequired = @('name', 'source', 'description', 'version')
             foreach ($field in $pluginRequired) {
                 if (-not $plugin.ContainsKey($field) -or [string]::IsNullOrWhiteSpace([string]$plugin[$field])) {
-                    $errors += "plugin '$pluginName': missing required field '$field'"
+                    $pluginErrors += "missing required field '$field'"
                 }
             }
 
             # Duplicate name check
             if ($seenNames.ContainsKey($pluginName)) {
-                $errors += "duplicate plugin name '$pluginName'"
+                $pluginErrors += "duplicate plugin name '$pluginName'"
             }
             else {
                 $seenNames[$pluginName] = $true
@@ -210,7 +299,7 @@ function Invoke-MarketplaceValidation {
             if (-not [string]::IsNullOrWhiteSpace($plugin.source)) {
                 $formatError = Test-PluginSourceFormat -Source $plugin.source
                 if ($formatError) {
-                    $errors += "plugin '$pluginName': $formatError"
+                    $pluginErrors += $formatError
                 }
             }
 
@@ -218,26 +307,44 @@ function Invoke-MarketplaceValidation {
             if (-not [string]::IsNullOrWhiteSpace($plugin.source)) {
                 $dirError = Test-PluginSourceDirectory -Source $plugin.source -PluginsRoot $pluginsRoot
                 if ($dirError) {
-                    $errors += "plugin '$pluginName': $dirError"
+                    $pluginErrors += $dirError
                 }
             }
 
             # Name-source consistency
             if ($pluginName -ne $plugin.source) {
-                $errors += "plugin '$pluginName': name does not match source '$($plugin.source)'"
+                $pluginErrors += "name does not match source '$($plugin.source)'"
             }
 
             # Plugin version consistency
             if ($expectedVersion -and $plugin.version -ne $expectedVersion) {
-                $errors += "plugin '$pluginName': version '$($plugin.version)' does not match package.json version '$expectedVersion'"
+                $pluginErrors += "version '$($plugin.version)' does not match package.json version '$expectedVersion'"
+            }
+
+            $results += @{
+                PluginName = $pluginName
+                IsValid    = ($pluginErrors.Count -eq 0)
+                Errors     = @($pluginErrors)
+                Warnings   = @($pluginWarnings)
+            }
+
+            foreach ($pluginError in $pluginErrors) {
+                $errors += "plugin '$pluginName': $pluginError"
             }
         }
     }
 
-    $errorCount = $errors.Count
+    if ($errors.Count -gt 0 -and $results.Count -eq 0) {
+        $results += @{
+            PluginName = 'marketplace'
+            IsValid    = $false
+            Errors     = @($errors)
+            Warnings   = @()
+        }
+    }
 
-    if ($errorCount -gt 0) {
-        Write-Host "  FAIL marketplace.json - $errorCount error(s)" -ForegroundColor Red
+    if ($errors.Count -gt 0) {
+        Write-Host "  FAIL marketplace.json - $($errors.Count) error(s)" -ForegroundColor Red
         foreach ($err in $errors) {
             Write-Host "      $err" -ForegroundColor Red
         }
@@ -246,9 +353,11 @@ function Invoke-MarketplaceValidation {
         Write-Host "  OK marketplace.json ($($manifest.plugins.Count) plugins)"
     }
 
+    Write-MarketplaceValidationReport -RepoRoot $RepoRoot -OutputPath $OutputPath -ErrorCount $errors.Count -Results $results
+
     return @{
-        Success    = ($errorCount -eq 0)
-        ErrorCount = $errorCount
+        Success    = ($errors.Count -eq 0)
+        ErrorCount = $errors.Count
     }
 }
 
@@ -260,7 +369,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
         $RepoRoot = (Get-Item "$ScriptDir/../..").FullName
 
-        $result = Invoke-MarketplaceValidation -RepoRoot $RepoRoot
+        $result = Invoke-MarketplaceValidation -RepoRoot $RepoRoot -OutputPath $OutputPath
 
         if (-not $result.Success) {
             throw "Marketplace validation failed with $($result.ErrorCount) error(s)."

--- a/scripts/tests/plugins/Validate-Marketplace.Tests.ps1
+++ b/scripts/tests/plugins/Validate-Marketplace.Tests.ps1
@@ -352,3 +352,63 @@ Describe 'Invoke-MarketplaceValidation - valid manifest' {
         $result.ErrorCount | Should -Be 0
     }
 }
+
+Describe 'Invoke-MarketplaceValidation - JSON output' {
+    BeforeEach {
+        $script:repoRoot = Join-Path $TestDrive 'repo-json-output'
+        $script:manifestDir = Join-Path $script:repoRoot '.github/plugin'
+        New-Item -ItemType Directory -Path $script:manifestDir -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:repoRoot 'plugins/my-plugin') -Force | Out-Null
+        Set-Content -Path (Join-Path $script:repoRoot 'package.json') -Value '{"version":"1.0.0"}'
+    }
+
+    It 'Writes report with expected schema for valid plugin validation' {
+        $outputPath = Join-Path $TestDrive 'logs/marketplace-validation-results.json'
+        $json = @{
+            name     = 'test'
+            metadata = @{ description = 'd'; version = '1.0.0'; pluginRoot = 'plugins' }
+            owner    = @{ name = 'owner' }
+            plugins  = @(
+                @{ name = 'my-plugin'; source = 'my-plugin'; description = 'A plugin'; version = '1.0.0' }
+            )
+        } | ConvertTo-Json -Depth 5
+        Set-Content -Path (Join-Path $script:manifestDir 'marketplace.json') -Value $json
+
+        $result = Invoke-MarketplaceValidation -RepoRoot $script:repoRoot -OutputPath $outputPath
+        $report = Get-Content -Path $outputPath -Raw | ConvertFrom-Json
+
+        $result.Success | Should -BeTrue
+        $report.Timestamp | Should -Not -BeNullOrEmpty
+        { [DateTimeOffset]::Parse($report.Timestamp) } | Should -Not -Throw
+        $report.ErrorCount | Should -Be 0
+        $report.Results.Count | Should -Be 1
+        $report.Results[0].PluginName | Should -Be 'my-plugin'
+        $report.Results[0].IsValid | Should -BeTrue
+        $report.Results[0].Errors | Should -BeNullOrEmpty
+        $report.Results[0].Warnings | Should -BeNullOrEmpty
+    }
+
+    It 'Writes per-plugin errors into JSON results' {
+        $outputPath = Join-Path $TestDrive 'logs/marketplace-validation-results.json'
+        New-Item -ItemType Directory -Path (Join-Path $script:repoRoot 'plugins/actual-source') -Force | Out-Null
+        $json = @{
+            name     = 'test'
+            metadata = @{ description = 'd'; version = '1.0.0'; pluginRoot = 'plugins' }
+            owner    = @{ name = 'owner' }
+            plugins  = @(
+                @{ name = 'display-name'; source = 'actual-source'; description = 'A plugin'; version = '1.0.0' }
+            )
+        } | ConvertTo-Json -Depth 5
+        Set-Content -Path (Join-Path $script:manifestDir 'marketplace.json') -Value $json
+
+        $result = Invoke-MarketplaceValidation -RepoRoot $script:repoRoot -OutputPath $outputPath
+        $report = Get-Content -Path $outputPath -Raw | ConvertFrom-Json
+        $pluginResult = @($report.Results | Where-Object { $_.PluginName -eq 'display-name' })[0]
+
+        $result.Success | Should -BeFalse
+        $report.ErrorCount | Should -BeGreaterThan 0
+        $pluginResult.IsValid | Should -BeFalse
+        $pluginResult.Errors | Should -Contain "name does not match source 'actual-source'"
+        $pluginResult.Warnings | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
Implements issue #991 by adding JSON report output to marketplace validation, wiring npm lint command output path, and adding Pester coverage for JSON schema/results.