### PR TITLE
fix(scripts): Exclude plugins/ from ms.date freshness check to prevent duplicate stale reports

### DIFF
--- a/scripts/linting/Invoke-MsDateFreshnessCheck.ps1
+++ b/scripts/linting/Invoke-MsDateFreshnessCheck.ps1
@@ -69,7 +69,7 @@ function Get-MarkdownFiles {
         return @($files | Where-Object { Test-Path $_ -PathType Leaf })
     }
 
-    $excludePatterns = @('node_modules', '.git', 'logs', '.copilot-tracking', 'CHANGELOG.md')
+    $excludePatterns = @('node_modules', '.git', 'logs', '.copilot-tracking', 'CHANGELOG.md', 'plugins')
     $allFiles = @()
 
     # Bypass exclusions only when the caller passes a single explicit file path.

--- a/scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1
+++ b/scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1
@@ -84,6 +84,8 @@ Describe 'Get-MarkdownFiles' -Tag 'Unit' {
             New-Item -ItemType File -Path 'logs/output.md' -Force | Out-Null
             New-Item -ItemType Directory -Path '.copilot-tracking' -Force | Out-Null
             New-Item -ItemType File -Path '.copilot-tracking/notes.md' -Force | Out-Null
+            New-Item -ItemType Directory -Path 'plugins/hve-core' -Force | Out-Null
+            New-Item -ItemType File -Path 'plugins/hve-core/README.md' -Force | Out-Null
             New-Item -ItemType File -Path 'CHANGELOG.md' -Force | Out-Null
             New-Item -ItemType File -Path 'valid.md' -Force | Out-Null
         }
@@ -110,6 +112,11 @@ Describe 'Get-MarkdownFiles' -Tag 'Unit' {
         It 'Excludes .copilot-tracking directory' {
             $files = @(Get-MarkdownFiles -SearchPaths @('.'))
             $files.Name | Should -Not -Contain 'notes.md'
+        }
+
+        It 'Excludes plugins directory' {
+            $files = @(Get-MarkdownFiles -SearchPaths @('.'))
+            $files.Name | Should -Not -Contain 'README.md'
         }
 
         It 'Excludes CHANGELOG.md' {


### PR DESCRIPTION
## Description

The `Invoke-MsDateFreshnessCheck.ps1` script was scanning symlinked markdown files in the `plugins/` directory, causing duplicate stale documentation reports. This happened because `Get-ChildItem -Recurse` follows symlinks on Linux, and all 532 markdown files under `plugins/` are symlinked mirrors of collection-generated content from source locations elsewhere in the repository.

This fix adds `plugins` to the exclusion patterns in the freshness check script, following the same pattern already established in `Validate-MarkdownFrontmatter.ps1`. The change eliminates the duplicate scanning and prevents downstream workflows from creating multiple GitHub issues for the same underlying stale documentation source.

**Impact of the fix:**
- Resolves 177 of 346 duplicate scanned files from `plugins/`
- Eliminates 41 of 54 duplicate stale entries in weekly validation reports
- Prevents creation of up to 14 duplicate GitHub issues per unique stale source file

## Related Issue(s)

Fixes #1585

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [x] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Added comprehensive test coverage in `scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1`:

- Created test fixtures for the `plugins/` directory structure
- Added new test case: "Excludes plugins directory" that validates the exclusion works correctly
- Test follows the same pattern as existing exclusion tests for `.copilot-tracking`, `logs`, and other directories
- Verified that `Get-MarkdownFiles` properly filters out files in the plugins path

Run tests locally:
```powershell
npm run test:ps -- -TestPath "scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1"
```

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

- The root cause analysis identified that `Get-ChildItem -Recurse` on Linux follows symlinks, causing all files under `plugins/` to be scanned despite their symlinked nature
- This fix aligns the `Invoke-MsDateFreshnessCheck.ps1` behavior with `Validate-MarkdownFrontmatter.ps1`, which already excludes `plugins/**`
- The change is minimal and localized, introducing no breaking changes or backwards compatibility concerns
