### PR TITLE
feat(scripts): add structured JSON log output to Validate-Collections.ps1

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -40,14 +40,14 @@ jobs:
             Install-Module -Name PowerShell-Yaml -RequiredVersion 0.4.7 -Force -Scope CurrentUser
           }
 
+      - name: Create logs directory
+        run: mkdir -p logs
+
       - name: Validate collection metadata
         run: npm run lint:collections-metadata
 
       - name: Validate marketplace manifest
         run: npm run lint:marketplace
-
-      - name: Create logs directory
-        run: mkdir -p logs
 
       - name: Check plugin freshness
         run: |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:links": "pwsh -NoProfile -Command \"& scripts/linting/Invoke-LinkLanguageCheck.ps1 -ExcludePaths 'scripts/tests/**'\"",
     "lint:md-links": "pwsh -File scripts/linting/Markdown-Link-Check.ps1",
     "lint:frontmatter": "pwsh -NoProfile -Command \"& './scripts/linting/Validate-MarkdownFrontmatter.ps1' -WarningsAsErrors -EnableSchemaValidation\"",
-    "lint:collections-metadata": "pwsh -File scripts/collections/Validate-Collections.ps1",
+    "lint:collections-metadata": "pwsh -NoProfile -Command \"./scripts/collections/Validate-Collections.ps1 -OutputPath logs/collection-validation-results.json\"",
     "lint:marketplace": "pwsh -File scripts/plugins/Validate-Marketplace.ps1",
     "lint:version-consistency": "pwsh -NoProfile -Command \"./scripts/security/Test-ActionVersionConsistency.ps1 -FailOnMismatch -Format Json -OutputPath logs/action-version-consistency-results.json\"",
     "lint:permissions": "pwsh -NoProfile -Command \"& './scripts/security/Test-WorkflowPermissions.ps1' -FailOnViolation\"",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:links": "pwsh -NoProfile -Command \"& scripts/linting/Invoke-LinkLanguageCheck.ps1 -ExcludePaths 'scripts/tests/**'\"",
     "lint:md-links": "pwsh -File scripts/linting/Markdown-Link-Check.ps1",
     "lint:frontmatter": "pwsh -NoProfile -Command \"& './scripts/linting/Validate-MarkdownFrontmatter.ps1' -WarningsAsErrors -EnableSchemaValidation\"",
-    "lint:collections-metadata": "pwsh -File scripts/collections/Validate-Collections.ps1",
+    "lint:collections-metadata": "pwsh -NoProfile -Command \"./scripts/collections/Validate-Collections.ps1 -OutputPath logs/collection-validation-results.json\"",
     "lint:marketplace": "pwsh -File scripts/plugins/Validate-Marketplace.ps1 -OutputPath logs/marketplace-validation-results.json",
     "lint:version-consistency": "pwsh -NoProfile -Command \"./scripts/security/Test-ActionVersionConsistency.ps1 -FailOnMismatch -Format Json -OutputPath logs/action-version-consistency-results.json\"",
     "lint:permissions": "pwsh -NoProfile -Command \"& './scripts/security/Test-WorkflowPermissions.ps1' -FailOnViolation\"",

--- a/scripts/collections/Validate-Collections.ps1
+++ b/scripts/collections/Validate-Collections.ps1
@@ -16,7 +16,10 @@
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [Parameter()]
+    [string]$OutputPath = (Join-Path $PSScriptRoot '../../logs/collection-validation-results.json')
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -137,7 +140,7 @@ function Invoke-CollectionValidation {
         Absolute path to the repository root directory.
 
     .OUTPUTS
-        Hashtable with Success bool, ErrorCount int, and CollectionCount int.
+        Hashtable with Success bool, ErrorCount int, CollectionCount int, and Results array.
     #>
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -147,12 +150,39 @@ function Invoke-CollectionValidation {
         [string]$RepoRoot
     )
 
+    $validationResults = [System.Collections.Generic.List[hashtable]]::new()
+
+    function Add-ValidationResult {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Collection,
+
+            [Parameter(Mandatory = $true)]
+            [string]$ErrorType,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Message,
+
+            [Parameter()]
+            [ValidateSet('Error', 'Warning')]
+            [string]$Severity = 'Error'
+        )
+
+        $validationResults.Add(@{
+            Collection = $Collection
+            Severity   = $Severity
+            ErrorType  = $ErrorType
+            Message    = $Message
+        })
+    }
+
     $collectionsDir = Join-Path -Path $RepoRoot -ChildPath 'collections'
     $collectionFiles = Get-ChildItem -Path $collectionsDir -Filter '*.collection.yml' -File
 
     if ($collectionFiles.Count -eq 0) {
         Write-Host ' WARN No collection manifests found in collections/' -ForegroundColor Yellow
-        return @{ Success = $true; ErrorCount = 0; CollectionCount = 0 }
+        Add-ValidationResult -Collection 'collections' -ErrorType 'NoCollectionManifests' -Message 'No collection manifests found in collections/' -Severity 'Warning'
+        return @{ Success = $true; ErrorCount = 0; CollectionCount = 0; Results = @($validationResults) }
     }
 
     Write-Host 'Validating collections...'
