### PR TITLE
fix(skills): resolve pip-audit findings in tts-voiceover skill lock file

### DIFF
--- a/.github/skills/experimental/tts-voiceover/pip-audit-known-vulnerabilities.txt
+++ b/.github/skills/experimental/tts-voiceover/pip-audit-known-vulnerabilities.txt
@@ -1,0 +1,4 @@
+# pyjwt PYSEC-2025-183 / CVE-2025-45768 — disputed by supplier; key length is chosen
+# by the application, not the library. No fix available upstream as of pyjwt 2.12.1.
+# Revisit if upstream changes disposition or releases a patched version.
+PYSEC-2025-183

--- a/.github/skills/experimental/tts-voiceover/uv.lock
+++ b/.github/skills/experimental/tts-voiceover/uv.lock
@@ -400,11 +400,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Resolves the open `pip-audit` findings against the `tts-voiceover` skill's locked Python dependencies.

* Upgrades `idna` from **3.11 → 3.15** in *.github/skills/experimental/tts-voiceover/uv.lock* to remediate [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) / [CVE-2026-45409](https://nvd.nist.gov/vuln/detail/CVE-2026-45409).
* Adds *.github/skills/experimental/tts-voiceover/pip-audit-known-vulnerabilities.txt* to allowlist `PYSEC-2025-183` (pyjwt 2.12.1). The advisory is **disputed by the supplier** because the affected key length is chosen by the calling application, not the library; there is no upstream fix as of pyjwt 2.12.1. The file documents the rationale and notes that the disposition should be revisited if upstream changes.

The allowlist file is consumed by the existing reusable workflow [.github/workflows/pip-audit.yml](.github/workflows/pip-audit.yml): each non-comment line is passed to `pip-audit` as `--ignore-vuln <id>`. The format and parsing path were already in production for other skills.

No source code, agent, prompt, instruction, or `SKILL.md` content changed — this is a pure dependency-hygiene patch scoped to the `tts-voiceover` skill folder.

## Related Issue(s)

Closes #1624

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

Agent-run validations:

* `npm run lint:all` — **Passed** (exit 0). Covers `lint:md`, `lint:ps`, `lint:yaml`, `lint:links`, `lint:frontmatter`, `lint:collections-metadata`, `lint:marketplace`, `lint:version-consistency`, `lint:permissions`, `lint:dependency-pinning`, `lint:py`, `validate:skills`, `lint:ai-artifacts`, and `lint:models`.
* Diff inspection — confirmed only two files touched (`uv.lock` and the new `pip-audit-known-vulnerabilities.txt`); no SKILL.md, agent, prompt, instructions, or workflow content changed.
* Allowlist format verification — confirmed the new file is parsed correctly by [.github/workflows/pip-audit.yml](.github/workflows/pip-audit.yml#L89-L97): comments and blank lines are stripped, the single ID `PYSEC-2025-183` becomes one `--ignore-vuln PYSEC-2025-183` argument.

Security analysis summary: the `idna` bump remediates a published advisory with no API surface impact; the pyjwt entry is a documented allowlist for a supplier-disputed finding, not a suppression of an exploitable vulnerability. No secrets or sensitive data in the diff.

> [!NOTE]
> Manual testing was not performed. The reusable `pip-audit` workflow is the source of truth for end-to-end validation and will run on this PR.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — no docs changes; the allowlist file is self-documenting via inline comments)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable) (N/A — advisory remediation; no new functionality)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check` (N/A — no prose changes; allowlist file contains only IDs and reviewer-facing comments)
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate` (N/A — no agent/skill/prompt/instructions metadata changed; plugin output is unaffected)
* [ ] Docusaurus tests: `npm run docs:test` (N/A — no `docs/` changes)

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

**Files changed** (2 files, 7 insertions, 3 deletions):

* *.github/skills/experimental/tts-voiceover/uv.lock* — `idna` 3.11 → 3.15.
* *.github/skills/experimental/tts-voiceover/pip-audit-known-vulnerabilities.txt* (new, 4 lines) — three comment lines explaining the disputed advisory plus one ID: `PYSEC-2025-183`.

**Advisory disposition table:**

| Package | Advisory | Disposition | Mechanism |
|---|---|---|---|
| `idna` | [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) / [CVE-2026-45409](https://nvd.nist.gov/vuln/detail/CVE-2026-45409) | Resolved | Lock file upgraded to `idna==3.15` |
| `pyjwt` | `PYSEC-2025-183` / [CVE-2025-45768](https://nvd.nist.gov/vuln/detail/CVE-2025-45768) | Documented allowlist | Supplier-disputed; key length is application-controlled, no upstream fix as of `pyjwt==2.12.1` |
