### PR TITLE
fix(build): bump basic-ftp override to 6.0.1 to clear high-severity advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,9 +1785,9 @@
       "optional": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+      "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "markdownlint-rule-search-replace": "1.2.0"
   },
   "overrides": {
-    "basic-ftp": "5.3.0",
+    "basic-ftp": "6.0.1",
     "ip-address": "10.2.0",
     "markdown-it": "14.1.1",
     "picomatch@^2": "2.3.2",


### PR DESCRIPTION
## Description

Bumps the existing `basic-ftp` `overrides` pin in the root `package.json` from `5.3.0` (vulnerable) to `6.0.1` (fixed). This clears [GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89) — a high-severity DoS where a malicious FTP server can cause unbounded multiline control-response buffering on the client (CVSS 7.5, CWE-400 / CWE-770).

`basic-ftp` is reachable only transitively through `markdown-link-check → proxy-agent → get-uri → basic-ftp`; no direct dependency change is needed. The `ip-address` override at `10.2.0` is already outside the `<=10.1.0` range of [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) and remains untouched.

### Change

A single one-line bump in `package.json`:

```diff
   "overrides": {
-    "basic-ftp": "5.3.0",
+    "basic-ftp": "6.0.1",
     "ip-address": "10.2.0",
     ...
```

`package-lock.json` is regenerated by `npm install` and reflects the new resolution (`basic-ftp@6.0.1`).

## Related Issue(s)

N/A — drive-by audit fix in response to the `audit:npm` CI job failing on PR #1544 builds.

> [!NOTE]
> The `component-detection-dependency-submission-action` step on this PR's build is failing with an HTTP 500 from GitHub's Dependency Submission API; this is unrelated to the override change. Tracked in #1546.

## Type of Change

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [x] Dependency update

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

* `npm install` — refreshed `package-lock.json` (added 29, removed 7, changed 54 packages, all transitive).
* `npm run audit:npm` — passed (`high: 0, critical: 0, total: 0`).
* `npm ls basic-ftp` — confirms resolved version `basic-ftp@6.0.1`.
* `npm ls ip-address` — confirms resolved version `ip-address@10.2.0`.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable) — N/A
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible — override is transitive only; `basic-ftp` is not used by direct hve-core code.
* [ ] Tests added for new functionality — N/A (dependency override, no test surface).

### Required Automated Checks

* [x] `npm run audit:npm` passes locally
* [ ] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information.
* [x] Dependency update has been reviewed: `basic-ftp@6.0.1` is the latest published release at time of writing and the patched line for the advisory.
* [x] No expansion of trust surface — override only affects the transitive `basic-ftp` resolution under `markdown-link-check`.

## Additional Notes

> [!NOTE]
> The two recent transitive advisories (`ip-address` and `basic-ftp`) both surface through the same `markdown-link-check → proxy-agent` subtree. A longer-term fix would be a bump or replacement of `markdown-link-check`; this PR is the minimal patch to unblock CI.