@@ -172,9 +202,11 @@ function Invoke-CollectionValidation {
 
     foreach ($file in $collectionFiles) {
         $baseName = $file.Name -replace '\.collection\.yml$', ''
+        $collectionLabel = $baseName
         $companionPath = Join-Path -Path $collectionsDir -ChildPath "$baseName.collection.md"
         if (-not (Test-Path -Path $companionPath)) {
             Write-Host " WARN $($file.Name): missing companion '$baseName.collection.md'" -ForegroundColor Yellow
+            Add-ValidationResult -Collection $collectionLabel -ErrorType 'MissingCompanionCollectionMd' -Message "missing companion '$baseName.collection.md'" -Severity 'Warning'
         }
 
         if (Test-Path -Path $companionPath) {
@@ -184,6 +216,7 @@ function Invoke-CollectionValidation {
 
             if ($hasBegin -xor $hasEnd) {
                 Write-Host "  WARN $($file.Name): $baseName.collection.md has mismatched auto-generation markers" -ForegroundColor Yellow
+                Add-ValidationResult -Collection $collectionLabel -ErrorType 'MismatchedAutoGenerationMarkers' -Message "$baseName.collection.md has mismatched auto-generation markers" -Severity 'Warning'
             }
 
             if ($hasBegin -and $hasEnd) {
@@ -191,6 +224,7 @@ function Invoke-CollectionValidation {
                 $endIdx = $mdContent.IndexOf($CollectionMdEndMarker)
                 if ($endIdx -le $beginIdx) {
                     Write-Host "  WARN $($file.Name): $baseName.collection.md has markers in wrong order" -ForegroundColor Yellow
+                    Add-ValidationResult -Collection $collectionLabel -ErrorType 'CollectionMarkersWrongOrder' -Message "$baseName.collection.md has markers in wrong order" -Severity 'Warning'
                 }
             }
         }
@@ -211,12 +245,14 @@ function Invoke-CollectionValidation {
         if ($fileErrors.Count -gt 0) {
             foreach ($err in $fileErrors) {
                 Write-Host "    x $($file.Name): $err" -ForegroundColor Red
+                Add-ValidationResult -Collection $collectionLabel -ErrorType 'CollectionValidationError' -Message $err
             }
             $errorCount += $fileErrors.Count
             continue
         }
 
         $id = $manifest.id
+        $collectionLabel = $id
 
         # Id format
         if ($id -notmatch '^[a-z0-9-]+$') {
@@ -294,6 +330,7 @@ function Invoke-CollectionValidation {
                     $folderName = $pathSegments[2]
                     if ($folderName -ne 'shared' -and -not $knownCollectionIds.ContainsKey($folderName)) {
                         Write-Host " WARN collection '$id': item folder '$folderName' does not match any known collection ID: $itemPath" -ForegroundColor Yellow
+                        Add-ValidationResult -Collection $collectionLabel -ErrorType 'UnknownCollectionFolderReference' -Message "item folder '$folderName' does not match any known collection ID: $itemPath" -Severity 'Warning'
                     }
                 }
             }
@@ -323,6 +360,7 @@ function Invoke-CollectionValidation {
             Write-Host "  FAIL $id ($itemCount items) - $($fileErrors.Count) error(s)" -ForegroundColor Red
             foreach ($err in $fileErrors) {
                 Write-Host "      $err" -ForegroundColor Red
+                Add-ValidationResult -Collection $collectionLabel -ErrorType 'CollectionValidationError' -Message $err
             }
             $errorCount += $fileErrors.Count
         }
@@ -338,6 +376,7 @@ function Invoke-CollectionValidation {
     }).Count -gt 0
     if (-not $canonicalManifestFound) {
         Write-Host " WARN '$canonicalCollectionId.collection.yml' not found; skipping orphan and cross-collection coverage checks" -ForegroundColor Yellow
+        Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'CanonicalCollectionMissing' -Message "'$canonicalCollectionId.collection.yml' not found; skipping orphan and cross-collection coverage checks" -Severity 'Warning'
     }
 
     # Duplicate artifact key detection across all collections
@@ -363,6 +402,7 @@ function Invoke-CollectionValidation {
             $nameLabel = ($compositeKey -split '\|')[1]
             $pathList = ($paths | Sort-Object) -join ', '
             Write-Host "  FAIL duplicate $kindLabel artifact key '$nameLabel' found at distinct paths: $pathList" -ForegroundColor Red
+            Add-ValidationResult -Collection 'all-collections' -ErrorType 'DuplicateArtifactKey' -Message "duplicate $kindLabel artifact key '$nameLabel' found at distinct paths: $pathList"
             $errorCount++
         }
     }
@@ -376,6 +416,7 @@ function Invoke-CollectionValidation {
         if ($canonicalManifestFound -and $themedMatches.Count -gt 0 -and $canonicalMatches.Count -eq 0) {
             $themedCollections = ($themedMatches | ForEach-Object { $_.CollectionId } | Sort-Object -Unique) -join ', '
             Write-Host "  FAIL item '$itemKey' exists in themed collection(s) [$themedCollections] but is absent from '$canonicalCollectionId'" -ForegroundColor Red
+            Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'ThemedItemMissingFromCanonical' -Message "item '$itemKey' exists in themed collection(s) [$themedCollections] but is absent from '$canonicalCollectionId'"
             $errorCount++
             continue
         }
@@ -386,6 +427,7 @@ function Invoke-CollectionValidation {
             foreach ($occurrence in $themedMatches) {
                 if ($occurrence.Maturity -ne $canonical.Maturity) {
                     Write-Host "  FAIL maturity conflict for '$itemKey': canonical '$canonicalCollectionId'='$($canonical.Maturity)', '$($occurrence.CollectionId)'='$($occurrence.Maturity)'" -ForegroundColor Red
+                    Add-ValidationResult -Collection $occurrence.CollectionId -ErrorType 'MaturityConflict' -Message "maturity conflict for '$itemKey': canonical '$canonicalCollectionId'='$($canonical.Maturity)', '$($occurrence.CollectionId)'='$($occurrence.Maturity)'"
                     $errorCount++
                 }
             }
@@ -404,9 +446,11 @@ function Invoke-CollectionValidation {
 
             if (-not $inCanonical) {
                 Write-Host "  FAIL orphan: '$diskKey' is on disk but absent from '$canonicalCollectionId'" -ForegroundColor Red
+                Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'OrphanArtifact' -Message "'$diskKey' is on disk but absent from '$canonicalCollectionId'"
                 $errorCount++
             } elseif (-not $inThemed) {
                 Write-Host " WARN '$diskKey' exists in '$canonicalCollectionId' but is not in any themed collection" -ForegroundColor Yellow
+                Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'CanonicalOnlyArtifact' -Message "'$diskKey' exists in '$canonicalCollectionId' but is not in any themed collection" -Severity 'Warning'
             }
         }
     }
@@ -418,7 +462,33 @@ function Invoke-CollectionValidation {
         Success         = ($errorCount -eq 0)
         ErrorCount      = $errorCount
         CollectionCount = $validatedCount
+        Results         = @($validationResults)
     }
+}
+
+function Export-CollectionValidationReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$ValidationResult,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    $logsDir = Split-Path -Path $OutputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($logsDir) -and -not (Test-Path -Path $logsDir)) {
+        New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+    }
+
+    $report = @{
+        Timestamp        = (Get-Date).ToUniversalTime().ToString('o')
+        TotalCollections = $ValidationResult.CollectionCount
+        ErrorCount       = $ValidationResult.ErrorCount
+        Results          = @($ValidationResult.Results)
+    }
+
+    $report | ConvertTo-Json -Depth 10 | Set-Content -Path $OutputPath -Encoding utf8
 }
 
 #endregion Orchestration
@@ -437,6 +507,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $RepoRoot = (Get-Item "$ScriptDir/../..").FullName
 
         $result = Invoke-CollectionValidation -RepoRoot $RepoRoot
+        Export-CollectionValidationReport -ValidationResult $result -OutputPath $OutputPath
 
         if (-not $result.Success) {
             throw "Validation failed with $($result.ErrorCount) error(s)."

--- a/scripts/collections/Validate-Collections.ps1
+++ b/scripts/collections/Validate-Collections.ps1
@@ -16,7 +16,10 @@
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [Parameter()]
+    [string]$OutputPath = (Join-Path $PSScriptRoot '../../logs/collection-validation-results.json')
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -137,7 +140,7 @@ function Invoke-CollectionValidation {
         Absolute path to the repository root directory.
 
     .OUTPUTS
-        Hashtable with Success bool, ErrorCount int, and CollectionCount int.
+        Hashtable with Success bool, ErrorCount int, CollectionCount int, and Results array.
     #>
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -147,12 +150,39 @@ function Invoke-CollectionValidation {
         [string]$RepoRoot
     )
 
+    $validationResults = [System.Collections.Generic.List[hashtable]]::new()
+
+    function Add-ValidationResult {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Collection,
+
+            [Parameter(Mandatory = $true)]
+            [string]$ErrorType,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Message,
+
+            [Parameter()]
+            [ValidateSet('Error', 'Warning')]
+            [string]$Severity = 'Error'
+        )
+
+        $validationResults.Add(@{
+            Collection = $Collection
+            Severity   = $Severity
+            ErrorType  = $ErrorType
+            Message    = $Message
+        })
+    }
+
     $collectionsDir = Join-Path -Path $RepoRoot -ChildPath 'collections'
     $collectionFiles = Get-ChildItem -Path $collectionsDir -Filter '*.collection.yml' -File
 
     if ($collectionFiles.Count -eq 0) {
         Write-Host ' WARN No collection manifests found in collections/' -ForegroundColor Yellow
-        return @{ Success = $true; ErrorCount = 0; CollectionCount = 0 }
+        Add-ValidationResult -Collection 'collections' -ErrorType 'NoCollectionManifests' -Message 'No collection manifests found in collections/' -Severity 'Warning'
+        return @{ Success = $true; ErrorCount = 0; CollectionCount = 0; Results = @($validationResults) }
     }
 
     Write-Host 'Validating collections...'
@@ -179,9 +209,11 @@ function Invoke-CollectionValidation {
 
     foreach ($file in $collectionFiles) {
         $baseName = $file.Name -replace '\.collection\.yml$', ''
+        $collectionLabel = $baseName
         $companionPath = Join-Path -Path $collectionsDir -ChildPath "$baseName.collection.md"
         if (-not (Test-Path -Path $companionPath)) {
             Write-Host " WARN $($file.Name): missing companion '$baseName.collection.md'" -ForegroundColor Yellow
+            Add-ValidationResult -Collection $collectionLabel -ErrorType 'MissingCompanionCollectionMd' -Message "missing companion '$baseName.collection.md'" -Severity 'Warning'
         }
 
         if (Test-Path -Path $companionPath) {
@@ -191,6 +223,7 @@ function Invoke-CollectionValidation {
 
             if ($hasBegin -xor $hasEnd) {
                 Write-Host "  WARN $($file.Name): $baseName.collection.md has mismatched auto-generation markers" -ForegroundColor Yellow
+                Add-ValidationResult -Collection $collectionLabel -ErrorType 'MismatchedAutoGenerationMarkers' -Message "$baseName.collection.md has mismatched auto-generation markers" -Severity 'Warning'
             }
 
             if ($hasBegin -and $hasEnd) {
@@ -198,6 +231,7 @@ function Invoke-CollectionValidation {
                 $endIdx = $mdContent.IndexOf($CollectionMdEndMarker)
                 if ($endIdx -le $beginIdx) {
                     Write-Host "  WARN $($file.Name): $baseName.collection.md has markers in wrong order" -ForegroundColor Yellow
+                    Add-ValidationResult -Collection $collectionLabel -ErrorType 'CollectionMarkersWrongOrder' -Message "$baseName.collection.md has markers in wrong order" -Severity 'Warning'
                 }
             }
         }
@@ -210,29 +244,31 @@ function Invoke-CollectionValidation {
         $requiredFields = @('id', 'name', 'description', 'items')
         foreach ($field in $requiredFields) {
             if (-not $manifest.ContainsKey($field) -or $null -eq $manifest[$field]) {
-                $fileErrors += "missing required field '$field'"
+                $fileErrors += @{ ErrorType = 'MissingRequiredField'; Message = "missing required field '$field'" }
             }
         }
 
         # Skip further checks if required fields are absent
         if ($fileErrors.Count -gt 0) {
             foreach ($err in $fileErrors) {
-                Write-Host "    x $($file.Name): $err" -ForegroundColor Red
+                Write-Host "    x $($file.Name): $($err.Message)" -ForegroundColor Red
+                Add-ValidationResult -Collection $collectionLabel -ErrorType $err.ErrorType -Message $err.Message
             }
             $errorCount += $fileErrors.Count
             continue
         }
 
         $id = $manifest.id
+        $collectionLabel = $id
 
         # Id format
         if ($id -notmatch '^[a-z0-9-]+$') {
-            $fileErrors += "id '$id' must match ^[a-z0-9-]+$"
+            $fileErrors += @{ ErrorType = 'InvalidIdFormat'; Message = "id '$id' must match ^[a-z0-9-]+$" }
         }
 
         # Duplicate id check
         if ($seenIds.ContainsKey($id)) {
-            $fileErrors += "duplicate id '$id' (also in $($seenIds[$id]))"
+            $fileErrors += @{ ErrorType = 'DuplicateCollectionId'; Message = "duplicate id '$id' (also in $($seenIds[$id]))" }
         }
         else {
             $seenIds[$id] = $file.Name
@@ -242,7 +278,7 @@ function Invoke-CollectionValidation {
         if ($manifest.ContainsKey('maturity') -and -not [string]::IsNullOrWhiteSpace([string]$manifest.maturity)) {
             $collMaturity = [string]$manifest.maturity
             if ($allowedMaturities -notcontains $collMaturity) {
-                $fileErrors += "invalid collection maturity '$collMaturity' (allowed: $($allowedMaturities -join ', '))"
+                $fileErrors += @{ ErrorType = 'InvalidCollectionMaturity'; Message = "invalid collection maturity '$collMaturity' (allowed: $($allowedMaturities -join ', '))" }
             }
         }
 
@@ -260,34 +296,34 @@ function Invoke-CollectionValidation {
 
             # Repo-specific path exclusion
             if (Test-HveCoreRepoRelativePath -Path $itemPath) {
-                $fileErrors += "repo-specific path not allowed in collections: $itemPath (root-level artifacts under .github/{type}/ are excluded from distribution)"
+                $fileErrors += @{ ErrorType = 'RepoSpecificPath'; Message = "repo-specific path not allowed in collections: $itemPath (root-level artifacts under .github/{type}/ are excluded from distribution)" }
             }
 
             # Path existence
             if (-not (Test-Path -Path $absolutePath)) {
-                $fileErrors += "path not found: $itemPath"
+                $fileErrors += @{ ErrorType = 'PathNotFound'; Message = "path not found: $itemPath" }
             }
 
             # Kind-suffix consistency
             if ($kind) {
                 $suffixError = Test-KindSuffix -Kind $kind -ItemPath $itemPath -RepoRoot $RepoRoot
                 if ($suffixError) {
-                    $fileErrors += $suffixError
+                    $fileErrors += @{ ErrorType = 'MissingSuffix'; Message = $suffixError }
                 }
             }
             else {
-                $fileErrors += "item missing 'kind': $itemPath"
+                $fileErrors += @{ ErrorType = 'MissingItemKind'; Message = "item missing 'kind': $itemPath" }
             }
 
             if (-not [string]::IsNullOrWhiteSpace($itemMaturity) -and ($allowedMaturities -notcontains $itemMaturity)) {
-                $fileErrors += "invalid maturity '$itemMaturity' for item '$itemPath' (allowed: $($allowedMaturities -join ', '))"
+                $fileErrors += @{ ErrorType = 'InvalidMaturity'; Message = "invalid maturity '$itemMaturity' for item '$itemPath' (allowed: $($allowedMaturities -join ', '))" }
             }
 
             # Check 2: intra-collection duplicate detection
             if (-not [string]::IsNullOrWhiteSpace($itemPath) -and -not [string]::IsNullOrWhiteSpace($kind)) {
                 $dupKey = Get-CollectionItemKey -Kind $kind -ItemPath $itemPath
                 if ($seenItemKeys.ContainsKey($dupKey)) {
-                    $fileErrors += "duplicate item '$dupKey' appears more than once in collection '$id'"
+                    $fileErrors += @{ ErrorType = 'IntraCollectionDuplicate'; Message = "duplicate item '$dupKey' appears more than once in collection '$id'" }
                 } else {
                     $seenItemKeys[$dupKey] = $true
                 }
@@ -301,6 +337,7 @@ function Invoke-CollectionValidation {
                     $folderName = $pathSegments[2]
                     if (-not $sharedSubdomainFolders.ContainsKey($folderName) -and -not $knownCollectionIds.ContainsKey($folderName)) {
                         Write-Host " WARN collection '$id': item folder '$folderName' does not match any known collection ID: $itemPath" -ForegroundColor Yellow
+                        Add-ValidationResult -Collection $collectionLabel -ErrorType 'UnknownCollectionFolderReference' -Message "item folder '$folderName' does not match any known collection ID: $itemPath" -Severity 'Warning'
                     }
                 }
             }
@@ -329,7 +366,8 @@ function Invoke-CollectionValidation {
         if ($fileErrors.Count -gt 0) {
             Write-Host "  FAIL $id ($itemCount items) - $($fileErrors.Count) error(s)" -ForegroundColor Red
             foreach ($err in $fileErrors) {
-                Write-Host "      $err" -ForegroundColor Red
+                Write-Host "      $($err.Message)" -ForegroundColor Red
+                Add-ValidationResult -Collection $collectionLabel -ErrorType $err.ErrorType -Message $err.Message
             }
             $errorCount += $fileErrors.Count
         }
@@ -345,6 +383,7 @@ function Invoke-CollectionValidation {
     }).Count -gt 0
     if (-not $canonicalManifestFound) {
         Write-Host " WARN '$canonicalCollectionId.collection.yml' not found; skipping orphan and cross-collection coverage checks" -ForegroundColor Yellow
+        Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'CanonicalCollectionMissing' -Message "'$canonicalCollectionId.collection.yml' not found; skipping orphan and cross-collection coverage checks" -Severity 'Warning'
     }
 
     # Duplicate artifact key detection across all collections
@@ -370,6 +409,7 @@ function Invoke-CollectionValidation {
             $nameLabel = ($compositeKey -split '\|')[1]
             $pathList = ($paths | Sort-Object) -join ', '
             Write-Host "  FAIL duplicate $kindLabel artifact key '$nameLabel' found at distinct paths: $pathList" -ForegroundColor Red
+            Add-ValidationResult -Collection 'all-collections' -ErrorType 'DuplicateArtifactKey' -Message "duplicate $kindLabel artifact key '$nameLabel' found at distinct paths: $pathList"
             $errorCount++
         }
     }
@@ -386,6 +426,7 @@ function Invoke-CollectionValidation {
         if ($canonicalManifestFound -and $activeThemedMatches.Count -gt 0 -and $canonicalMatches.Count -eq 0) {
             $themedCollections = ($activeThemedMatches | ForEach-Object { $_.CollectionId } | Sort-Object -Unique) -join ', '
             Write-Host "  FAIL item '$itemKey' exists in themed collection(s) [$themedCollections] but is absent from '$canonicalCollectionId'" -ForegroundColor Red
+            Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'ThemedItemMissingFromCanonical' -Message "item '$itemKey' exists in themed collection(s) [$themedCollections] but is absent from '$canonicalCollectionId'"
             $errorCount++
             continue
         }
@@ -396,6 +437,7 @@ function Invoke-CollectionValidation {
             foreach ($occurrence in $themedMatches) {
                 if ($occurrence.Maturity -ne $canonical.Maturity) {
                     Write-Host "  FAIL maturity conflict for '$itemKey': canonical '$canonicalCollectionId'='$($canonical.Maturity)', '$($occurrence.CollectionId)'='$($occurrence.Maturity)'" -ForegroundColor Red
+                    Add-ValidationResult -Collection $occurrence.CollectionId -ErrorType 'MaturityConflict' -Message "maturity conflict for '$itemKey': canonical '$canonicalCollectionId'='$($canonical.Maturity)', '$($occurrence.CollectionId)'='$($occurrence.Maturity)'"
                     $errorCount++
                 }
             }
@@ -420,10 +462,12 @@ function Invoke-CollectionValidation {
                     Write-Verbose "Skipping orphan check for tombstoned item '$diskKey'"
                 } else {
                     Write-Host "  FAIL orphan: '$diskKey' is on disk but absent from '$canonicalCollectionId'" -ForegroundColor Red
+                    Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'OrphanArtifact' -Message "'$diskKey' is on disk but absent from '$canonicalCollectionId'"
                     $errorCount++
                 }
             } elseif (-not $inThemed) {
                 Write-Host " WARN '$diskKey' exists in '$canonicalCollectionId' but is not in any themed collection" -ForegroundColor Yellow
+                Add-ValidationResult -Collection $canonicalCollectionId -ErrorType 'CanonicalOnlyArtifact' -Message "'$diskKey' exists in '$canonicalCollectionId' but is not in any themed collection" -Severity 'Warning'
             }
         }
     }
@@ -435,7 +479,33 @@ function Invoke-CollectionValidation {
         Success         = ($errorCount -eq 0)
         ErrorCount      = $errorCount
         CollectionCount = $validatedCount
+        Results         = @($validationResults)
     }
+}
+
+function Export-CollectionValidationReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$ValidationResult,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    $logsDir = Split-Path -Path $OutputPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($logsDir) -and -not (Test-Path -Path $logsDir)) {
+        New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+    }
+
+    $report = @{
+        Timestamp        = (Get-Date).ToUniversalTime().ToString('o')
+        TotalCollections = $ValidationResult.CollectionCount
+        ErrorCount       = $ValidationResult.ErrorCount
+        Results          = @($ValidationResult.Results)
+    }
+
+    $report | ConvertTo-Json -Depth 10 | Set-Content -Path $OutputPath -Encoding utf8
 }
 
 #endregion Orchestration
@@ -454,6 +524,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         $RepoRoot = (Get-Item "$ScriptDir/../..").FullName
 
         $result = Invoke-CollectionValidation -RepoRoot $RepoRoot
+        Export-CollectionValidationReport -ValidationResult $result -OutputPath $OutputPath
 
         if (-not $result.Success) {
             throw "Validation failed with $($result.ErrorCount) error(s)."

--- a/scripts/tests/collections/Validate-Collections.Tests.ps1
+++ b/scripts/tests/collections/Validate-Collections.Tests.ps1
@@ -1185,3 +1185,64 @@ Content.
         $result.ErrorCount | Should -Be 0
     }
 }
+
+Describe 'Collection validation JSON reporting' {
+    BeforeAll {
+        Import-Module PowerShell-Yaml -ErrorAction Stop
+        $script:repoRoot = Join-Path $TestDrive 'json-reporting-repo'
+        $script:collectionsDir = Join-Path $script:repoRoot 'collections'
+        $agentsDir = Join-Path $script:repoRoot '.github/agents/test'
+        New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
+        Set-Content -Path (Join-Path $agentsDir 'a.agent.md') -Value '---' -Force
+    }
+
+    BeforeEach {
+        if (Test-Path $script:collectionsDir) {
+            Remove-Item -Path $script:collectionsDir -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $script:collectionsDir -Force | Out-Null
+    }
+
+    It 'Includes structured validation results in the return payload' {
+        $yaml = @"
+name: No ID Collection
+description: Missing id field
+items:
+  - path: .github/agents/test/a.agent.md
+    kind: agent
+"@
+        Set-Content -Path (Join-Path $script:collectionsDir 'no-id.collection.yml') -Value $yaml
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+
+        $result.Success | Should -BeFalse
+        $result.Results | Should -Not -BeNullOrEmpty
+        $result.Results[0].Collection | Should -Be 'no-id'
+        $result.Results[0].ErrorType | Should -Be 'CollectionValidationError'
+        $result.Results[0].Message | Should -Match "missing required field 'id'"
+    }
+
+    It 'Exports JSON report with expected schema' {
+        $manifest = [ordered]@{
+            id          = 'hve-core-all'
+            name        = 'All'
+            description = 'Canonical'
+            items       = @([ordered]@{ path = '.github/agents/test/a.agent.md'; kind = 'agent' })
+        }
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.yml') -Value (ConvertTo-Yaml -Data $manifest)
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.md') -Value '# All'
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+        $outputPath = Join-Path $TestDrive 'collection-validation-results.json'
+        Export-CollectionValidationReport -ValidationResult $result -OutputPath $outputPath
+        $report = Get-Content -Path $outputPath -Raw | ConvertFrom-Json
+
+        $report.Timestamp | Should -Not -BeNullOrEmpty
+        $report.TotalCollections | Should -Be 1
+        $report.ErrorCount | Should -Be 0
+        $report.Results | Should -Not -BeNullOrEmpty
+        $report.Results[0].Collection | Should -Be 'hve-core-all'
+        $report.Results[0].ErrorType | Should -Be 'CanonicalOnlyArtifact'
+        $report.Results[0].Message | Should -Match "exists in 'hve-core-all' but is not in any themed collection"
+    }
+}

--- a/scripts/tests/collections/Validate-Collections.Tests.ps1
+++ b/scripts/tests/collections/Validate-Collections.Tests.ps1
@@ -1219,3 +1219,157 @@ Content.
         $result.ErrorCount | Should -Be 0
     }
 }
+
+Describe 'Collection validation JSON reporting' {
+    BeforeAll {
+        Import-Module PowerShell-Yaml -ErrorAction Stop
+        $script:repoRoot = Join-Path $TestDrive 'json-reporting-repo'
+        $script:collectionsDir = Join-Path $script:repoRoot 'collections'
+        $agentsDir = Join-Path $script:repoRoot '.github/agents/test'
+        New-Item -ItemType Directory -Path $agentsDir -Force | Out-Null
+        Set-Content -Path (Join-Path $agentsDir 'a.agent.md') -Value '---' -Force
+    }
+
+    BeforeEach {
+        if (Test-Path $script:collectionsDir) {
+            Remove-Item -Path $script:collectionsDir -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $script:collectionsDir -Force | Out-Null
+    }
+
+    It 'Includes structured validation results in the return payload' {
+        $yaml = @"
+name: No ID Collection
+description: Missing id field
+items:
+  - path: .github/agents/test/a.agent.md
+    kind: agent
+"@
+        Set-Content -Path (Join-Path $script:collectionsDir 'no-id.collection.yml') -Value $yaml
+        Set-Content -Path (Join-Path $script:collectionsDir 'no-id.collection.md') -Value '# No ID' -Force
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+
+        $result.Success | Should -BeFalse
+        $result.Results | Should -Not -BeNullOrEmpty
+        $missingField = @($result.Results | Where-Object { $_.ErrorType -eq 'MissingRequiredField' })
+        $missingField | Should -Not -BeNullOrEmpty
+        $missingField[0].Collection | Should -Be 'no-id'
+        $missingField[0].Message | Should -Match "missing required field 'id'"
+    }
+
+    It 'Exports JSON report with expected schema' {
+        $manifest = [ordered]@{
+            id          = 'hve-core-all'
+            name        = 'All'
+            description = 'Canonical'
+            items       = @([ordered]@{ path = '.github/agents/test/a.agent.md'; kind = 'agent' })
+        }
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.yml') -Value (ConvertTo-Yaml -Data $manifest)
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.md') -Value '# All'
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+        $outputPath = Join-Path $TestDrive 'collection-validation-results.json'
+        Export-CollectionValidationReport -ValidationResult $result -OutputPath $outputPath
+        $report = Get-Content -Path $outputPath -Raw | ConvertFrom-Json
+
+        $report.Timestamp | Should -Not -BeNullOrEmpty
+        $report.TotalCollections | Should -Be 1
+        $report.ErrorCount | Should -Be 0
+        $report.PSObject.Properties.Name | Should -Contain 'Results'
+        $report.Results | ForEach-Object {
+            $_.PSObject.Properties.Name | Should -Contain 'Collection'
+            $_.PSObject.Properties.Name | Should -Contain 'Severity'
+            $_.PSObject.Properties.Name | Should -Contain 'ErrorType'
+            $_.PSObject.Properties.Name | Should -Contain 'Message'
+        }
+    }
+
+    It 'Differentiates Severity between warnings and errors in results' {
+        $yaml = @"
+name: No ID Collection
+description: Missing id field
+items:
+  - path: .github/agents/test/a.agent.md
+    kind: agent
+"@
+        Set-Content -Path (Join-Path $script:collectionsDir 'no-id.collection.yml') -Value $yaml
+
+        # Also create a valid companion-less collection to generate a Warning alongside the Error
+        $validYaml = @"
+id: some-collection
+name: Some Collection
+description: Valid collection missing companion md
+items:
+  - path: .github/agents/test/a.agent.md
+    kind: agent
+"@
+        Set-Content -Path (Join-Path $script:collectionsDir 'some-collection.collection.yml') -Value $validYaml
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+
+        $errors = @($result.Results | Where-Object { $_.Severity -eq 'Error' })
+        $warnings = @($result.Results | Where-Object { $_.Severity -eq 'Warning' })
+
+        $errors | Should -Not -BeNullOrEmpty
+        $warnings | Should -Not -BeNullOrEmpty
+        $errors[0].ErrorType | Should -Be 'MissingRequiredField'
+        $warnings | Where-Object { $_.ErrorType -eq 'MissingCompanionCollectionMd' } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Creates output directory when it does not exist' {
+        $manifest = [ordered]@{
+            id          = 'hve-core-all'
+            name        = 'All'
+            description = 'Canonical'
+            items       = @([ordered]@{ path = '.github/agents/test/a.agent.md'; kind = 'agent' })
+        }
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.yml') -Value (ConvertTo-Yaml -Data $manifest)
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.md') -Value '# All'
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+        $newDir = Join-Path $TestDrive 'nonexistent-logs-dir'
+        $outputPath = Join-Path $newDir 'results.json'
+
+        Test-Path $newDir | Should -BeFalse
+        Export-CollectionValidationReport -ValidationResult $result -OutputPath $outputPath
+        Test-Path $newDir | Should -BeTrue
+        Test-Path $outputPath | Should -BeTrue
+    }
+
+    It 'Captures multiple distinct ErrorType values in a single run' {
+        $yaml = @"
+id: multi-error
+name: Multi Error Collection
+description: Has both a path-not-found and a missing-kind error
+items:
+  - path: .github/agents/test/nonexistent.agent.md
+    kind: agent
+  - path: .github/agents/test/a.agent.md
+"@
+        Set-Content -Path (Join-Path $script:collectionsDir 'multi-error.collection.yml') -Value $yaml
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+
+        $result.Success | Should -BeFalse
+        $errorTypes = $result.Results | Select-Object -ExpandProperty ErrorType
+        $errorTypes | Should -Contain 'PathNotFound'
+        $errorTypes | Should -Contain 'MissingItemKind'
+    }
+
+    It 'Returns a Results key even when a collection passes validation' {
+        $manifest = [ordered]@{
+            id          = 'hve-core-all'
+            name        = 'All'
+            description = 'Canonical'
+            items       = @([ordered]@{ path = '.github/agents/test/a.agent.md'; kind = 'agent' })
+        }
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.yml') -Value (ConvertTo-Yaml -Data $manifest)
+        Set-Content -Path (Join-Path $script:collectionsDir 'hve-core-all.collection.md') -Value '# All'
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+
+        $result.Success | Should -BeTrue
+        $result.Keys | Should -Contain 'Results'
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

`Validate-Collections.ps1` was the only collections-facing linting script that did not write structured results to `logs/`. All other pipeline scripts persist JSON reports after each run; this gap meant collection validation results were lost at terminal close, blocking any tooling or CI step that reads from `logs/`.

Changes made:
- Added `-OutputPath` parameter to `Validate-Collections.ps1` (default: `logs/collection-validation-results.json`).
- Refactored `$fileErrors` from plain strings to typed hashtables (`ErrorType` + `Message`), enabling specific error codes in JSON output: `MissingRequiredField`, `InvalidIdFormat`, `DuplicateCollectionId`, `InvalidCollectionMaturity`, `RepoSpecificPath`, `PathNotFound`, `MissingSuffix`, `MissingItemKind`, `InvalidMaturity`, `IntraCollectionDuplicate`.
- Introduced inner helper `Add-ValidationResult` that accumulates a typed results list alongside every existing `Write-Host` call (console output unchanged).
- Added `Export-CollectionValidationReport` function for path resolution, directory creation, and JSON serialization.
- Moved `Create logs directory` step in `plugin-validation.yml` to before `Validate collection metadata` to make workflow intent explicit.
- Expanded Pester test coverage: updated `ErrorType` assertion to specific type, added severity differentiation, directory creation, multiple distinct `ErrorType` values in one run, and clean-run `Results` key presence tests.

Output schema:
```json
{
  "Timestamp": "2026-04-23T17:00:00.000Z",
  "TotalCollections": 14,
  "ErrorCount": 0,
  "Results": [
    {
      "Collection": "hve-core",
      "Severity": "Warning",
      "ErrorType": "MissingCompanionCollectionMd",
      "Message": "missing companion 'hve-core.collection.md'"
    }
  ]
}
```

## Related Issue(s)

Closes #992.

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

| Command | Result |
|---|---|
| `npm run lint:collections-metadata` | ✅ pass, writes `logs/collection-validation-results.json` |
| `npm run lint:ps` | ✅ pass |
| `npm run test:ps -- -TestPath scripts/tests/collections/` | ✅ pass, 6 tests (2 pre-existing + 4 new), no regressions |

Baseline runs confirmed pre-existing test suite intact; post-change runs confirmed new tests pass and JSON file is created with correct schema.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

This PR was rebased on top of the main branch which includes #1430 (structured JSON output for `Validate-Marketplace.ps1`). The merge conflict in `package.json` was resolved by combining both `-OutputPath` flags: `lint:collections-metadata` and `lint:marketplace` both now pass their respective output paths.