### PR TITLE
docs: document collection validation output

### DIFF
--- a/scripts/collections/README.md
+++ b/scripts/collections/README.md
@@ -18,6 +18,33 @@ helper functions used by both collection validation and plugin generation.
 * PowerShell 7.0+
 * PowerShell-Yaml module (`Install-Module -Name PowerShell-Yaml -RequiredVersion 0.4.7`)
 
+## Validate-Collections.ps1
+
+Validates collection manifests and writes a structured JSON report after each
+run.
+
+### Parameters
+
+* `-OutputPath` (string) - Path where the JSON result file is written (default:
+  `logs/collection-validation-results.json`)
+
+### JSON output
+
+The report contains:
+
+* `Timestamp` - UTC timestamp for the validation run
+* `TotalCollections` - Number of collection manifests validated
+* `ErrorCount` - Number of validation errors
+* `Results` - Per-collection validation messages with `Collection`, `Severity`,
+  `ErrorType`, and `Message` fields
+
+### Examples
+
+```powershell
+./scripts/collections/Validate-Collections.ps1
+./scripts/collections/Validate-Collections.ps1 -OutputPath custom/results.json
+```
+
 ## Adding a New Collection
 
 1. Create `collections/<id>.collection.yml` (see existing collections for


### PR DESCRIPTION
## Description

Documents the `-OutputPath` parameter of `scripts/collections/Validate-Collections.ps1` in `scripts/collections/README.md`: what the collection-validation JSON report contains and what each field means, plus usage examples for both the default output path and a custom one. This is a documentation-only change — no code or behavior changes.

## Related Issue(s)

Fixes #1514.

## Type of Change

**Code & Documentation:**

* [x] Documentation update

## Testing

Ran the repo's documentation validators locally against the changed file (`scripts/collections/README.md`):

- `npm run lint:md` (markdownlint-cli2 v0.22.1 / markdownlint v0.40.0) — **0 errors**
- `npm run spell-check` (cspell) — **0 issues**
- `npm run lint:md-links` — requires PowerShell (`pwsh`); left to CI.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable) — N/A (docs-only)

### Required Automated Checks

* [x] Markdown linting: `npm run lint:md` — passed locally
* [x] Spell checking: `npm run spell-check` — passed locally
* [ ] Link validation: `npm run lint:md-links` — CI (requires PowerShell)
* [ ] PowerShell analysis: `npm run lint:ps` — N/A (no `.ps1` changes)
* [ ] Frontmatter validation: `npm run lint:frontmatter` — N/A

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] No new dependencies are introduced
