### PR TITLE
feat(prompts): integrate Vally evals-authoring offer into Prompt Builder

### DIFF
--- a/.github/agents/hve-core/prompt-builder.agent.md
+++ b/.github/agents/hve-core/prompt-builder.agent.md
@@ -7,6 +7,7 @@ agents:
   - Prompt Evaluator
   - Prompt Updater
   - Researcher Subagent
+  - Vally Test Author
 handoffs:
   - label: "💡 Update/Create"
     agent: Prompt Builder
@@ -115,7 +116,7 @@ Run `Prompt Evaluator` as a subagent with `runSubagent` or `task`, providing the
 **Based on objectives, gaps, outstanding requirements and issues:**
 
 * Move on to Phase 2 with the findings from the *evaluation-log* and the user's requirements, then iterate on research.
-* If no more modifications are required, finalize your responses following User Conversation Guidelines and respond to the user with important updates, any outstanding issues not yet addressed, and suggestions for next steps.
+* If no more modifications are required, finalize your responses following User Conversation Guidelines and respond to the user with important updates, any outstanding issues not yet addressed, and suggestions for next steps. Include the Handoff Status table from the Handoff Status section to surface lint and eval gate outcomes.
 
 ### Phase 2: Prompt File(s) Research
 
@@ -158,6 +159,8 @@ Finalize the primary research document:
 
 #### Step 2: Iterate Parallel Prompt Updater Subagents
 
+When a target prompt file already exists in the repo, determine intent (update the existing file or author a new variant) and communicate that choice to the user before running `Prompt Updater`.
+
 Run `Prompt Updater` as a subagent using `runSubagent` or `task`, and parallelize calls when prompt files are independent, providing these inputs:
 
 * Prompt file(s) to create or modify.
@@ -191,6 +194,22 @@ When finishing, and after all Phases have been completed and repeated until *eva
 
 * Delete all sandbox file(s) and folder(s) unless otherwise specified by the user.
 * Do not respond with your final output until all sandboxes for this request are cleaned up.
+
+## Handoff Status
+
+When responding to the user after all phases complete, include a Handoff Status table that surfaces lint and eval gate outcomes side by side. The eval columns apply when the workflow created or modified a parent agent file (`.github/agents/**/*.agent.md` without `user-invocable: false`); otherwise mark them `n/a`.
+
+| Gate                              | Status                  | Notes                                                                                |
+|-----------------------------------|-------------------------|--------------------------------------------------------------------------------------|
+| `npm run lint:md`                 | `pass` / `fail`         | Markdown linting on modified prompt and agent files.                                 |
+| `npm run lint:ai-artifacts`       | `pass` / `fail`         | Prompt-engineering artifact lint.                                                    |
+| Surface signature regenerated     | `pass` / `fail` / `n/a` | `pwsh scripts/evals/New-AgentSurfaceSignatures.ps1` produced an entry for the agent. |
+| Stimulus partial authored         | `pass` / `fail` / `n/a` | `evals/agent-behavior/stimuli/<slug>.yml` exists and uses the class recipe.          |
+| Eval spec coverage                | `pass` / `fail` / `n/a` | `pwsh scripts/evals/Test-EvalSpec.ps1 -NewAgentsOnly` exits 0.                       |
+| `Prompt Tester` verdict           | `pass` / `fail` / `n/a` | Subagent run on the new stimulus.                                                    |
+| `Prompt Evaluator` verdict        | `pass` / `fail` / `n/a` | Subagent run on the resulting transcript.                                            |
+
+Block the final handoff until every applicable row reports `pass`.
 
 ## User Conversation Guidelines
 

--- a/.github/prompts/hve-core/prompt-build.prompt.md
+++ b/.github/prompts/hve-core/prompt-build.prompt.md
@@ -24,3 +24,18 @@ When the user provides files and/or promptFiles, with no other requirements then
 ## Required Protocol
 
 Follow all instructions in Required Phases, iterate and repeat Required Phases until promptFiles or related prompt file(s) meet the requirements.
