### PR TITLE
feat: add Vally evaluation infrastructure

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,7 +24,8 @@
     "**/Cargo.lock",
     "CHANGELOG.md",
     "logs/**",
-    "docs/docusaurus/build/**"
+    "docs/docusaurus/build/**",
+    "evals/**/*.yaml"
   ],
   "ignoreRegExpList": [
     "/#.*/g",
@@ -77,7 +78,10 @@
     "whiteboarding",
     "ˈpræksɪs",
     "πρᾶξις",
-    "agentic"
+    "agentic",
+    "evals",
+    "skillmd",
+    "vally"
   ],
   "reporters": [
     "default",

--- a/.cspell.json
+++ b/.cspell.json
@@ -24,8 +24,7 @@
     "**/Cargo.lock",
     "CHANGELOG.md",
     "logs/**",
-    "docs/docusaurus/build/**",
-    "evals/**/*.yaml"
+    "docs/docusaurus/build/**"
   ],
   "ignoreRegExpList": [
     "/#.*/g",
@@ -63,6 +62,8 @@
     "general-technical"
   ],
   "words": [
+    "ˈpræksɪs",
+    "agentic",
     "atheris",
     "behaviour",
     "behavioural",
@@ -70,21 +71,26 @@
     "clusterfuzzlite",
     "collab",
     "easyops",
+    "evals",
+    "fetchone",
     "figjam",
     "hideable",
+    "idor",
     "learning",
+    "skillmd",
     "smol",
     "subcat",
+    "vally",
     "whiteboarding",
-    "ˈpræksɪs",
-    "πρᾶξις",
-    "agentic",
-    "evals",
-    "skillmd",
-    "vally"
+    "πρᾶξις"
   ],
   "reporters": [
     "default",
-    ["@cspell/cspell-json-reporter", { "outFile": "logs/cspell-results.json" }]
+    [
+      "@cspell/cspell-json-reporter",
+      {
+        "outFile": "logs/cspell-results.json"
+      }
+    ]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Vally evaluation results
+results/
+
 # macOS
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # Vally evaluation results
-results/
+evals/results/
 
 # macOS
 .DS_Store

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,6 +1,6 @@
 paths:
   evals: evals
-  results: results/
+  results: evals/results/
 
 suites:
   skill-quality:
@@ -15,8 +15,8 @@ suites:
       tags:
         category: agent-behavior
 
-  deterministic:
-    description: Validate deterministic script correctness via mock executor
+  script-validation:
+    description: Validate script correctness via copilot-sdk conversations
     filter:
       tags:
-        category: deterministic
+        category: script-validation

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,0 +1,22 @@
+paths:
+  evals: evals
+  results: results/
+
+suites:
+  skill-quality:
+    description: Evaluate skill behavior via copilot-sdk agent conversations
+    filter:
+      tags:
+        category: skill-quality
+
+  agent-behavior:
+    description: Evaluate agent routing and response quality
+    filter:
+      tags:
+        category: agent-behavior
+
+  deterministic:
+    description: Validate deterministic script correctness via mock executor
+    filter:
+      tags:
+        category: deterministic

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,6 +1,6 @@
 paths:
   evals: evals
-  results: evals/results/
+  results: evals/results
 
 suites:
   skill-quality:

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,55 @@
+# Evaluations
+
+This directory contains [Vally](https://www.npmjs.com/package/@microsoft/vally-cli) evaluation specs for hve-core.
+
+## Architecture
+
+```text
+evals/
+├── skill-quality/       copilot-sdk evals testing skill behavior
+├── agent-behavior/      copilot-sdk evals testing agent responses
+└── script-validation/   mock executor evals testing deterministic scripts
+```
+
+## Executors
+
+| Suite | Executor | Purpose |
+|-------|----------|---------|
+| `skill-quality` | `copilot-sdk` | Tests that skills provide accurate guidance via real agent conversation |
+| `agent-behavior` | `copilot-sdk` | Tests that agents respond correctly to domain prompts |
+| `script-validation` | `mock` | Tests deterministic validation scripts with fixture files |
+
+## Running evals
+
+```bash
+# Lint all eval specs (no execution, fast)
+npm run eval:lint
+
+# Run all evals
+npm run eval
+
+# Run a specific suite
+npm run eval -- --suite skill-quality
+npm run eval -- --suite deterministic
+
+# Compare results against baseline
+npm run eval:compare
+```
+
+## Adding new evals
+
+1. Create a directory under `evals/` with an `eval.yaml`.
+2. Choose the executor:
+   - `copilot-sdk` for testing skill/agent behavior (non-deterministic, use `runs: 3`+).
+   - `mock` for testing scripts/validators (deterministic, use `runs: 1`).
+3. Write per-stimulus graders (one stimulus per test case).
+4. Run `npm run eval:lint` to validate the spec.
+5. Tag stimuli with `category` matching a suite filter in `.vally.yaml`.
+
+## Anti-patterns
+
+- Don't use `runs: 1` for copilot-sdk evals (non-deterministic output needs multiple runs).
+- Don't set timeout below `120s` for copilot-sdk evals.
+- Don't use `output-contains` as the sole grader for qualitative agent output.
+- Don't bundle multiple test cases into one stimulus with an aggregate grader.
+- Don't pin models in eval specs.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,4 +1,9 @@
-# Evaluations
+---
+title: Evaluations
+description: 'Architecture overview and contributor guide for Vally evaluation specs'
+author: HVE Core Team
+ms.date: 2026-05-14
+---
 
 This directory contains [Vally](https://www.npmjs.com/package/@microsoft/vally-cli) evaluation specs for hve-core.
 
@@ -8,48 +13,52 @@ This directory contains [Vally](https://www.npmjs.com/package/@microsoft/vally-c
 evals/
 ├── skill-quality/       copilot-sdk evals testing skill behavior
 ├── agent-behavior/      copilot-sdk evals testing agent responses
-└── script-validation/   mock executor evals testing deterministic scripts
+└── script-validation/   copilot-sdk evals testing deterministic scripts
 ```
 
 ## Executors
 
-| Suite | Executor | Purpose |
-|-------|----------|---------|
-| `skill-quality` | `copilot-sdk` | Tests that skills provide accurate guidance via real agent conversation |
-| `agent-behavior` | `copilot-sdk` | Tests that agents respond correctly to domain prompts |
-| `script-validation` | `mock` | Tests deterministic validation scripts with fixture files |
+| Suite               | Executor      | Purpose                                                                 |
+|---------------------|---------------|-------------------------------------------------------------------------|
+| `skill-quality`     | `copilot-sdk` | Tests that skills provide accurate guidance via real agent conversation |
+| `agent-behavior`    | `copilot-sdk` | Tests that agents respond correctly to domain prompts                   |
+| `script-validation` | `copilot-sdk` | Tests deterministic validation scripts with fixture files               |
 
-## Running evals
+## Running Evals
 
 ```bash
 # Lint all eval specs (no execution, fast)
-vally lint --eval evals/
+npx vally lint --eval evals/
 
 # Run all evals
-vally eval
+npx vally eval
 
 # Run a specific suite
-vally eval --suite skill-quality
-vally eval --suite deterministic
+npx vally eval --suite skill-quality
+npx vally eval --suite script-validation
 
 # Compare results against baseline
-vally compare
+npx vally compare
 ```
 
-## Adding new evals
+## Adding New Evals
 
 1. Create a directory under `evals/` with an `eval.yaml`.
 2. Choose the executor:
-   - `copilot-sdk` for testing skill/agent behavior (non-deterministic, use `runs: 3`+).
-   - `mock` for testing scripts/validators (deterministic, use `runs: 1`).
+   * `copilot-sdk` for testing skill/agent behavior (non-deterministic, use `runs: 3`+).
+   * `mock` for testing scripts/validators (deterministic, use `runs: 1`).
 3. Write per-stimulus graders (one stimulus per test case).
-4. Run `vally lint --eval evals/` to validate the spec.
+4. Run `npx vally lint --eval evals/` to validate the spec.
 5. Tag stimuli with `category` matching a suite filter in `.vally.yaml`.
 
-## Anti-patterns
+## Anti-Patterns
 
-- Don't use `runs: 1` for copilot-sdk evals (non-deterministic output needs multiple runs).
-- Don't set timeout below `120s` for copilot-sdk evals.
-- Don't use `output-contains` as the sole grader for qualitative agent output.
-- Don't bundle multiple test cases into one stimulus with an aggregate grader.
-- Don't pin models in eval specs.
+* Don't use `runs: 1` for copilot-sdk evals (non-deterministic output needs multiple runs).
+* Don't set timeout below `120s` for copilot-sdk evals.
+* Don't use `output-contains` as the sole grader for qualitative agent output.
+* Don't bundle multiple test cases into one stimulus with an aggregate grader.
+* Don't pin models in eval specs.
+
+---
+
+🤖 Crafted with precision by ✨Copilot following brilliant human instruction, then carefully refined by our team of discerning human reviewers.

--- a/evals/README.md
+++ b/evals/README.md
@@ -18,17 +18,17 @@ evals/
 
 ## Executors
 
-| Suite               | Executor      | Purpose                                                                 |
-|---------------------|---------------|-------------------------------------------------------------------------|
-| `skill-quality`     | `copilot-sdk` | Tests that skills provide accurate guidance via real agent conversation |
-| `agent-behavior`    | `copilot-sdk` | Tests that agents respond correctly to domain prompts                   |
-| `script-validation` | `copilot-sdk` | Tests deterministic validation scripts with fixture files               |
+| Suite               | Executor      | Purpose                                                                            |
+|---------------------|---------------|------------------------------------------------------------------------------------|
+| `skill-quality`     | `copilot-sdk` | Tests that skills provide accurate guidance via real agent conversation            |
+| `agent-behavior`    | `copilot-sdk` | Tests that agents respond correctly to domain prompts                              |
+| `script-validation` | `copilot-sdk` | Tests agent reasoning about validation rules (will migrate to mock when available) |
 
 ## Running Evals
 
 ```bash
 # Lint all eval specs (no execution, fast)
-npx vally lint --eval evals/
+npm run eval:lint
 
 # Run all evals
 npx vally eval
@@ -46,9 +46,9 @@ npx vally compare
 1. Create a directory under `evals/` with an `eval.yaml`.
 2. Choose the executor:
    * `copilot-sdk` for testing skill/agent behavior (non-deterministic, use `runs: 3`+).
-   * `mock` for testing scripts/validators (deterministic, use `runs: 1`).
+   * `mock` for testing scripts/validators with fixture files (deterministic, use `runs: 1`). Not yet available - use `copilot-sdk` until the mock executor plugin ships.
 3. Write per-stimulus graders (one stimulus per test case).
-4. Run `npx vally lint --eval evals/` to validate the spec.
+4. Run `npm run eval:lint` to validate the spec.
 5. Tag stimuli with `category` matching a suite filter in `.vally.yaml`.
 
 ## Anti-Patterns
@@ -58,7 +58,5 @@ npx vally compare
 * Don't use `output-contains` as the sole grader for qualitative agent output.
 * Don't bundle multiple test cases into one stimulus with an aggregate grader.
 * Don't pin models in eval specs.
-
----
 
 🤖 Crafted with precision by ✨Copilot following brilliant human instruction, then carefully refined by our team of discerning human reviewers.

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,17 +23,17 @@ evals/
 
 ```bash
 # Lint all eval specs (no execution, fast)
-npm run eval:lint
+vally lint --eval evals/
 
 # Run all evals
-npm run eval
+vally eval
 
 # Run a specific suite
-npm run eval -- --suite skill-quality
-npm run eval -- --suite deterministic
+vally eval --suite skill-quality
+vally eval --suite deterministic
 
 # Compare results against baseline
-npm run eval:compare
+vally compare
 ```
 
 ## Adding new evals
@@ -43,7 +43,7 @@ npm run eval:compare
    - `copilot-sdk` for testing skill/agent behavior (non-deterministic, use `runs: 3`+).
    - `mock` for testing scripts/validators (deterministic, use `runs: 1`).
 3. Write per-stimulus graders (one stimulus per test case).
-4. Run `npm run eval:lint` to validate the spec.
+4. Run `vally lint --eval evals/` to validate the spec.
 5. Tag stimuli with `category` matching a suite filter in `.vally.yaml`.
 
 ## Anti-patterns

--- a/evals/agent-behavior/eval.yaml
+++ b/evals/agent-behavior/eval.yaml
@@ -11,8 +11,8 @@ config:
 
 environment:
   skills:
-    - ../../.github/skills/security/owasp-top-10/SKILL.md
-    - ../../.github/skills/coding-standards/python-foundational/SKILL.md
+    - ../../.github/skills/security/owasp-top-10
+    - ../../.github/skills/coding-standards/python-foundational
 
 scoring:
   threshold: 0.7

--- a/evals/agent-behavior/eval.yaml
+++ b/evals/agent-behavior/eval.yaml
@@ -1,0 +1,64 @@
+name: agent-behavior
+description: >
+  Evaluate hve-core agent behavior via copilot-sdk. Tests that agents
+  respond with correct structure, apply their specialized perspectives,
+  and stay within defined boundaries.
+type: capability
+config:
+  runs: 3
+  timeout: 120s
+  executor: copilot-sdk
+
+environment:
+  skills:
+    - ../../.github/skills/security/owasp-top-10/SKILL.md
+    - ../../.github/skills/coding-standards/python-foundational/SKILL.md
+
+scoring:
+  threshold: 0.7
+
+stimuli:
+  - name: pr-review-identifies-security
+    prompt: |
+      Review this code change for a Python web application:
+      ```python
+      @app.route('/user/<id>')
+      def get_user(id):
+          query = f"SELECT * FROM users WHERE id = {id}"
+          return db.execute(query).fetchone()
+      ```
+      Focus on security and code quality.
+    tags:
+      category: agent-behavior
+      agent: pr-review
+    graders:
+      - type: output-matches
+        name: identifies-sql-injection
+        config:
+          pattern: "(?i)sql.injection|parameterized|sql.concat"
+      - type: output-matches
+        name: provides-remediation
+        config:
+          pattern: "(?i)parameterized|prepared|placeholder|bind"
+
+  - name: pr-review-identifies-error-handling
+    prompt: |
+      Review this code change:
+      ```python
+      def process_payment(amount):
+          response = requests.post(PAYMENT_API, json={"amount": amount})
+          return response.json()["transaction_id"]
+      ```
+      What issues do you see?
+    tags:
+      category: agent-behavior
+      agent: pr-review
+    graders:
+      - type: output-matches
+        name: identifies-missing-error-handling
+        config:
+          pattern: "(?i)error.handling|exception|try|status.code|timeout"
+      - type: output-matches
+        name: identifies-missing-validation
+        config:
+          pattern: "(?i)validat|check|verify|amount|negative"

--- a/evals/agent-behavior/eval.yaml
+++ b/evals/agent-behavior/eval.yaml
@@ -1,8 +1,10 @@
 name: agent-behavior
 description: >
-  Evaluate hve-core agent behavior via copilot-sdk. Tests that agents
-  respond with correct structure, apply their specialized perspectives,
-  and stay within defined boundaries.
+  Evaluate hve-core skill+agent behavior via copilot-sdk. Tests that the
+  combination of skills loaded in an agent context produces correct structure,
+  applies specialized perspectives, and stays within defined boundaries.
+  Note: Tests skill behavior under agent-style prompts rather than invoking
+  a specific .agent.md file directly (Vally does not yet support agent routing).
 type: capability
 config:
   runs: 3
@@ -35,7 +37,7 @@ stimuli:
       - type: output-matches
         name: identifies-sql-injection
         config:
-          pattern: "(?i)sql.injection|parameterized|sql.concat"
+          pattern: "(?i)\\bsql\\s*injection\\b|\\binjection\\b"
       - type: output-matches
         name: provides-remediation
         config:
@@ -61,4 +63,5 @@ stimuli:
       - type: output-matches
         name: identifies-missing-validation
         config:
+          # cspell:disable-next-line
           pattern: "(?i)validat|check|verify|amount|negative"

--- a/evals/script-validation/eval.yaml
+++ b/evals/script-validation/eval.yaml
@@ -31,7 +31,7 @@ stimuli:
       Does this follow valid skill structure conventions? What required
       elements are present?
     tags:
-      category: deterministic
+      category: script-validation
       script: skill-validation
     graders:
       - type: output-matches
@@ -56,7 +56,7 @@ stimuli:
       ```
       Is this a valid skill structure? What's missing?
     tags:
-      category: deterministic
+      category: script-validation
       script: skill-validation
     graders:
       - type: output-matches
@@ -79,7 +79,7 @@ stimuli:
       Is this frontmatter complete for a skill file? What fields
       are missing according to skill conventions?
     tags:
-      category: deterministic
+      category: script-validation
       script: frontmatter-validation
     graders:
       - type: output-matches

--- a/evals/script-validation/eval.yaml
+++ b/evals/script-validation/eval.yaml
@@ -11,7 +11,7 @@ config:
 
 environment:
   skills:
-    - ../../.github/skills/coding-standards/python-foundational/SKILL.md
+    - ../../.github/skills/coding-standards/python-foundational
 
 scoring:
   threshold: 0.7
@@ -85,4 +85,4 @@ stimuli:
       - type: output-matches
         name: identifies-missing-description
         config:
-          pattern: "(?i)description.*missing|missing.*description|need.*description"
+          pattern: "(?i)description.*missing|missing.*description|need.*description|no.*description|description.*required|lacks.*description|without.*description|description.*absent|description.*not"

--- a/evals/script-validation/eval.yaml
+++ b/evals/script-validation/eval.yaml
@@ -1,0 +1,88 @@
+name: script-validation
+description: >
+  Validate that agents correctly identify valid and invalid skill
+  structures when presented with file listings. Uses copilot-sdk
+  to test real agent reasoning about validation rules.
+type: capability
+config:
+  runs: 3
+  timeout: 120s
+  executor: copilot-sdk
+
+environment:
+  skills:
+    - ../../.github/skills/coding-standards/python-foundational/SKILL.md
+
+scoring:
+  threshold: 0.7
+
+stimuli:
+  - name: identify-valid-skill-structure
+    prompt: |
+      I have a skill directory with the following structure:
+      ```
+      my-skill/
+      ├── SKILL.md (contains frontmatter with name, description, license)
+      ├── references/
+      │   └── api-guide.md
+      └── scripts/
+          └── validate.py
+      ```
+      Does this follow valid skill structure conventions? What required
+      elements are present?
+    tags:
+      category: deterministic
+      script: skill-validation
+    graders:
+      - type: output-matches
+        name: identifies-valid-structure
+        config:
+          pattern: "(?i)valid|correct|proper|follows.*convention"
+      - type: output-matches
+        name: identifies-skill-md
+        config:
+          pattern: "(?i)SKILL\\.md|skill.entry|entrypoint"
+
+  - name: identify-missing-skill-md
+    prompt: |
+      I have a skill directory with this structure:
+      ```
+      broken-skill/
+      ├── README.md
+      ├── references/
+      │   └── guide.md
+      └── scripts/
+          └── run.py
+      ```
+      Is this a valid skill structure? What's missing?
+    tags:
+      category: deterministic
+      script: skill-validation
+    graders:
+      - type: output-matches
+        name: identifies-missing-skillmd
+        config:
+          pattern: "(?i)missing.*SKILL\\.md|no.*SKILL\\.md|SKILL\\.md.*required|SKILL\\.md.*missing"
+      - type: output-matches
+        name: identifies-invalid
+        config:
+          pattern: "(?i)invalid|not.*valid|missing.*required|incomplete"
+
+  - name: identify-frontmatter-issues
+    prompt: |
+      This SKILL.md file has the following frontmatter:
+      ```yaml
+      ---
+      name: my-tool
+      ---
+      ```
+      Is this frontmatter complete for a skill file? What fields
+      are missing according to skill conventions?
+    tags:
+      category: deterministic
+      script: frontmatter-validation
+    graders:
+      - type: output-matches
+        name: identifies-missing-description
+        config:
+          pattern: "(?i)description.*missing|missing.*description|need.*description"

--- a/evals/script-validation/eval.yaml
+++ b/evals/script-validation/eval.yaml
@@ -2,7 +2,8 @@ name: script-validation
 description: >
   Validate that agents correctly identify valid and invalid skill
   structures when presented with file listings. Uses copilot-sdk
-  to test real agent reasoning about validation rules.
+  to test real agent reasoning about validation rules. Will migrate
+  to the mock executor when the deterministic plugin ships.
 type: capability
 config:
   runs: 3

--- a/evals/skill-quality/eval.yaml
+++ b/evals/skill-quality/eval.yaml
@@ -11,8 +11,8 @@ config:
 
 environment:
   skills:
-    - ../../.github/skills/security/owasp-top-10/SKILL.md
-    - ../../.github/skills/security/owasp-cicd/SKILL.md
+    - ../../.github/skills/security/owasp-top-10
+    - ../../.github/skills/security/owasp-cicd
 
 scoring:
   threshold: 0.7

--- a/evals/skill-quality/eval.yaml
+++ b/evals/skill-quality/eval.yaml
@@ -34,7 +34,7 @@ stimuli:
       - type: output-matches
         name: references-parameterized-queries
         config:
-          pattern: "(?i)parameterized|prepared.statement|input.validation"
+          pattern: "(?i)parameterized|prepared.statement"
 
   - name: owasp-top10-identify-broken-access
     prompt: |
@@ -51,6 +51,7 @@ stimuli:
       - type: output-matches
         name: suggests-authorization-check
         config:
+          # cspell:disable-next-line
           pattern: "(?i)authori[sz]ation|access.control|ownership.check|server.side"
 
   - name: owasp-cicd-pipeline-poisoning

--- a/evals/skill-quality/eval.yaml
+++ b/evals/skill-quality/eval.yaml
@@ -1,0 +1,72 @@
+name: skill-quality
+description: >
+  Evaluate hve-core skill behavior via copilot-sdk. Tests that skills
+  provide accurate, structured guidance when invoked with domain-specific
+  prompts. Uses multiple runs to account for non-deterministic output.
+type: capability
+config:
+  runs: 3
+  timeout: 120s
+  executor: copilot-sdk
+
+environment:
+  skills:
+    - ../../.github/skills/security/owasp-top-10/SKILL.md
+    - ../../.github/skills/security/owasp-cicd/SKILL.md
+
+scoring:
+  threshold: 0.7
+
+stimuli:
+  - name: owasp-top10-identify-injection
+    prompt: |
+      I have a web application that constructs SQL queries by concatenating
+      user input directly into the query string. What OWASP Top 10 category
+      does this fall under, and what are the recommended mitigations?
+    tags:
+      category: skill-quality
+      skill: owasp-top-10
+    graders:
+      - type: output-matches
+        name: identifies-injection-category
+        config:
+          pattern: "(?i)\\binjection\\b"
+      - type: output-matches
+        name: references-parameterized-queries
+        config:
+          pattern: "(?i)parameterized|prepared.statement|input.validation"
+
+  - name: owasp-top10-identify-broken-access
+    prompt: |
+      A user can modify the URL parameter from /api/users/123 to /api/users/456
+      and access another user's data. What OWASP Top 10 vulnerability is this?
+    tags:
+      category: skill-quality
+      skill: owasp-top-10
+    graders:
+      - type: output-matches
+        name: identifies-broken-access-control
+        config:
+          pattern: "(?i)broken.access.control|insecure.direct.object.reference|IDOR"
+      - type: output-matches
+        name: suggests-authorization-check
+        config:
+          pattern: "(?i)authori[sz]ation|access.control|ownership.check|server.side"
+
+  - name: owasp-cicd-pipeline-poisoning
+    prompt: |
+      Our CI/CD pipeline pulls build scripts from an external repository
+      that multiple developers can push to without review. What security
+      risks does this introduce according to OWASP CI/CD guidelines?
+    tags:
+      category: skill-quality
+      skill: owasp-cicd
+    graders:
+      - type: output-matches
+        name: identifies-pipeline-poisoning
+        config:
+          pattern: "(?i)pipeline.poison|code.injection|supply.chain|untrusted"
+      - type: output-matches
+        name: recommends-controls
+        config:
+          pattern: "(?i)branch.protect|code.review|sign|pin|restrict"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@cspell/cspell-json-reporter": "10.0.0",
+        "@microsoft/vally-cli": "0.4.0",
         "@vscode/vsce": "3.9.1",
         "audit-ci": "7.1.0",
         "cspell": "10.0.0",
@@ -365,6 +366,7 @@
       "integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=22.18.0"
       }
@@ -446,7 +448,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
       "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -586,14 +589,16 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
       "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -791,7 +796,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -861,6 +867,512 @@
         "node": ">=22.18.0"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.48.tgz",
+      "integrity": "sha512-U5SzyTEq376UU9A4Sd3TEKz+Y2nRUd90cLO4Hc1otaB8yFSy9Ur2UVGcI2/wCoodL3a39k6WbdgNzFxr0gWFRQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.48",
+        "@github/copilot-darwin-x64": "1.0.48",
+        "@github/copilot-linux-arm64": "1.0.48",
+        "@github/copilot-linux-x64": "1.0.48",
+        "@github/copilot-win32-arm64": "1.0.48",
+        "@github/copilot-win32-x64": "1.0.48"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.48.tgz",
+      "integrity": "sha512-82MLoMQwPVVFM8EYssihFxSEPUYtZADE8rMzQ3jG9HgRg2qjQSfnHQS1mKe64dlXswZUK/onw6/8kjnW5I4pPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.48.tgz",
+      "integrity": "sha512-1VQ5r5F0h8GwboXmZTcutqcJT+iCpPXAF27QqodmpKEvW9aYfG8g9X2kFJOzDZoX+SA3Uaka9qXdYKF2xT6Uog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.48.tgz",
+      "integrity": "sha512-PmsGnb0DZlI+Bf53l9HM1PAHHkUcMyB4y8v/7tnC/jDOV5dGF124n0HnDNfJLOLiJGiQGodthIif6QtPaAxpeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.48.tgz",
+      "integrity": "sha512-b2cc4euSlke9fYHXXsS2EL9UYbctN0h4lZvtAcKUDY+RCnpYAQOVBZK+c1R9dQrtsT6Z/yUv7PuFPSs8qdtc2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
+      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.36-0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.48.tgz",
+      "integrity": "sha512-VEEOwddtpJ3DTbXGhnK6K8im4ofl9m08q1m/K++sNvWV8wkkOSOQBTiPdyUsuU/TXAoFhb8tZMIJv+6NnMBtMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.48.tgz",
+      "integrity": "sha512-93BzvXLPHTyy1gWBXQY/IWIHor4IAwZuuo7/obG80/Qa6U0WeaN9slz/FBJvrsgVNrrRfEID5Xm3At+S6Kj67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
+      "integrity": "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.2.tgz",
+      "integrity": "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.14.tgz",
+      "integrity": "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.13.tgz",
+      "integrity": "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.13.tgz",
+      "integrity": "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.13.tgz",
+      "integrity": "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.3.tgz",
+      "integrity": "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.5",
+        "@inquirer/confirm": "^6.0.13",
+        "@inquirer/editor": "^5.1.2",
+        "@inquirer/expand": "^5.0.14",
+        "@inquirer/input": "^5.0.13",
+        "@inquirer/number": "^4.0.13",
+        "@inquirer/password": "^5.0.13",
+        "@inquirer/rawlist": "^5.2.9",
+        "@inquirer/search": "^4.1.9",
+        "@inquirer/select": "^5.1.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.9.tgz",
+      "integrity": "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.9.tgz",
+      "integrity": "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.5.tgz",
+      "integrity": "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -869,6 +1381,32 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@microsoft/vally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.4.0.tgz",
+      "integrity": "sha512-OhqxzeyhFT3JCJkTj5WXXFDUUvKzfV+i6zKU7RoUzrjAC/qUFs8BMzSJEojM/cFfucSYhIqxfNHsM+hRJvhZ8g==",
+      "dev": true,
+      "dependencies": {
+        "@github/copilot-sdk": "0.3.0",
+        "js-tiktoken": "^1.0.21",
+        "picomatch": "^4.0.4",
+        "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@microsoft/vally-cli": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.4.0.tgz",
+      "integrity": "sha512-YQuPXZDUVLMvA89UjzmLv+S7OcrpnhZz8H2w16sa+E5CBj82pTu88/UL3wCncRZXCVvfugA+TpYGUvk0LgfyrA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/prompts": "^8.4.2",
+        "@microsoft/vally": "^0.4.0",
+        "commander": "^14.0.3"
+      },
+      "bin": {
+        "vally": "dist/index.js"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1781,8 +2319,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "6.0.1",
@@ -2015,6 +2552,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cheerio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -2066,6 +2610,16 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2973,6 +3527,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -2989,6 +3560,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3805,6 +4386,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4230,6 +4821,7 @@
       "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "16.2.0",
         "js-yaml": "4.1.1",
@@ -6719,6 +7311,16 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
@@ -6984,6 +7586,16 @@
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -45,10 +45,14 @@
     "clean:logs": "pwsh -NoProfile -Command \"Get-ChildItem -Path logs -File -Recurse -Exclude .gitkeep | Remove-Item -Force\"",
     "docs:build": "npm --prefix docs/docusaurus run build",
     "docs:test": "npm --prefix docs/docusaurus test",
-    "docs:serve": "npm --prefix docs/docusaurus run serve"
+    "docs:serve": "npm --prefix docs/docusaurus run serve",
+    "eval": "vally eval",
+    "eval:lint": "vally lint --eval evals/",
+    "eval:compare": "vally compare"
   },
   "devDependencies": {
     "@cspell/cspell-json-reporter": "10.0.0",
+    "@microsoft/vally-cli": "0.4.0",
     "@vscode/vsce": "3.9.1",
     "audit-ci": "7.1.0",
     "cspell": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:ai-artifacts": "pwsh -NoProfile -Command \"& './scripts/linting/Validate-PlannerArtifacts.ps1' -FailOnMissing\"",
     "lint:models": "pwsh -NoProfile -File scripts/linting/Test-ModelReferences.ps1 -OutputPath logs/model-validation-results.json",
     "lint:models:refresh": "pwsh -NoProfile -File scripts/linting/Update-ModelCatalog.ps1",
-    "lint:all": "npm run format:tables && npm run lint:md && npm run lint:ps && npm run lint:yaml && npm run lint:links && npm run lint:frontmatter && npm run lint:collections-metadata && npm run lint:marketplace && npm run lint:version-consistency && npm run lint:permissions && npm run lint:dependency-pinning && npm run lint:ps-module-pins && npm run lint:py && npm run validate:skills && npm run lint:ai-artifacts && npm run lint:models",
+    "lint:all": "npm run format:tables && npm run lint:md && npm run lint:ps && npm run lint:yaml && npm run lint:links && npm run lint:frontmatter && npm run lint:collections-metadata && npm run lint:marketplace && npm run lint:version-consistency && npm run lint:permissions && npm run lint:dependency-pinning && npm run lint:ps-module-pins && npm run lint:py && npm run validate:skills && npm run lint:ai-artifacts && npm run lint:models && npm run eval:lint",
     "format:tables": "markdown-table-formatter \"**/*.md\"",
     "extension:prepare": "pwsh ./scripts/extension/Prepare-Extension.ps1",
     "extension:prepare:prerelease": "pwsh ./scripts/extension/Prepare-Extension.ps1 -Channel PreRelease",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "docs:build": "npm --prefix docs/docusaurus run build",
     "docs:test": "npm --prefix docs/docusaurus test",
     "docs:serve": "npm --prefix docs/docusaurus run serve",
-    "eval": "vally eval",
-    "eval:lint": "vally lint --eval evals/",
-    "eval:compare": "vally compare"
+    "eval:lint": "vally lint --eval evals/"
   },
   "devDependencies": {
     "@cspell/cspell-json-reporter": "10.0.0",


### PR DESCRIPTION
# Pull Request

## Description

Add Vally evaluation infrastructure to hve-core. This introduces structured evaluation specs that test skill and agent behavior using the `@microsoft/vally-cli` framework with the `copilot-sdk` executor.

Includes three evaluation suites:
* `skill-quality` tests that OWASP skills provide accurate security guidance
* `agent-behavior` tests agent-style prompts produce correct structure and security identification
* `script-validation` tests agent reasoning about skill structure validation rules

Also adds `eval:lint` to the `lint:all` chain and configures `.vally.yaml` for suite discovery.

## Related Issue(s)

No tracking issue. This is the initial evaluation infrastructure.

## Type of Change

* [x] New feature (non-breaking change adding functionality)
* [x] Documentation update

## Testing

* `npm run eval:lint` passes (all 3 eval specs valid)
* `npm run spell-check` passes
* `npm run lint:md` passes
* `npm run format:tables` passes
* `npm run lint:frontmatter` passes

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues

## Additional Notes

* The `agent-behavior` suite tests skill behavior under agent-style prompts. Direct agent routing (loading `.agent.md` files) is not yet supported by Vally, so the suite will be updated when that capability ships.
* The `script-validation` suite currently uses `copilot-sdk` for reasoning-based validation. It will migrate to the `mock` executor when the deterministic plugin is available.
* `npx vally eval` and `npx vally compare` are the execution commands (no npm run wrappers needed, since these require credentials/environment setup not suitable for CI).