### PR TITLE
fix(docs): improve contrast for badges and search hint

### DIFF
--- a/docs/docusaurus/src/components/CollectionCards/styles.module.css
+++ b/docs/docusaurus/src/components/CollectionCards/styles.module.css
@@ -56,18 +56,18 @@
 }
 
 .maturityStable {
-  background: var(--ifm-color-success-contrast-background);
-  color: var(--ifm-color-success-dark);
+  background: #e6f6e6;
+  color: #006b00;
 }
 
 .maturityPreview {
-  background: var(--ifm-color-warning-contrast-background);
-  color: var(--ifm-color-warning-dark);
+  background: #fff8e6;
+  color: #7a4f00;
 }
 
 .maturityExperimental {
-  background: var(--ifm-color-info-contrast-background);
-  color: var(--ifm-color-info-dark);
+  background: #eef9fd;
+  color: #005f73;
 }
 
 .collectionDescription {

--- a/docs/docusaurus/src/css/custom.css
+++ b/docs/docusaurus/src/css/custom.css
@@ -90,6 +90,13 @@ a:visited {
   color: inherit;
 }
 
+.navbar__search kbd {
+  background-color: #ebedf0;
+  border-color: #6b7680;
+  box-shadow: inset 0 -1px 0 #6b7680;
+  color: #4a5560;
+}
+
 /* Navbar: MS Learn-style sizing */
 .navbar {
   height: 54px;


### PR DESCRIPTION
# Pull Request

## Description

Updated the Docusaurus documentation styles to improve contrast for shared accessibility findings in collection card maturity badges and the navbar search keyboard hint.

* Set explicit accessible color pairs for stable, preview, and experimental maturity badges in `docs/docusaurus/src/components/CollectionCards/styles.module.css`.
* Added navbar search `kbd` color, border, and background overrides in `docs/docusaurus/src/css/custom.css`.

## Related Issue(s)

Closes #1907
Closes #1908
Closes #1909
Closes #1910
Closes #1911
Closes #1912
Closes #1913
Closes #1914
Closes #1915
Closes #1916
Closes #1917
Closes #1918

Issue #1654 is intentionally excluded from this PR.

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

N/A. This PR does not change AI artifacts.

## Testing

Automated validation completed:

* `git diff --check origin/main...HEAD` passed.
* `npm run docs:build` passed.
* `git status --short --branch` showed the branch clean and tracking `origin/fix/a11y-docs-contrast-1907-1918` after push.

Diff-based checks completed:

* Confirmed the PR diff is limited to two CSS files.
* Confirmed no AI artifact files changed.
* Confirmed no generated plugin or extension package outputs changed.

Security analysis:

* No runtime security-sensitive code, dependencies, scripts, workflows, or authentication behavior changed.

Manual validation:

* Validated contrast ratios for the updated shared UI elements: stable badge `6.02`, preview badge `6.73`, experimental badge `6.80`, search hint text `6.49`, and search hint border/background `3.95`.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (N/A, CSS contrast fix only)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution (N/A)
* [ ] Addressed all feedback from `prompt-builder` review (N/A)
* [ ] Verified contribution follows common standards and type-specific requirements (N/A)

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

Validation run for this scoped CSS change:

* [x] `git diff --check origin/main...HEAD`
* [x] `npm run docs:build`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] This PR does not add or update dependencies
* [x] This PR does not change security-related scripts or permissions

This PR only updates Docusaurus CSS. It does not change dependencies, generated plugin outputs, scripts, workflows, authentication, authorization, or data handling.

## Additional Notes

The related accessibility issues share the same Docusaurus component selectors, so the remediation is intentionally concentrated in the shared CSS rules.