+
+## Evals-Authoring Offer
+
+When a session creates or modifies a `prompt`, `instructions`, `agent`, or `skill` artifact, the Prompt Builder offers to author Vally conformance tests as part of session wrap-up. Frame this as a conversational offer rather than a gate. Present it at the natural session-end point and pick one of three responses based on the user's reply.
+
+* `yes`: Dispatch the `Vally Test Author` subagent in `from-artifact` mode against every artifact touched in this session. When the artifact kind is `agent`, also trigger the supporting eval mechanics:
+  * Regenerate per-agent surface signatures with `pwsh scripts/evals/New-AgentSurfaceSignatures.ps1`.
+  * Author a stimulus partial at `evals/agent-behavior/stimuli/<slug>.yml` matching the agent's class recipe in `evals/agent-behavior/README.md` (one of `research-writer`, `code-reviewer`, `code-implementor`, `workitem-manager`, or `planner-coach`); assign the class through the manifest produced by `pwsh scripts/evals/Build-AgentInventory.ps1`.
+  * Regenerate the behavioral eval spec with `pwsh scripts/evals/Build-AgentBehaviorSpec.ps1` and commit the resulting `evals/agent-behavior/eval.yaml`.
+  * Invoke the `Prompt Tester` subagent on the new stimulus, then the `Prompt Evaluator` subagent on the resulting transcript.
+  * Verify that `pwsh scripts/evals/Test-EvalSpec.ps1 -NewAgentsOnly` exits 0.
+* `no`: Skip Vally test authoring for this session. Record the skip as a single line in the final handoff so the user can revisit it later.
+* `corpus-import`: Surface the dedicated `/evals-import` prompt as the path for importing CSV or XLSX corpora into Vally eval suites; do not attempt a corpus import inline from this prompt.
+
+When the user picks `yes` on an `agent` artifact, the gate mechanics from the steps above are surfaced in the Prompt Builder's final Handoff Status table.

--- a/.github/prompts/hve-core/prompt-refactor.prompt.md
+++ b/.github/prompts/hve-core/prompt-refactor.prompt.md
@@ -19,3 +19,18 @@ agent: Prompt Builder
 ## Required Protocol
 
 Follow all instructions in Required Phases, iterate and repeat Required Phases until promptFiles or related prompt file(s) meet the requirements.
+
+## Evals-Authoring Offer
+
+When a session creates or modifies a `prompt`, `instructions`, `agent`, or `skill` artifact, the Prompt Builder offers to author Vally conformance tests as part of session wrap-up. Frame this as a conversational offer rather than a gate. Present it at the natural session-end point and pick one of three responses based on the user's reply.
+
+* `yes`: Dispatch the `Vally Test Author` subagent in `from-artifact` mode against every artifact touched in this session. When the artifact kind is `agent`, also trigger the supporting eval mechanics:
+  * Regenerate per-agent surface signatures with `pwsh scripts/evals/New-AgentSurfaceSignatures.ps1`.
+  * Author a stimulus partial at `evals/agent-behavior/stimuli/<slug>.yml` matching the agent's class recipe in `evals/agent-behavior/README.md` (one of `research-writer`, `code-reviewer`, `code-implementor`, `workitem-manager`, or `planner-coach`); assign the class through the manifest produced by `pwsh scripts/evals/Build-AgentInventory.ps1`.
+  * Regenerate the behavioral eval spec with `pwsh scripts/evals/Build-AgentBehaviorSpec.ps1` and commit the resulting `evals/agent-behavior/eval.yaml`.
+  * Invoke the `Prompt Tester` subagent on the new stimulus, then the `Prompt Evaluator` subagent on the resulting transcript.
+  * Verify that `pwsh scripts/evals/Test-EvalSpec.ps1 -NewAgentsOnly` exits 0.
+* `no`: Skip Vally test authoring for this session. Record the skip as a single line in the final handoff so the user can revisit it later.
+* `corpus-import`: Surface the dedicated `/evals-import` prompt as the path for importing CSV or XLSX corpora into Vally eval suites; do not attempt a corpus import inline from this prompt.
+
+When the user picks `yes` on an `agent` artifact, the gate mechanics from the steps above are surfaced in the Prompt Builder's final Handoff Status table.


### PR DESCRIPTION
# Pull Request

## Description

Integrated a Vally evals-authoring offer into the Prompt Builder workflow. Extended *prompt-builder.agent.md* so that, after creating or refactoring an AI artifact, the agent offers to author matching Vally tests, and added the corresponding hand-off steps to *prompt-build.prompt.md* and *prompt-refactor.prompt.md*.

## Related Issue(s)

Closes #1822

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [x] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:** "Build a new instruction file for Terraform formatting."

**Execution Flow:** Prompt Builder creates the artifact, then offers to author Vally tests for it and, on acceptance, hands off to the vally-test-author subagent.

**Output Artifacts:** The new AI artifact plus an optional set of Vally stimuli and expectations.

**Success Indicators:** The authoring offer appears after artifact creation and the hand-off produces valid eval specs.

## Testing

Validated via `npm run lint:all` (exit 0), including `npm run lint:frontmatter` and `npm run lint:ai-artifacts` for the modified agent and prompt files.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Tenth PR in the #1637 stack. **Base branch: `feat/1637-l8-collections`.** Modifies the existing Prompt Builder artifacts at `stable` maturity.
