### PR TITLE
build: pin brace-expansion 5.0.6

### DIFF
--- a/docs/docusaurus/package-lock.json
+++ b/docs/docusaurus/package-lock.json
@@ -8751,9 +8751,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -55,6 +55,7 @@
     "node": ">=20.0"
   },
   "overrides": {
+    "brace-expansion@^5": "5.0.6",
     "express": ">=4.21.2",
     "minimatch": ">=3.1.3",
     "picomatch": ">=2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,9 +2375,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "overrides": {
     "basic-ftp": "6.0.1",
+    "brace-expansion@^5": "5.0.6",
     "ip-address": "10.2.0",
     "markdown-it": "14.1.1",
     "picomatch@^2": "2.3.2",


### PR DESCRIPTION
<!-- markdownlint-disable-file -->
# Pull Request

## Description

Pinned **`brace-expansion@^5`** to `5.0.6` in both the root and *docs/docusaurus/* npm trees to remediate advisory [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) (ReDoS in `brace-expansion` 5.0.0–5.0.5).

The override is scoped to the vulnerable major (`^5`) so any nested `brace-expansion@1.x` consumers remain untouched. Both lockfiles refresh cleanly to `5.0.6`, and a root `npm audit` now reports zero advisories.

## Related Issue(s)

Closes #1620

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [x] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

Agent-run validations:

* `npm run audit:npm` — **Passed**. Root tree reports 0 vulnerabilities across all severities (580 deps).
* `npm run lint:dependency-pinning` — **Passed**. 100% pinning compliance over 212 dependencies, 0 violations.
* Lockfile inspection — verified `brace-expansion@5.0.6` in both *package-lock.json* and *docs/docusaurus/package-lock.json*.

Security analysis summary: dependency pin is scoped to the vulnerable major, no new packages introduced, no secrets or sensitive data in the diff.

> [!NOTE]
> Manual testing was not performed.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — no docs changes)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable) (N/A — dependency pin)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

**Files changed** (4 files, 8 insertions, 6 deletions):

* *package.json* — added `brace-expansion@^5: 5.0.6` to `overrides`.
* *package-lock.json* — refreshed `brace-expansion` to `5.0.6`.
* *docs/docusaurus/package.json* — added `brace-expansion@^5: 5.0.6` to `overrides`.
* *docs/docusaurus/package-lock.json* — refreshed `brace-expansion` to `5.0.6`.

**Out-of-scope advisories** in the *docs/docusaurus/* subtree are unrelated to GHSA-jxxr-4gwj-5jf2 and are not gated by `npm run audit:npm` (which only audits the root lockfile). A follow-up issue is recommended:

| Package | Severity | Advisory |
|---|---|---|
| `@babel/plugin-transform-modules-systemjs` | high | [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) |
| `webpack-dev-server` | moderate | [GHSA-79cf-xcqc-c78w](https://github.com/advisories/GHSA-79cf-xcqc-c78w) |
| `ws` | moderate | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) |
