### PR TITLE
feat(agents): add copilot-tracking path reporting guidance

### DIFF
--- a/.github/agents/project-planning/product-manager-advisor.agent.md
+++ b/.github/agents/project-planning/product-manager-advisor.agent.md
@@ -72,6 +72,8 @@ Every code change has a corresponding issue or work item for tracking and contex
 
 Apply the conventions from `story-quality.instructions.md` when evaluating or creating work items. Specifically enforce the Scope and Sizing, Completeness Dimensions, and Evidence Source sections.
 
+When persisting draft work items, requirements, or planning artifacts to files, write them under `.copilot-tracking/` and report the `.copilot-tracking/` path in your response.
+
 Guide labeling and categorization:
 
 * Apply labels that reflect component, scope size, and priority.

--- a/.github/agents/rai-planning/rai-planner.agent.md
+++ b/.github/agents/rai-planning/rai-planner.agent.md
@@ -97,7 +97,7 @@ Pre-scans the security plan, asks output preferences, then reads the security pl
 
 ## State Management Protocol
 
-State files live under `.copilot-tracking/rai-plans/{project-slug}/`.
+State files live under `.copilot-tracking/rai-plans/{project-slug}/`. When reporting where artifacts or state were saved, cite the canonical `.copilot-tracking/rai-plans/{project-slug}/` path rather than any underlying physical or temporary path.
 
 State JSON schema for `state.json`:
 


### PR DESCRIPTION
# Pull Request

## Description

Added copilot-tracking path reporting guidance to two planning agents so they surface their tracking-file locations to the user. Updated *product-manager-advisor.agent.md* and *rai-planner.agent.md* with the path-reporting instruction.

## Related Issue(s)

Closes #1824

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:** "Help me draft requirements for a new feature."

**Execution Flow:** The Product Manager Advisor agent runs its workflow and now reports the copilot-tracking path where its session artifacts are stored.

**Output Artifacts:** Planning artifacts plus an explicit path reference in the agent's response.

**Success Indicators:** The agent states the tracking-file location to the user.

## Testing

Validated via `npm run lint:all` (exit 0), including `npm run lint:frontmatter` and `npm run lint:ai-artifacts`.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Twelfth PR in the #1637 stack. **Base branch: `feat/1637-a-content-policies`.** Small guidance addition to existing `stable` agents.
