### PR TITLE
feat(scripts): allowlist accessibility skills subdomain and recognize templates subdir

### DIFF
--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -64,7 +64,7 @@ Skill files are typically organized in a collection subdirectory by convention:
 ├── references/                 # Additional documentation (optional)
 │   └── REFERENCE.md            # Detailed technical reference
 ├── assets/                     # Static resources (optional)
-│   └── templates/              # Document or configuration templates
+├── templates/                  # Document or configuration templates (optional)
 ├── examples/
 │   └── README.md               # Usage examples (recommended)
 └── tests/
@@ -83,7 +83,7 @@ The `scripts/` directory is **optional**. When present, it **MUST** contain at l
 * Use lowercase kebab-case for directory names: `video-to-gif`
 * Main definition file MUST be named `SKILL.md`
 * Script names should describe their action: `convert.sh`, `validate.ps1`
-* Only recognized subdirectories are allowed: `scripts`, `references`, `assets`, `examples`, `tests`,`templates` (the `tests` directory is excluded from extension and CLI outputs)
+* Only recognized subdirectories are allowed: `scripts`, `references`, `assets`, `examples`, `tests`, `templates` (the `tests` directory is excluded from extension and CLI outputs)
 
 ## Frontmatter Requirements
 
@@ -534,7 +534,7 @@ Before submitting your skill, verify:
 * [ ] Directory at `.github/skills/<skill-name>/`
 * [ ] SKILL.md present with valid frontmatter
 * [ ] If `scripts/` directory exists: at least one `.ps1` file present (`.sh` recommended)
-* [ ] Only recognized subdirectories used (`scripts`, `references`, `assets`, `examples`, `tests`,`templates`)
+* [ ] Only recognized subdirectories used (`scripts`, `references`, `assets`, `examples`, `tests`, `templates`)
 * [ ] Examples README (recommended)
 
 ### Frontmatter

--- a/scripts/collections/Validate-Collections.ps1
+++ b/scripts/collections/Validate-Collections.ps1
@@ -203,8 +203,9 @@ function Invoke-CollectionValidation {
     # Sub-domain folders that group artifacts shared across multiple themed collections
     # but are intentionally not collections themselves.
     $sharedSubdomainFolders = @{
-        'shared'       = $true
-        'rai-planning' = $true
+        'shared'        = $true
+        'rai-planning'  = $true
+        'accessibility' = $true
     }
 
     foreach ($file in $collectionFiles) {

--- a/scripts/tests/collections/Validate-Collections.Tests.ps1
+++ b/scripts/tests/collections/Validate-Collections.Tests.ps1
@@ -344,6 +344,11 @@ Describe 'Invoke-CollectionValidation - collection-to-folder name consistency' {
         New-Item -ItemType Directory -Path $raiPlanningDir -Force | Out-Null
         Set-Content -Path (Join-Path $raiPlanningDir 'rai.instructions.md') -Value '---\ndescription: rai-planning instruction\n---'
 
+        # accessibility sub-domain folder structure (shared across themed collections)
+        $accessibilityDir = Join-Path $script:repoRoot '.github/instructions/accessibility'
+        New-Item -ItemType Directory -Path $accessibilityDir -Force | Out-Null
+        Set-Content -Path (Join-Path $accessibilityDir 'accessibility.instructions.md') -Value '---\ndescription: accessibility instruction\n---'
+
         # hve-core folder structure (cross-collection reference allowed without warning)
         $hveCoreDir = Join-Path $script:repoRoot '.github/agents/hve-core'
         New-Item -ItemType Directory -Path $hveCoreDir -Force | Out-Null
@@ -493,6 +498,31 @@ Describe 'Invoke-CollectionValidation - collection-to-folder name consistency' {
         }
     }
 
+    It 'Allows items from accessibility/ folder in any collection' {
+        Mock Write-Host {}
+
+        $manifest = [ordered]@{
+            id          = 'my-collection'
+            name        = 'My Collection'
+            description = 'Collection referencing accessibility item'
+            items       = @(
+                [ordered]@{
+                    path = '.github/instructions/accessibility/accessibility.instructions.md'
+                    kind = 'instruction'
+                }
+            )
+        }
+        $yaml = ConvertTo-Yaml -Data $manifest
+        Set-Content -Path (Join-Path $script:collectionsDir 'my-collection.collection.yml') -Value $yaml
+
+        $result = Invoke-CollectionValidation -RepoRoot $script:repoRoot
+        $result.Success | Should -BeTrue
+        $result.ErrorCount | Should -Be 0
+        Should -Not -Invoke Write-Host -ParameterFilter {
+            $Object -match 'WARN collection'
+        }
+    }
+
     It 'Allows hve-core-all to reference items from any folder' {
         Mock Write-Host {}
 
@@ -515,6 +545,10 @@ Describe 'Invoke-CollectionValidation - collection-to-folder name consistency' {
                 },
                 [ordered]@{
                     path = '.github/instructions/rai-planning/rai.instructions.md'
+                    kind = 'instruction'
+                },
+                [ordered]@{
+                    path = '.github/instructions/accessibility/accessibility.instructions.md'
                     kind = 'instruction'
                 },
                 [ordered]@{


### PR DESCRIPTION
# Pull Request

## Description

This is the first PR in the stacked Accessibility Planner series. It prepares the validation tooling so the later accessibility skills and collection entries pass repository checks.

* Updated **`scripts/collections/Validate-Collections.ps1`** to allowlist the `accessibility` skills subdomain so accessibility skill paths resolve during collection validation.
* Updated **`scripts/linting/Validate-SkillStructure.ps1`** to recognize the `templates` subdirectory as a valid skill support folder.
* Updated **`docs/contributing/skills.md`** to document the `templates` subdirectory.

> This PR contains only the validator changes that subsequent PRs in the stack depend on. It is intentionally small so the tooling lands before the content that relies on it.

## Related Issue(s)

Closes #1725

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

* PowerShell analysis (`npm run lint:ps`) passed on the integrated stack tip.
* The full Pester suite (`npm run test:ps`) passed (2310 tests, 0 failures) on the integrated stack tip that includes these validator changes.
* No manual testing was performed beyond automated validation.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [x] PowerShell analysis: `npm run lint:ps`
* [x] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [x] Security-related scripts follow the principle of least privilege (N/A — no security scripts changed)

## Additional Notes

First PR of a six-PR stacked series for the Accessibility Planner. Base branch is `main`; later PRs stack on top of this branch.