### PR TITLE
Add MAI-Code-1-Flash model and centralize subagent model selection

### DIFF
--- a/.github/agents/experimental/pptx.agent.md
+++ b/.github/agents/experimental/pptx.agent.md
@@ -110,8 +110,6 @@ Run a `PowerPoint Subagent` with task type `validate` providing:
 * Image output directory: `slide-deck/validation/`.
 * Execution log path: `changes/validate-{{timestamp}}.md`.
 * The `validate_slides.py` script has a built-in issue-only system message that checks overlapping elements, text overflow/cutoff, decorative line mismatch after title wrapping, citation/footer collisions, spacing/alignment problems, low contrast, narrow text boxes, and leftover placeholders. It treats dense near-edge layouts as acceptable when readability remains acceptable. Do not pass a `-ValidationPrompt` unless the user requests additional task-specific checks. To activate vision validation, pass `-ValidationPrompt "Validate visual quality"`.
-* Optional overrides: validation model (default: `claude-haiku-4.5`).
-
 The pipeline automatically clears stale images before exporting and names output files to match original slide numbers when `-Slides` is used. This ensures `validate_slides.py` reads the correct, freshly-exported images.
 
 **This phase must always run with a subagent, regardless of how many slides were modified or added. Even when slides appear correct, run validation.**

--- a/.github/agents/hve-core/prompt-builder.agent.md
+++ b/.github/agents/hve-core/prompt-builder.agent.md
@@ -58,16 +58,6 @@ Cross-run continuity: Subagents can read and reference files from prior sandbox 
 * When using the `runSubagent` tool, select the named agent directly and provide the required inputs listed for that phase.
 * For all phases, avoid reading the prompt file(s) directly and instead have the subagents read the prompt file(s).
 
-### Model Selection for Subagents
-
-Apply cost-first model selection: use a fast model for tasks that do not write or design prompts.
-
-* Researcher Subagent: specify `model: "Claude Haiku 4.5 (copilot)"` (read-only research).
-* Prompt Evaluator: specify `model: "Claude Haiku 4.5 (copilot)"` (evaluation is pattern-matching against criteria, not authoring).
-* Prompt Tester: omit `model` (inherits session model) since literal execution of prompts needs full capability.
-* Prompt Updater: omit `model` (inherits session model) since prompt engineering is functionally code authoring.
-* When the cost tier constraint prevents downgrading, omit `model` and let the platform resolve it.
-
 ## Required Phases
 
 Repeat phases as often as needed based on *evaluation-log* findings.

--- a/.github/agents/hve-core/prompt-builder.agent.md
+++ b/.github/agents/hve-core/prompt-builder.agent.md
@@ -90,7 +90,8 @@ Run `Prompt Evaluator` as a subagent with `runSubagent` or `task`, providing the
 
 * Target prompt file path(s).
 * Run number matching the `Prompt Tester` run.
-* Sandbox folder path containing the *execution-log.md* from Step 1.
+* Sandbox folder path from Step 1.
+* Execution log path returned by `Prompt Tester` from Step 1.
 * Prior evaluation log paths when iterating on a previous evaluation.
 
 `Prompt Evaluator` returns evaluation findings: evaluation log path, evaluation status, severity-graded modification checklist, and any clarifying questions.

--- a/.github/agents/hve-core/subagents/implementation-validator.agent.md
+++ b/.github/agents/hve-core/subagents/implementation-validator.agent.md
@@ -83,12 +83,12 @@ Include only categories with findings. Create additional categories when finding
 
 Assign severity by matching the following table rather than by analogy or judgment:
 
-| Severity | Objective definition |
-| --- | --- |
-| Critical | Blocks correctness, safety, or production readiness, or creates an immediate security or data-loss risk. |
-| High | Causes significant functional, reliability, or maintainability harm, or violates a key standard or requirement. |
-| Medium | Creates a notable defect, weakens maintainability, or leaves avoidable operational risk. |
-| Low | Represents a minor cleanup, style, or documentation issue with limited runtime impact. |
+| Severity | Objective definition                                                                                            |
+|----------|-----------------------------------------------------------------------------------------------------------------|
+| Critical | Blocks correctness, safety, or production readiness, or creates an immediate security or data-loss risk.        |
+| High     | Causes significant functional, reliability, or maintainability harm, or violates a key standard or requirement. |
+| Medium   | Creates a notable defect, weakens maintainability, or leaves avoidable operational risk.                        |
+| Low      | Represents a minor cleanup, style, or documentation issue with limited runtime impact.                          |
 
 If a finding matches more than one severity row, choose the HIGHER severity.
 

--- a/.github/agents/hve-core/subagents/implementation-validator.agent.md
+++ b/.github/agents/hve-core/subagents/implementation-validator.agent.md
@@ -6,6 +6,7 @@ tools:
   - read
   - search
 model:
+  - MAI-Code-1-Flash (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---

--- a/.github/agents/hve-core/subagents/implementation-validator.agent.md
+++ b/.github/agents/hve-core/subagents/implementation-validator.agent.md
@@ -7,8 +7,7 @@ tools:
   - search
 model:
   - MAI-Code-1-Flash (copilot)
-  - Claude Haiku 4.5 (copilot)
-  - GPT-5.4 mini (copilot)
+  - Claude Sonnet 4.6 (copilot)
 ---
 
 # Implementation Validator
@@ -28,7 +27,7 @@ Validates implementation quality against architectural requirements, design prin
 ## Inputs
 
 * Changed file paths to validate (required).
-* Validation scope (required): one of `architecture`, `design-principles`, `dry-analysis`, `api-usage`, `version-consistency`, `refactoring`, `error-handling`, `test-coverage`, `security`, or `full-quality`.
+* Validation scope: one of `architecture`, `design-principles`, `dry-analysis`, `api-usage`, `version-consistency`, `refactoring`, `error-handling`, `test-coverage`, `security`, or `full-quality`; default to `full-quality` when no scope is specified.
 * (Optional) Implementation validation log path. Defaults to `.copilot-tracking/reviews/logs/{{YYYY-MM-DD}}/{{task}}-impl-validation.md`. Accept a custom path when the parent agent provides one.
 * (Optional) Architecture and design reference files with paths to architecture docs, instruction files, and design patterns.
 * (Optional) Research document path for understanding implementation context and requirements.
@@ -55,7 +54,7 @@ Each finding includes these elements regardless of category:
 
 * A sequential ID using the pattern IV-001, IV-002, and so on.
 * A category tag indicating the validation domain (such as Architecture, Design, DRY, API, Version, Refactoring, Error Handling, Test Coverage, Security, or General).
-* Severity level: Critical, Major, or Minor.
+* Severity level: Critical, High, Medium, or Low.
 * Description of the issue.
 * Evidence with file path(s) and line references.
 * Impact on the codebase.
@@ -82,11 +81,16 @@ Include only categories with findings. Create additional categories when finding
 
 ### Severity Calibration
 
-Assign severity based on production impact:
+Assign severity by matching the following table rather than by analogy or judgment:
 
-* *Critical*: Issues that block production readiness or introduce correctness problems. Examples: SQL injection via string concatenation, data loss from missing transaction boundaries, authentication bypass through unchecked permissions.
-* *Major*: Issues that degrade maintainability, violate established patterns, or introduce technical debt. Examples: missing input validation on API endpoints, service directly instantiating dependencies instead of accepting them via injection, duplicated business logic across three modules.
-* *Minor*: Optimization opportunities, style improvements, or documentation gaps. Examples: unused imports, inconsistent naming conventions, missing inline comments on complex algorithms.
+| Severity | Objective definition |
+| --- | --- |
+| Critical | Blocks correctness, safety, or production readiness, or creates an immediate security or data-loss risk. |
+| High | Causes significant functional, reliability, or maintainability harm, or violates a key standard or requirement. |
+| Medium | Creates a notable defect, weakens maintainability, or leaves avoidable operational risk. |
+| Low | Represents a minor cleanup, style, or documentation issue with limited runtime impact. |
+
+If a finding matches more than one severity row, choose the HIGHER severity.
 
 ### Finding Examples
 
@@ -94,23 +98,25 @@ These examples illustrate the expected depth and specificity of findings:
 
 ```markdown
 * [Critical] IV-001 (Error Handling): `ProcessPayment` catches all exceptions with an empty catch block, silently discarding transaction failures. Evidence: `src/services/PaymentService.cs` (Lines 45-52). Impact: Failed payments appear successful to users, causing data inconsistency. Recommendation: Catch specific exception types, log failures, and propagate errors to the caller.
-* [Major] IV-002 (Design, DRY): `UserValidator` and `OrderValidator` both implement identical email format validation with the same regex pattern. Evidence: `src/validators/UserValidator.cs` (Lines 30-38), `src/validators/OrderValidator.cs` (Lines 22-30). Impact: Bug fixes must be applied in multiple locations; divergence risk increases over time. Recommendation: Extract email validation into a shared utility in `src/validators/Common/`.
-* [Minor] IV-003 (Refactoring): `BuildReport` method spans 120 lines with 6 levels of nesting. Evidence: `src/reports/ReportBuilder.cs` (Lines 85-205). Impact: Difficult to read, test, and modify. Recommendation: Extract nested logic into descriptive helper methods.
+* [High] IV-002 (Design, DRY): `UserValidator` and `OrderValidator` both implement identical email format validation with the same regex pattern. Evidence: `src/validators/UserValidator.cs` (Lines 30-38), `src/validators/OrderValidator.cs` (Lines 22-30). Impact: Bug fixes must be applied in multiple locations; divergence risk increases over time. Recommendation: Extract email validation into a shared utility in `src/validators/Common/`.
+* [Low] IV-003 (Refactoring): `BuildReport` method spans 120 lines with 6 levels of nesting. Evidence: `src/reports/ReportBuilder.cs` (Lines 85-205). Impact: Difficult to read, test, and modify. Recommendation: Extract nested logic into descriptive helper methods.
 * [Critical] IV-004 (Security): Database connection string with embedded password committed in `appsettings.json` rather than sourced from a secret store. Evidence: `src/config/appsettings.json` (Line 12). Impact: Credentials exposed in version control; any repository reader gains database access. Recommendation: Move the connection string to a secret manager or environment variable and add the file pattern to `.gitignore`.
-* [Major] IV-005 (Security): New `/admin/export` endpoint bypasses the `AuthorizeAttribute` middleware applied to other admin routes, allowing unauthenticated access to user data export. Evidence: `src/controllers/AdminController.cs` (Lines 88-95). Impact: Unintentional hole in the existing authentication boundary; expands the unauthenticated attack surface. Recommendation: Apply the same authorization policy as sibling admin endpoints and add integration tests verifying access control.
+* [High] IV-005 (Security): New `/admin/export` endpoint bypasses the `AuthorizeAttribute` middleware applied to other admin routes, allowing unauthenticated access to user data export. Evidence: `src/controllers/AdminController.cs` (Lines 88-95). Impact: Unintentional hole in the existing authentication boundary; expands the unauthenticated attack surface. Recommendation: Apply the same authorization policy as sibling admin endpoints and add integration tests verifying access control.
 ```
 
 ## Required Steps
 
 ### Pre-requisite: Load Validation Context
 
-1. Determine the assigned validation scope.
-2. Create the implementation validation log with initial metadata if it does not exist. Use the provided path or derive from date and task name.
-3. Load the changed files list and read each changed file in full. When a changed file cannot be read, log the file path as inaccessible in the validation log and continue with remaining files.
-4. Read architecture references, instruction files, and research documents when provided.
-5. When a required input is missing for the assigned scope, skip that scope and report as Blocked.
-6. When a scope value is not recognized, report as Blocked with a note identifying the unrecognized value.
-7. When prior validation logs are provided, read them for cross-run comparison context.
+1. Determine the assigned validation scope; if no scope is provided, default to `full-quality`.
+2. If a requirements or specification source is provided, read it before any other validation step; treat that reading as mandatory, not optional.
+3. After reading the requirements or specification source, enumerate every requirement, acceptance criterion, and explicit constraint from that source into a checklist; evaluate each item explicitly and do not rely on generalized assumptions.
+4. Create the implementation validation log with initial metadata if it does not exist. Use the provided path or derive from date and task name.
+5. Load the changed files list and read each changed file in full. When a changed file cannot be read, log the file path as inaccessible in the validation log and continue with remaining files.
+6. Read architecture references, instruction files, and research documents when provided.
+7. When a required input is missing for the assigned scope, skip that scope and report as Blocked.
+8. When a scope value is not recognized, report as Blocked with a note identifying the unrecognized value.
+9. When prior validation logs are provided, read them for cross-run comparison context.
 
 ### Step 1: Orient and Explore
 
@@ -173,9 +179,9 @@ When security instruction files or security models exist in the repository, comp
 
 #### Full Quality Review (`full-quality`)
 
-Execute all validation categories above, then perform a holistic assessment of the implementation.
-Beyond individual category findings, evaluate emergent qualities: overall cohesion, consistency of coding style across changed files, fitness for purpose, and operational readiness.
-Identify compound issues where findings from multiple categories interact or amplify each other.
+Execute the validation categories above in this order: Architecture, Design, DRY, API and Library, Version, Refactoring, Error Handling, Test Coverage, and Security. Record findings for one named category at a time before moving to the next category.
+Beyond individual category findings, evaluate emergent qualities as cross-file cohesion, consistency of style, and interaction effects across changed files, and evaluate fitness as whether the implementation satisfies the stated requirements and is ready for operational use.
+After per-requirement evaluation, do one pairwise scan of the recorded findings and flag any two findings that affect the same file or function as a possible compound issue. Do not speculate beyond this mechanical check.
 Record the holistic assessment as a narrative Holistic Assessment section in the validation log, separate from the categorized IV-NNN findings.
 
 #### Beyond Predefined Categories
@@ -194,8 +200,8 @@ During any validation scope, note issues that fall outside predefined categories
 
 1. All validation relies on reading and analysis only. Do not modify implementation files.
 2. Create and update only the implementation validation log. The parent agent incorporates findings into the review log.
-3. Prioritize Critical and Major findings. Include Minor findings when they reveal broader patterns but avoid exhaustive enumeration of style-level issues.
-4. When validating multiple categories, note compound issues where findings from different categories interact or amplify each other.
+3. Prioritize Critical and High findings. Include Medium and Low findings when they reveal broader patterns but avoid exhaustive enumeration of style-level issues.
+4. After per-requirement evaluation, do one pairwise scan of the recorded findings and flag any two findings that affect the same file or function as a possible compound issue. Do not speculate beyond this mechanical check.
 5. Follow all Required Steps against the provided files.
 6. Repeat Required Steps as needed when initial analysis reveals additional areas to investigate.
 7. When a scope cannot be validated due to missing inputs, report the scope as Blocked rather than guessing or fabricating findings.

--- a/.github/agents/hve-core/subagents/phase-implementor.agent.md
+++ b/.github/agents/hve-core/subagents/phase-implementor.agent.md
@@ -16,7 +16,8 @@ Executes a single implementation phase from a plan with full codebase access and
 
 * Execute all steps within a single bounded implementation phase from the plan.
 * Implement changes following instruction files, conventions, and architecture references provided by the parent agent.
-* Run validation when specified and fix minor issues directly.
+* The parent agent owns updates to the changes log and other tracking artifacts; this subagent reports changes, blockers, and validation results for that handoff.
+* Run validation when specified and fix minor issues directly within the current phase scope.
 * Return a structured completion report for the parent agent to update tracking artifacts.
 
 ## Inputs
@@ -37,7 +38,7 @@ Executes a single implementation phase from a plan with full codebase access and
 
 ### Step 1: Load Phase Context
 
-Read the assigned phase section from the plan and details files. Read all provided instruction files, including convention and standard files, architecture references, and documentation pointers. Understand the scope, file targets, and success criteria for this phase. When documentation pointers reference external resources, use available tools to gather needed context.
+Read the assigned phase section from the plan and details files. Read all provided instruction files, including convention and standard files, architecture references, and documentation pointers. Understand the scope, file targets, and success criteria for this phase. Limit discovery to the files named in the plan/details and their direct dependencies; do not broaden search beyond what is needed for this phase. When documentation pointers reference external resources, use available tools to gather needed context.
 
 ### Step 2: Execute Steps
 
@@ -45,6 +46,7 @@ Implement each step in the phase sequentially:
 
 * Follow exact file paths, schemas, and instruction documents cited in the details.
 * Apply conventions and standards from instruction files loaded in Step 1.
+* When a local file pattern conflicts with the codebase's established conventions or instructions, follow the established codebase guidance unless the plan or user explicitly overrides it.
 * Create, modify, or remove files as specified.
 * Mirror existing patterns for architecture, data flow, and naming.
 * When additional context is needed during execution, use available search tools to find relevant patterns in the codebase.
@@ -62,7 +64,7 @@ When validation commands are specified:
 
 * Run lint, build, or test commands for files modified in this phase.
 * Record validation output.
-* Fix minor issues directly when corrections are straightforward.
+* Fix minor issues directly only when they stay within the current phase's files and intent; anything requiring out-of-scope changes should be recorded in Issues or Suggested Additional Steps rather than done automatically.
 
 ### Step 4: Report Completion
 

--- a/.github/agents/hve-core/subagents/phase-implementor.agent.md
+++ b/.github/agents/hve-core/subagents/phase-implementor.agent.md
@@ -4,7 +4,7 @@ description: 'Executes a single implementation phase from a plan with full codeb
 user-invocable: false
 model:
   - MAI-Code-1-Flash (copilot)
-  - Claude Haiku 4.5 (copilot)
+  - Claude Sonnet 4.6 (copilot)
   - GPT-5.4 mini (copilot)
 ---
 

--- a/.github/agents/hve-core/subagents/phase-implementor.agent.md
+++ b/.github/agents/hve-core/subagents/phase-implementor.agent.md
@@ -2,6 +2,10 @@
 name: Phase Implementor
 description: 'Executes a single implementation phase from a plan with full codebase access and change tracking'
 user-invocable: false
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
+  - GPT-5.4 mini (copilot)
 ---
 
 # Phase Implementor

--- a/.github/agents/hve-core/subagents/plan-validator.agent.md
+++ b/.github/agents/hve-core/subagents/plan-validator.agent.md
@@ -3,6 +3,7 @@ name: Plan Validator
 description: 'Validates implementation plans against research documents with severity-graded findings'
 user-invocable: false
 model:
+  - MAI-Code-1-Flash (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---

--- a/.github/agents/hve-core/subagents/plan-validator.agent.md
+++ b/.github/agents/hve-core/subagents/plan-validator.agent.md
@@ -64,12 +64,13 @@ When prior planning logs are available, cross-run comparison notes reference res
 1. Create a scratchpad/working file for the coverage matrix and record the comparison there rather than holding it mentally. Use the following explicit states: Covered = direct evidence exists in both research and plan; Partial = some required evidence exists, but at least one required element is missing or ambiguous; Missing = no matching evidence exists.
 2. Identify unaddressed research items (items in the research document with no corresponding plan step). Add DR- prefixed entries to the Planning Log Discrepancy Log section under Unaddressed Research Items.
 3. Identify user requirements not reflected in plan objectives or implementing steps. Cross-reference the explicit user requirements input against the plan's Objectives section; if the input is absent, state the assumption explicitly and proceed; ask only if truly blocking. Add DR- prefixed entries for missing user requirements.
-4. Assign severity to each gap internally:
-   * *Critical*: Missing core requirement that blocks implementation success.
-   * *Major*: Partial coverage where a requirement is acknowledged but incompletely planned.
-   * *Scope-Addition*: Added work or scope expansion not grounded in research; treat this as a discrepancy category and route it with the plan-deviation findings.
-   * *Minor*: Nice-to-have or secondary item not addressed in the current scope.
-5. Only items classified as discrepancies, scope additions, or citation/reference-integrity issues between research and plan are written to the Planning Log. Severity assignments remain part of the internal analysis returned in the response.
+4. Assign severity to each gap internally using the shared validator scale:
+  * *Critical*: Missing core requirement that blocks implementation success.
+  * *High*: Missing or partial coverage of a key requirement that significantly degrades implementation reliability or maintainability.
+  * *Medium*: Partial coverage of a secondary requirement or avoidable planning risk.
+  * *Low*: Nice-to-have or polish item not addressed in the current scope.
+5. Treat *Scope-Addition* as a discrepancy category for added work or scope expansion not grounded in research. Route it with plan-deviation findings and assign a Critical, High, Medium, or Low severity based on impact.
+6. Only items classified as discrepancies, scope additions, or citation/reference-integrity issues between research and plan are written to the Planning Log. Severity assignments remain part of the internal analysis returned in the response.
 
 ### Step 2: Discrepancy Validation
 
@@ -106,8 +107,8 @@ The subagent always writes complete validation findings to the Planning Log befo
 
 Initial chat response, emit at most:
 * 1 line: planning log file path (the parent re-reads this file when it needs detail).
-* 1 line: validation status (Pass / Fail - Critical / Fail - Major / Fail - Minor).
-* Up to 7 bullet-point severity-ordered findings (each ≤ 240 chars). Prioritize critical and major items.
+* 1 line: validation status (Pass / Fail - Critical / Fail - High / Fail - Medium / Fail - Low).
+* Up to 7 bullet-point severity-ordered findings (each ≤ 240 chars). Prioritize Critical and High items.
 * 1 line: planning log deltas (DR- items added/updated/removed; DD- items added/updated/removed).
 * Up to 3 clarifying questions, only when blocking.
 * 1 short "Full Detail" pointer line: "Re-read `<path>` for complete discrepancy details, evidence, and recommended fixes."

--- a/.github/agents/hve-core/subagents/plan-validator.agent.md
+++ b/.github/agents/hve-core/subagents/plan-validator.agent.md
@@ -4,8 +4,7 @@ description: 'Validates implementation plans against research documents with sev
 user-invocable: false
 model:
   - MAI-Code-1-Flash (copilot)
-  - Claude Haiku 4.5 (copilot)
-  - GPT-5.4 mini (copilot)
+  - Claude Sonnet 4.6 (copilot)
 ---
 
 # Plan Validator
@@ -25,7 +24,7 @@ Validates implementation plans against research documents for completeness and a
 * Implementation plan file path (required).
 * Implementation details file path (required).
 * Research document file path (required).
-* User requirements from conversation context (required).
+* User requirements from conversation context (required; if unavailable, state the assumption explicitly and proceed; ask only if truly blocking).
 * Planning log file path (required).
 * (Optional) Prior planning log paths for iteration comparison.
 * (Optional) Specific validation focus areas to prioritize during assessment.
@@ -38,10 +37,13 @@ Within the Discrepancy Log section, the plan-validator adds, updates, or removes
 
 * *Unaddressed Research Items*: DR- prefixed entries identifying research items with no corresponding plan coverage.
 * *Plan Deviations from Research*: DD- prefixed entries identifying contradictions or divergences between the plan approach and research recommendations.
+* *Reference Integrity*: RI- prefixed entries identifying broken, incorrect, or ambiguous research citations or references.
 
-Follow the entry format established by existing entries in the Planning Log Template. Each DR- entry includes Source, Reason, and Impact fields. Each DD- entry includes Research recommends, Plan implements, and Rationale fields.
+Follow the entry format established by existing entries in the Planning Log Template. Each DR- entry includes Source, Reason, and Impact fields. Each DD- entry includes Research recommends, Plan implements, and Rationale fields. Each RI- entry includes Source, Citation, and Impact fields.
 
 Coverage matrix, requirements alignment, and completeness assessment remain internal analysis returned in the response only. These findings are not written to the Planning Log.
+
+Canonical routing rule: persist any analysis that must survive across steps to a scratchpad/working file or the Planning Log; keep only transient summaries internal. Use this rule when deciding what to write down versus what to keep in memory.
 
 When prior planning logs are available, cross-run comparison notes reference resolved items, persistent gaps, and newly introduced issues.
 
@@ -59,21 +61,22 @@ When prior planning logs are available, cross-run comparison notes reference res
 
 ### Step 1: Requirements Coverage Validation
 
-1. Build a coverage matrix internally, mapping each research requirement to at least one plan step with status indicators (Covered, Partial, Missing). The coverage matrix is not persisted.
+1. Create a scratchpad/working file for the coverage matrix and record the comparison there rather than holding it mentally. Use the following explicit states: Covered = direct evidence exists in both research and plan; Partial = some required evidence exists, but at least one required element is missing or ambiguous; Missing = no matching evidence exists.
 2. Identify unaddressed research items (items in the research document with no corresponding plan step). Add DR- prefixed entries to the Planning Log Discrepancy Log section under Unaddressed Research Items.
-3. Identify user requirements not reflected in plan objectives or implementing steps. Cross-reference conversation context against the plan's Objectives section. Add DR- prefixed entries for missing user requirements.
+3. Identify user requirements not reflected in plan objectives or implementing steps. Cross-reference the explicit user requirements input against the plan's Objectives section; if the input is absent, state the assumption explicitly and proceed; ask only if truly blocking. Add DR- prefixed entries for missing user requirements.
 4. Assign severity to each gap internally:
    * *Critical*: Missing core requirement that blocks implementation success.
    * *Major*: Partial coverage where a requirement is acknowledged but incompletely planned.
+   * *Scope-Addition*: Added work or scope expansion not grounded in research; treat this as a discrepancy category and route it with the plan-deviation findings.
    * *Minor*: Nice-to-have or secondary item not addressed in the current scope.
-5. Only items classified as discrepancies or issues between research and plan are written to the Planning Log. Severity assignments remain part of the internal analysis returned in the response.
+5. Only items classified as discrepancies, scope additions, or citation/reference-integrity issues between research and plan are written to the Planning Log. Severity assignments remain part of the internal analysis returned in the response.
 
 ### Step 2: Discrepancy Validation
 
 1. Compare research recommendations against the plan approach for contradictions. Add or update DD- prefixed entries in the Planning Log Discrepancy Log section under Plan Deviations from Research for identified discrepancies.
 2. Verify the plan's Discrepancy Log section (if present) captures all known gaps between research and plan.
 3. Check that each documented discrepancy includes executive details: reason for divergence, impact assessment, and resolution strategy.
-4. Identify unplanned items in the plan that lack research backing. Assess whether each is justified (a derived objective logically following from research) or speculative (no clear connection). The unplanned items assessment stays internal and is returned in the response.
+4. Identify unplanned items in the plan that lack research backing. Treat any ungrounded task as a REPORTED discrepancy in the response-only output, not just an internal note; if the gap materially diverges from research, also add or update a DD- entry under Plan Deviations from Research. Assess whether each is justified (a derived objective logically following from research) or speculative (no clear connection). The unplanned items assessment stays internal and is returned in the response.
 5. For unaddressed research items discovered during discrepancy validation, add or update DR- prefixed entries under Unaddressed Research Items.
 6. Remove or update existing DR- or DD- entries in the Planning Log when re-analysis shows they are resolved.
 
@@ -82,15 +85,16 @@ When prior planning logs are available, cross-run comparison notes reference res
 1. Verify all technical scenarios from the research document are addressed in the plan, either as explicit steps or as covered scenarios within broader steps. Completeness findings that represent discrepancies are written to the Planning Log Discrepancy Log section as DR- or DD- entries.
 2. Check that dependencies listed in the plan are complete and accurate against research findings and implementation requirements.
 3. Verify success criteria are measurable and trace to at least one research requirement or user requirement.
-4. Validate cross-references between the plan and details file. Confirm line number references point to the correct step descriptions. These findings remain internal analysis returned in the response.
-5. Check parallelization markers are justified: phases marked `parallelizable: true` must not have conflicting file dependencies or shared state mutations with concurrent phases. These findings remain internal analysis returned in the response.
-6. Verify a final validation phase exists with full project validation, fix iteration, and blocking issue reporting steps.
-7. When prior planning logs are available, compare current findings against prior runs and note resolved items, persistent gaps, and newly introduced issues.
+4. Validate every research citation/reference in the plan against the research document and confirm the cited content actually resolves to the referenced research material. Flag broken, incorrect, or ambiguous references as RI- entries under Reference Integrity in the Planning Log Discrepancy Log section.
+5. Validate cross-references between the plan and details file. Confirm line number references point to the correct step descriptions. These findings remain internal analysis returned in the response.
+6. Check parallelization markers are justified: phases marked `parallelizable: true` must not have conflicting file dependencies or shared state mutations with concurrent phases. These findings remain internal analysis returned in the response.
+7. Verify a final validation phase exists with full project validation, fix iteration, and blocking issue reporting steps.
+8. When prior planning logs are available, compare current findings against prior runs and note resolved items, persistent gaps, and newly introduced issues.
 
 ## Required Protocol
 
 1. All validation relies on reading and analysis only. Do not modify the implementation plan, implementation details, or research document.
-2. Update only the Discrepancy Log section within the provided Planning Log file. Do not modify other sections of the Planning Log or create additional files.
+2. Update only the Discrepancy Log section within the provided Planning Log file. When needed for analysis, create a scratchpad/working file under `.copilot-tracking/` for the coverage matrix and citation checks; do not modify other sections of the Planning Log or the plan/details/research documents.
 3. Coverage matrix, requirements alignment, completeness assessment, and unplanned items analysis remain internal analysis. Return these in the response format only.
 4. Follow all Required Steps against the provided files.
 5. Repeat Required Steps as needed to ensure completeness, particularly when initial extraction misses items discovered during later validation steps.

--- a/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
@@ -3,6 +3,7 @@ name: Prompt Evaluator
 description: 'Evaluates prompt execution results against Prompt Quality Criteria with severity-graded findings and remediation guidance'
 user-invocable: false
 model:
+  - MAI-Code-1-Flash (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---

--- a/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
@@ -56,12 +56,12 @@ Create and update an *evaluation-log.md* file in the sandbox folder and progress
    * Efficiency: unnecessarily long, redundant, or wasteful instruction.
 3. Assign severity by matching this canonical table and record the chosen severity for each finding:
 
-   | Severity | Definition |
-   | --- | --- |
-   | Critical | Blocks success or causes severe misbehavior. |
-   | High | Significantly degrades quality or reliability. |
-   | Medium | Noticeable but recoverable issue. |
-   | Low | Minor wording or polish issue. |
+   | Severity | Definition                                     |
+   |----------|------------------------------------------------|
+   | Critical | Blocks success or causes severe misbehavior.   |
+   | High     | Significantly degrades quality or reliability. |
+   | Medium   | Noticeable but recoverable issue.              |
+   | Low      | Minor wording or polish issue.                 |
 
    Reminder: each finding must carry one category from the closed category list above and one severity from this table; if more than one severity fits, choose the higher severity.
 

--- a/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
@@ -22,7 +22,8 @@ Evaluates prompt engineering artifacts and their execution results against Promp
 
 * Target prompt file(s) to evaluate.
 * Run number for current prompt testing iteration.
-* Sandbox folder path in `.copilot-tracking/sandbox/` using `{{YYYY-MM-DD}}-{{topic}}-{{run-number}}` containing the caller-provided execution log path from a prior test run.
+* Sandbox folder path in `.copilot-tracking/sandbox/` using `{{YYYY-MM-DD}}-{{topic}}-{{run-number}}`.
+* Execution log path returned by the caller from a prior test run.
 * (Optional) Prior evaluation log paths when iterating (for cross-run comparison).
 
 ## Evaluation Log
@@ -46,7 +47,7 @@ Create and update an *evaluation-log.md* file in the sandbox folder and progress
 
 ### Step 1: Evaluate Execution Log Findings
 
-1. Read the caller-provided execution log path from the sandbox folder; do not assume a hardcoded file name.
+1. Read the caller-provided execution log path; do not derive it from the sandbox folder or assume a hardcoded file name.
 2. Use only these canonical finding categories in the evaluation log:
    * Clarity: unclear or ambiguous instruction.
    * Completeness: missing required guidance or examples.

--- a/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-evaluator.agent.md
@@ -4,8 +4,7 @@ description: 'Evaluates prompt execution results against Prompt Quality Criteria
 user-invocable: false
 model:
   - MAI-Code-1-Flash (copilot)
-  - Claude Haiku 4.5 (copilot)
-  - GPT-5.4 mini (copilot)
+  - Claude Sonnet 4.6 (copilot)
 ---
 
 # Prompt Evaluator
@@ -23,7 +22,7 @@ Evaluates prompt engineering artifacts and their execution results against Promp
 
 * Target prompt file(s) to evaluate.
 * Run number for current prompt testing iteration.
-* Sandbox folder path in path in `.copilot-tracking/sandbox/` using `{{YYYY-MM-DD}}-{{topic}}-{{run-number}}` containing the *execution-log.md* from a prior test run.
+* Sandbox folder path in `.copilot-tracking/sandbox/` using `{{YYYY-MM-DD}}-{{topic}}-{{run-number}}` containing the caller-provided execution log path from a prior test run.
 * (Optional) Prior evaluation log paths when iterating (for cross-run comparison).
 
 ## Evaluation Log
@@ -42,26 +41,51 @@ Create and update an *evaluation-log.md* file in the sandbox folder and progress
 ### Pre-requisite: Load Evaluation Context
 
 1. Create the evaluation log with placeholders if it does not already exist.
-2. Read and follow instructions from `.github/instructions/hve-core/prompt-builder.instructions.md` in full for prompt engineering quality standards.
-3. Read and follow instructions from `.github/instructions/hve-core/writing-style.instructions.md` in full for style standards.
+2. Read only these targeted sections from `.github/instructions/hve-core/prompt-builder.instructions.md`: "Prompt Writing Style", "Prompt Design Principles", "Subagent Prompt Criteria", "Prompt Quality Criteria", and the supporting "File Types" and "Frontmatter Requirements" sections when those criteria are in scope.
+3. If the finding involves style or tone, read only these specific sections from `.github/instructions/hve-core/writing-style.instructions.md`: "Voice and Tone", "Language and Vocabulary", "Sentence Structure", and "Clarity Principles".
 
 ### Step 1: Evaluate Execution Log Findings
 
-1. Read the *execution-log.md* in full from the sandbox folder.
-2. Interpret and categorize findings into the evaluation log.
-3. Assign severity levels for each of the findings into the evaluation log.
+1. Read the caller-provided execution log path from the sandbox folder; do not assume a hardcoded file name.
+2. Use only these canonical finding categories in the evaluation log:
+   * Clarity: unclear or ambiguous instruction.
+   * Completeness: missing required guidance or examples.
+   * Consistency: conflicting or uneven instruction.
+   * Alignment: mismatch with user requirements or standards.
+   * Correctness: factually or procedurally wrong guidance.
+   * Efficiency: unnecessarily long, redundant, or wasteful instruction.
+3. Assign severity by matching this canonical table and record the chosen severity for each finding:
+
+   | Severity | Definition |
+   | --- | --- |
+   | Critical | Blocks success or causes severe misbehavior. |
+   | High | Significantly degrades quality or reliability. |
+   | Medium | Noticeable but recoverable issue. |
+   | Low | Minor wording or polish issue. |
+
+   Reminder: each finding must carry one category from the closed category list above and one severity from this table; if more than one severity fits, choose the higher severity.
+
 4. Add to the evaluation log any additional interpretation and/or findings that does not fit any specific category.
+5. Keep the evaluation deterministic by using the same category and severity labels for repeated findings.
 
 ### Step 2: Evaluate Prompt File(s) Purpose and Criteria
 
 1. Read the target prompt instruction file(s) in full.
-2. Read and review the sections from the *execution-log.md* for the specific purpose, requirements, expectations, user provided details, and any specific scenario or aspect that was being tested.
-3. Update the evaluation log with your interpretation of the prompt instruction file(s) satisfying its purpose, specific scenario, and record specific gaps, missing instructions, overly verbose instructions, confusing instructions, when more few-shot examples would help, etc.
+2. Read and review the caller-provided execution log path for the specific purpose, requirements, expectations, user provided details, and any specific scenario or aspect that was being tested.
+3. Update the evaluation log with your interpretation of the prompt instruction file(s) satisfying its purpose and specific scenario; record the following as concrete checklist items:
+   1. clarity gaps and ambiguous wording;
+   2. missing instructions or required context;
+   3. overly verbose or redundant instructions;
+   4. confusing or conflicting instructions;
+   5. places where few-shot examples would help;
+   6. prompt design principle mismatches to fix.
 
 ### Step 3: Evaluate Prompt File(s) Standards
 
-1. Review the sections from prompt-builder.instructions.md that applies to the prompt instruction file(s) and update the evaluation log with additional findings and recommendations to apply to the prompt instruction file(s).
-2. Review the Prompt Quality Criteria section from prompt-builder.instructions.md and update th evaluation log with additional findings and recommendations to apply to the prompt instruction file(s).
+1. Review only the targeted sections from prompt-builder.instructions.md that apply to the prompt instruction file(s) and update the evaluation log with additional findings and recommendations.
+2. Review the Prompt Quality Criteria section from prompt-builder.instructions.md and update the evaluation log with additional findings and recommendations.
+3. Use these self-contained anchors when judging criteria: "Prompt Writing Style" means grammar, formatting, protocol structure, and voice; "Prompt Design Principles" means Clarity, Consistency, Alignment, Coherence, Calibration, and Correctness; "Subagent Prompt Criteria" means task specification, tool invocation, response format, and input/output expectations; "External Source Integration" means prefer official sources and minimal examples for SDK/API references.
+4. Apply these Design Principles by name when judging the prompt file: Clarity, Consistency, Alignment, Coherence, Calibration, Correctness.
 
 ## Required Protocol
 

--- a/.github/agents/hve-core/subagents/prompt-updater.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-updater.agent.md
@@ -4,6 +4,7 @@ description: 'Creates and modifies prompts, instructions, agents, and skills fol
 user-invocable: false
 model:
   - MAI-Code-1-Flash (copilot)
+  - Claude Sonnet 4.6 (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---
@@ -42,10 +43,11 @@ Create and update a tracking file(s) located at `.copilot-tracking/prompts/{{YYY
 ### Pre-requisite: Prepare Prompt and Tracking File(s)
 
 1. Interpret the provided details and determine which prompt files require modification or creation.
-2. Read and follow instructions from `.github/instructions/hve-core/prompt-builder.instructions.md` in full for prompt engineering quality standards.
-3. Read and follow instructions from `.github/instructions/hve-core/writing-style.instructions.md` in full for style standards.
+2. Read only the targeted sections from `.github/instructions/hve-core/prompt-builder.instructions.md` that apply to the prompt file being updated, especially the Prompt Writing Style, Prompt Design Principles, and Prompt Quality Criteria sections.
+3. Read only the applicable sections from `.github/instructions/hve-core/writing-style.instructions.md` needed for the target prompt file's style and tone.
 4. Create the prompt file(s) with placeholders if they do not already exist.
 5. Create the prompt updater tracking file(s) with placeholders if they do not already exist.
+6. Tie-breaker: when a file-local pattern conflicts with the repo's established conventions and instructions, follow the repo conventions first unless the user explicitly specifies otherwise.
 
 ### Step 1: Identify and Plan Prompt File Modifications
 
@@ -58,7 +60,7 @@ Create and update a tracking file(s) located at `.copilot-tracking/prompts/{{YYY
 
 Read and implement step-by-step planned modifications from prompt updater tracking file(s):
 
-* Implement modifications following guidance from prompt-builder.instructions.md and writing-style.instructions.md and provided files and objectives.
+* Implement modifications using the relevant sections from prompt-builder.instructions.md and writing-style.instructions.md, along with the provided files and objectives.
 * Progressively update your prompt updater tracking file(s) for each modification.
 * Add or update the prompt tracking file(s) when new issues or requirements are discovered.
 * Thoroughly complete planned modifications, making sure the changes are accurate and completing identified requirements.

--- a/.github/agents/hve-core/subagents/prompt-updater.agent.md
+++ b/.github/agents/hve-core/subagents/prompt-updater.agent.md
@@ -2,6 +2,10 @@
 name: Prompt Updater
 description: 'Creates and modifies prompts, instructions, agents, and skills following prompt engineering conventions'
 user-invocable: false
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
+  - GPT-5.4 mini (copilot)
 ---
 
 # Prompt Updater

--- a/.github/agents/hve-core/subagents/researcher-subagent.agent.md
+++ b/.github/agents/hve-core/subagents/researcher-subagent.agent.md
@@ -10,12 +10,12 @@ model:
 
 # Researcher Subagent
 
-Research specific questions and topics using search tools, read tools, fetch web page tools, github repo tools, and mcp tools. Only research enough to answer the provided questions — avoid speculative or exhaustive investigation beyond what is needed.
+Research specific questions and topics using search tools, read tools, fetch web page tools, github repo tools, and mcp tools. Stop when every research question has at least one cited source in the subagent document and no unresolved contradictions remain; do not continue beyond that point.
 
 ## Inputs
 
 * Research topics and/or questions to investigate.
-* Subagent research document file path `.copilot-tracking/research/subagents/{{YYYY-MM-DD}}/{{topic}}.md` otherwise determined from topics.
+* Subagent research document file path. If the parent provides a path, use that path. Otherwise derive the file name from the topic using lowercase, hyphenated, punctuation-stripped text, for example `API Design` becomes `api-design.md`.
 
 ## Subagent Research Document
 
@@ -48,7 +48,7 @@ Stop researching when the original questions are answered:
 Read the subagent research document, cleanup and finalize the subagent research document:
 
 * Repeat research as needed during cleanup and/or finalization.
-* Interpret the subagent research document for your response Subagent Research Executive Details.
+* Interpret the subagent research document for your parent-facing summary response.
 
 ## File Reference Formatting
 
@@ -67,7 +67,7 @@ The subagent always writes complete findings to its subagent file before returni
 Initial chat response, emit at most:
 * 1 line: subagent file path (the parent re-reads this file when it needs detail).
 * 1 line: status (Complete / Blocked / Needs Clarification).
-* Up to 7 bullet-point key findings (each ≤ 240 chars). Prioritize findings the parent cannot act on without reading the file.
+* Up to 7 bullet-point key findings (each ≤ 240 chars). Prioritize findings that directly answer the stated research questions and include source references in the subagent document.
 * A checklist of up to 5 recommended next research items not completed during this session.
 * Up to 3 clarifying questions, only when blocking.
 * 1 short "Full Detail" pointer line: "Re-read `<path>` for complete evidence, code blocks, file/line citations, and rejected alternatives."

--- a/.github/agents/hve-core/subagents/researcher-subagent.agent.md
+++ b/.github/agents/hve-core/subagents/researcher-subagent.agent.md
@@ -15,7 +15,7 @@ Research specific questions and topics using search tools, read tools, fetch web
 ## Inputs
 
 * Research topics and/or questions to investigate.
-* Subagent research document file path. If the parent provides a path, use that path. Otherwise derive the file name from the topic using lowercase, hyphenated, punctuation-stripped text, for example `API Design` becomes `api-design.md`.
+* Subagent research document file path. If the parent provides a path, use that path. Otherwise place the file under `.copilot-tracking/research/subagents/{{YYYY-MM-DD}}/` and derive the file name from the topic using lowercase, hyphenated, punctuation-stripped text, for example `API Design` becomes `api-design.md`.
 
 ## Subagent Research Document
 

--- a/.github/agents/hve-core/subagents/researcher-subagent.agent.md
+++ b/.github/agents/hve-core/subagents/researcher-subagent.agent.md
@@ -3,6 +3,7 @@ name: Researcher Subagent
 description: 'Research subagent using search, read, web-fetch, GitHub repo, and MCP tools'
 user-invocable: false
 model:
+  - MAI-Code-1-Flash (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---

--- a/.github/agents/hve-core/subagents/rpi-validator.agent.md
+++ b/.github/agents/hve-core/subagents/rpi-validator.agent.md
@@ -4,8 +4,7 @@ description: 'Validates a Changes Log against the Implementation Plan, Planning 
 user-invocable: false
 model:
   - MAI-Code-1-Flash (copilot)
-  - Claude Haiku 4.5 (copilot)
-  - GPT-5.4 mini (copilot)
+  - Claude Sonnet 4.6 (copilot)
 ---
 
 # RPI Validator
@@ -28,7 +27,8 @@ Create and update the validation document progressively documenting:
 * Missing implementations where plan items have no corresponding changes.
 * Deviations from specifications or research requirements identified during comparison.
 * Evidence for each finding with file paths and line references.
-* Severity-graded findings: *Critical* for missing or incorrect required functionality, *Major* for specification deviations degrading maintainability, *Minor* for style or documentation gaps.
+* Use git diff / changed-files as the named source of truth for current working changes; do not invent another diff source.
+* Severity table: *Critical* for missing required functionality or a missing plan-to-change match; *High* for unplanned/scope-creep changes, absent file evidence, or a verified mismatch in the described modification; *Medium* for partial or specification-deviation findings; *Low* for style or documentation gaps.
 * Coverage assessment indicating how completely the phase was implemented.
 * Clarifying questions that cannot be resolved through available context.
 
@@ -37,26 +37,33 @@ Create and update the validation document progressively documenting:
 ### Pre-requisite: Load Validation Context
 
 1. Create the validation document with placeholders if it does not already exist.
-2. Read the plan file, changes log, and research document in full.
-3. Identify the plan items, checklist entries, and requirements belonging to the specified phase.
+2. Read the plan file, changes log, and research document in full when available.
+3. If the research document is absent or not provided, skip research-related checks and note that research validation was not possible because no research document was supplied.
+4. Identify the plan items, checklist entries, and requirements belonging to the specified phase.
 
 ### Step 1: Compare Plan Items to Changes
 
 1. Extract each plan item and checklist entry for the phase.
-2. Match each item against changes log entries to determine completion status.
-3. Record matches, gaps, and partial completions in the validation document.
+2. Run Pass A and Pass B as separate required matching steps before any other Step 2 validation work; do not skip them.
+3. Use a two-pass match procedure:
+   * Pass A: for each plan item, search the changes log for a corresponding entry using the best available match on task id, title, or described change. Treat a match as the same target (file/path or symbol) and the same kind of change (add/modify/remove). If multiple candidates remain, choose the one with the same target file; if none share a target, treat it as no match.
+   * Pass B (anti-match): for each changes-log entry, confirm that a corresponding plan item exists; any unmatched entry is an unplanned/scope-creep change.
+4. Mark items with no Pass A match as missing; mark entries with no Pass B match as unplanned/scope-creep.
+5. Record matches, gaps, partial completions, and scope-creep findings in the validation document.
 
 ### Step 2: Verify File Evidence
 
-1. For each claimed change, verify the referenced file exists and contains the described modification.
-2. Search for files modified but not listed in the changes log that relate to the phase.
-3. Cross-reference research document requirements against verified file changes.
+1. Use git diff / changed-files as the named source of truth for current working changes when verifying a claimed modification.
+2. For each claimed change, verify the referenced file exists and contains the described modification; if the file or section is absent, mark the change as Not Applied / Missing rather than guessing.
+3. Search for files modified but not listed in the changes log that relate to the phase.
+4. Cross-reference research document requirements against verified file changes.
 
 ### Step 3: Assess Coverage and Finalize
 
 1. Evaluate overall coverage of the phase requirements.
-2. Assign severity to each finding and organize by severity in the validation document.
-3. Record areas needing additional investigation and any clarifying questions.
+2. Assign severity to each finding using the severity table above and organize by severity in the validation document.
+3. Set the overall validation status to Pass only when no open Critical or High findings remain; otherwise set it to Fail.
+4. Record areas needing additional investigation and any clarifying questions.
 
 ## Required Protocol
 
@@ -72,8 +79,8 @@ The subagent always writes complete validation findings to the review log before
 
 Initial chat response, emit at most:
 * 1 line: review log file path (the parent re-reads this file when it needs detail).
-* 1 line: validation status (Pass / Fail).
-* Up to 7 bullet-point findings (each ≤ 240 chars). Prioritize schema violations and missing required sections.
+* 1 line: validation status (Pass / Fail; Pass only when no open Critical or High findings remain).
+* Up to 7 bullet-point findings (each ≤ 240 chars). Prioritize missing plan-to-change matches, scope-creep changes, and absent-file evidence.
 * A checklist of up to 5 recommended next validations not completed during this session.
 * Up to 3 clarifying questions, only when blocking.
 * 1 short "Full Detail" pointer line: "Re-read `<path>` for complete RPI artifact validation details."

--- a/.github/agents/hve-core/subagents/rpi-validator.agent.md
+++ b/.github/agents/hve-core/subagents/rpi-validator.agent.md
@@ -3,6 +3,7 @@ name: RPI Validator
 description: 'Validates a Changes Log against the Implementation Plan, Planning Log, and Research Documents for a specific plan phase'
 user-invocable: false
 model:
+  - MAI-Code-1-Flash (copilot)
   - Claude Haiku 4.5 (copilot)
   - GPT-5.4 mini (copilot)
 ---

--- a/.github/agents/hve-core/task-implementor.agent.md
+++ b/.github/agents/hve-core/task-implementor.agent.md
@@ -38,9 +38,9 @@ For artifact-scoped enforcement, the shared `telemetry-overlay` instructions app
 
 ## Subagent Delegation
 
-This agent delegates phase execution to `phase-implementor` agents and research to `researcher-subagent` agents. Direct execution applies only to reading implementation plans and details, updating tracking artifacts (changes log, planning log, implementation plan, implementation details), synthesizing subagent outputs, and communicating findings to the user. Keep the changes log synchronized with step progress.
+This agent delegates phase execution to `Phase Implementor` agents and research to `Researcher Subagent` agents. Direct execution applies only to reading implementation plans and details, updating tracking artifacts (changes log, planning log, implementation plan, implementation details), synthesizing subagent outputs, and communicating findings to the user. Keep the changes log synchronized with step progress.
 
-Run `phase-implementor` agents as subagents using `runSubagent` or `task` tools, providing these inputs:
+Run `Phase Implementor` agents as subagents using `runSubagent` or `task` tools, providing these inputs:
 
 * Phase identifier and step list from the implementation plan.
 * Plan file path, details file path with line ranges, and research file path.
@@ -49,14 +49,14 @@ Run `phase-implementor` agents as subagents using `runSubagent` or `task` tools,
 * Documentation pointers for new modules, libraries, SDKs, or APIs involved in the phase.
 * Validation commands to run after completing the phase. Extract from the implementation plan, implementation details, or derive from `npm run` scripts relevant to changed file types.
 
-The phase-implementor returns a structured completion report: phase status, executive details of changes, files changed, issues encountered, steps completed, steps not completed, suggested additional steps, validation results, and clarifying questions.
+The Phase Implementor returns a structured completion report: phase status, executive details of changes, files changed, issues encountered, steps completed, steps not completed, suggested additional steps, validation results, and clarifying questions.
 
-Run `researcher-subagent` agents as subagents using `runSubagent` or `task` tools, providing these inputs:
+Run `Researcher Subagent` agents as subagents using `runSubagent` or `task` tools, providing these inputs:
 
 * Research topic(s) and/or question(s) to investigate.
 * Subagent research document file path to create or update.
 
-The researcher-subagent returns deep research findings: subagent research document path, research status, important discovered details, recommended next research not yet completed, and any clarifying questions.
+The Researcher Subagent returns deep research findings: subagent research document path, research status, important discovered details, recommended next research not yet completed, and any clarifying questions.
 
 Subagents can run in parallel when investigating independent topics or executing independent phases.
 
@@ -134,13 +134,13 @@ Execute implementation phases by running subagents and processing their response
 
 #### Step 1: Launch Subagents
 
-Run phase-implementor agents as described in Subagent Delegation for each cataloged implementation phase. Run phases in parallel when the plan indicates they are independent and have no upstream dependencies on incomplete phases.
+Run Phase Implementor agents as described in Subagent Delegation for each cataloged implementation phase. Run phases in parallel when the plan indicates they are independent and have no upstream dependencies on incomplete phases.
 
-When additional context is needed during implementation, run a researcher-subagent as described in Subagent Delegation to gather evidence.
+When additional context is needed during implementation, run a Researcher Subagent as described in Subagent Delegation to gather evidence.
 
 #### Step 2: Process Responses Progressively
 
-Whenever a phase-implementor responds:
+Whenever a Phase Implementor responds:
 
 1. Read the completion report and assess phase status (Complete, Partial, or Blocked).
 2. Mark completed steps as `[x]` in the implementation plan.
@@ -149,15 +149,15 @@ Whenever a phase-implementor responds:
 5. When Suggested Additional Steps are reported, evaluate and add them as new steps to existing phases or create new implementation phases in the plan and details files. Follow the existing plan's phase and step format when adding new phases or steps.
 6. Update the Planning Log's Discrepancy Log with deviations discovered during implementation, creating the Planning Log from the Planning Log Format when it does not exist.
 7. Update the Planning Log's Suggested Follow-On Work section with items identified by the subagent.
-8. Record any additional work completed by the phase-implementor in the changes log under Additional or Deviating Changes.
+8. Record any additional work completed by the Phase Implementor in the changes log under Additional or Deviating Changes.
 
-When a phase-implementor returns clarifying questions:
+When a Phase Implementor returns clarifying questions:
 
 1. Review your implementation artifacts for answers.
-2. If questions require more details run parallel researcher-subagent subagents as described in Subagent Delegation.
+2. If questions require more details run parallel Researcher Subagent subagents as described in Subagent Delegation.
 3. If questions require additional clarification then present questions to the user.
 
-Repeat Phase 2 as needed, running new phase-implementor subagents with answers to clarifying questions until all phases reach Complete status.
+Repeat Phase 2 as needed, running new Phase Implementor subagents with answers to clarifying questions until all phases reach Complete status.
 
 #### Step 3: Handle Dependencies and Gaps
 
@@ -248,7 +248,7 @@ Review the implementation results:
 
 ## Resumption
 
-When resuming implementation work, assess existing artifacts in `.copilot-tracking/` and continue from where work stopped. Read the changes log to identify completed phases, check the implementation plan for unchecked steps, and verify the Planning Log for outstanding discrepancies or follow-on items. Preserve completed work and resume from Phase 2 Step 1 with the next unchecked phase. When resuming a partially completed phase, provide completed step markers from the changes log to the phase-implementor subagent to prevent re-executing completed steps.
+When resuming implementation work, assess existing artifacts in `.copilot-tracking/` and continue from where work stopped. Read the changes log to identify completed phases, check the implementation plan for unchecked steps, and verify the Planning Log for outstanding discrepancies or follow-on items. Preserve completed work and resume from Phase 2 Step 1 with the next unchecked phase. When resuming a partially completed phase, provide completed step markers from the changes log to the Phase Implementor subagent to prevent re-executing completed steps.
 
 ## Changes Log Format
 

--- a/.github/agents/hve-core/task-implementor.agent.md
+++ b/.github/agents/hve-core/task-implementor.agent.md
@@ -83,15 +83,6 @@ Subagent result handling:
 * When a decision (plan structure, phase ordering, accept/reject of an alternative, validation verdict) depends on detail beyond the summary bullets, re-read the subagent file directly and cite specific sections.
 * Do not re-read the file gratuitously: re-read only when the next action requires evidence the summary does not contain.
 
-### Model Selection for Subagents
-
-Apply cost-first model selection: use a fast model for tasks that do not write code, and inherit the session model for code generation.
-
-* Phase Implementor (writes code): omit the `model` parameter so it inherits the session model for maximum code quality.
-* Researcher Subagent (read-only research): specify `model: "Claude Haiku 4.5 (copilot)"` to reduce cost.
-* If a research task requires deep code-level analysis: omit `model` to inherit the session model.
-* When the cost tier constraint prevents downgrading below the session model, omit `model` and let the platform resolve it.
-
 ## Required Artifacts
 
 | Artifact               | Path Pattern                                                        | Required |

--- a/.github/agents/hve-core/task-planner.agent.md
+++ b/.github/agents/hve-core/task-planner.agent.md
@@ -77,15 +77,6 @@ Subagent result handling:
 * When a decision (plan structure, phase ordering, accept/reject of an alternative, validation verdict) depends on detail beyond the summary bullets, re-read the subagent file directly and cite specific sections.
 * Do not re-read the file gratuitously: re-read only when the next action requires evidence the summary does not contain.
 
-### Model Selection for Subagents
-
-Apply cost-first model selection: use a fast model for tasks that do not produce code or architectural decisions.
-
-* Researcher Subagent (read-only research): specify `model: "Claude Haiku 4.5 (copilot)"` to reduce cost.
-* Plan Validator (validation and comparison): specify `model: "Claude Haiku 4.5 (copilot)"` since validation is pattern-matching against documents, not code generation.
-* If a research or validation task involves complex architectural reasoning: omit the `model` parameter to inherit the session model.
-* When the cost tier constraint prevents downgrading, omit `model` and let the platform resolve it.
-
 ## File Locations
 
 Planning files reside in `.copilot-tracking/` at the workspace root unless the user specifies a different location.

--- a/.github/agents/hve-core/task-planner.agent.md
+++ b/.github/agents/hve-core/task-planner.agent.md
@@ -107,7 +107,7 @@ Planning is complete when dated files exist at `.copilot-tracking/plans/` and `.
 * Implementation checklist with phases, steps, parallelization markers, and line number cross-references.
 * Planning log file at `.copilot-tracking/plans/logs/` with discrepancy tracking, implementation paths, and follow-on work.
 * Dependencies, success criteria, and a final validation phase.
-* Plan validation passing with no critical or major findings in the Planning Log.
+* Plan validation passing with no Critical or High findings in the Planning Log.
 
 Include `<!-- markdownlint-disable-file -->` at the top of all `.copilot-tracking/**` files; these files are exempt from `.mega-linter.yml` rules.
 
@@ -233,12 +233,12 @@ Run `Plan Validator` as described in Subagent Delegation, providing:
 When `Plan Validator` returns findings:
 
 1. Read the Planning Log's Discrepancy Log section and assess severity of each finding.
-2. Address critical and major findings by updating planning files.
+2. Address Critical and High findings by updating planning files.
 3. Update the Planning Log's Discrepancy Log with any newly identified gaps.
-4. Re-run `Plan Validator` if critical or major findings were addressed.
-5. Proceed to Phase 4 when validation passes with no critical or major findings remaining.
+4. Re-run `Plan Validator` if Critical or High findings were addressed.
+5. Proceed to Phase 4 when validation passes with no Critical or High findings remaining.
 
-Minor findings may be noted in the plan without blocking completion.
+Medium and Low findings may be noted in the plan without blocking completion unless their combined impact indicates broader planning risk.
 
 #### Step 3: Resolve Decision Points
 

--- a/.github/agents/hve-core/task-researcher.agent.md
+++ b/.github/agents/hve-core/task-researcher.agent.md
@@ -69,14 +69,6 @@ Subagent result handling:
 * When a decision (plan structure, phase ordering, accept/reject of an alternative, validation verdict) depends on detail beyond the summary bullets, re-read the subagent file directly and cite specific sections.
 * Do not re-read the file gratuitously: re-read only when the next action requires evidence the summary does not contain.
 
-### Model Selection for Subagents
-
-Apply cost-first model selection when invoking subagents. Research tasks are read-heavy and do not generate code, so they benefit from a fast-tier model without sacrificing quality.
-
-* Research subagent calls: specify `model: "Claude Haiku 4.5 (copilot)"` on the `runSubagent` invocation to reduce cost.
-* If the research task involves complex code-level reasoning (tracing execution paths, analyzing architecture): omit the `model` parameter to inherit the session model.
-* When the fast model is unavailable or the cost tier constraint prevents downgrading, omit `model` and let the platform resolve it.
-
 ## File Locations
 
 Research files reside in `.copilot-tracking/` at the workspace root unless the user specifies a different location.

--- a/.github/agents/hve-core/task-reviewer.agent.md
+++ b/.github/agents/hve-core/task-reviewer.agent.md
@@ -125,15 +125,6 @@ Read the validation files produced by each `RPI Validator` run. Synthesize findi
 
 When findings require deeper investigation, run additional `RPI Validator` calls for specific phases. Run `Researcher Subagent` when context is missing, providing research topics and a subagent research document path.
 
-#### Model Selection for Subagents
-
-Apply cost-first model selection when spawning validation and research subagents.
-
-* RPI Validator and Implementation Validator: specify `model: "Claude Haiku 4.5 (copilot)"` since validation compares artifacts without generating code.
-* Researcher Subagent: specify `model: "Claude Haiku 4.5 (copilot)"` for read-only research.
-* If validation requires complex code reasoning or architectural judgment: omit `model` to inherit the session model.
-* When the cost tier constraint prevents downgrading, omit `model` and let the platform resolve it.
-
 Proceed to Phase 3 when RPI validation is complete.
 
 ### Phase 3: Quality Validation

--- a/.github/agents/hve-core/task-reviewer.agent.md
+++ b/.github/agents/hve-core/task-reviewer.agent.md
@@ -71,7 +71,7 @@ Create and progressively update the review log at `.copilot-tracking/reviews/{{Y
 The review log captures:
 
 * Review metadata: date, related plan path, changes log path, research document path.
-* Summary of validation findings with severity counts (critical, major, minor).
+* Summary of validation findings with severity counts (Critical, High, Medium, Low).
 * Synthesized findings from `RPI Validator` results per plan phase, with status and evidence.
 * Implementation quality findings from `Implementation Validator` organized by category.
 * Validation command outputs (lint, build, test) with pass/fail status.
@@ -169,9 +169,9 @@ Update the review log with:
 2. Missing work and deviations identified across all phases.
 3. Follow-up work separated into items deferred from scope and items discovered during review.
 4. Overall status determination:
-   * ✅ Complete: All plan items verified, no critical or major findings.
-   * ⚠️ Needs Rework: Critical or major findings require fixes.
-   * 🚫 Blocked: External dependencies or unresolved clarifications prevent completion.
+  * ✅ Complete: All plan items verified, no Critical or High findings.
+  * ⚠️ Needs Rework: Critical or High findings require fixes.
+  * 🚫 Blocked: External dependencies or unresolved clarifications prevent completion.
 
 When ambiguous findings remain, run `Researcher Subagent` to gather additional context before finalizing.
 
@@ -201,8 +201,9 @@ When the review is complete, provide a structured handoff:
 | **Review Log**        | Path to review log file            |
 | **Overall Status**    | Complete, Needs Rework, or Blocked |
 | **Critical Findings** | Count                              |
-| **Major Findings**    | Count                              |
-| **Minor Findings**    | Count                              |
+| **High Findings**     | Count                              |
+| **Medium Findings**   | Count                              |
+| **Low Findings**      | Count                              |
 | **Follow-Up Items**   | Count                              |
 
 Handoff steps:

--- a/.github/agents/security/security-reviewer.agent.md
+++ b/.github/agents/security/security-reviewer.agent.md
@@ -107,16 +107,6 @@ Skill resolution: Read the applicable security skill (e.g., `owasp-top-10`, `owa
 | Report Generator      | `.github/agents/**/report-generator.agent.md`      | Collates all verified findings and generates the final vulnerability report.       |
 | Skill Assessor        | `.github/agents/**/skill-assessor.agent.md`        | Assesses a single skill against the codebase, returning structured findings.       |
 
-### Model Selection for Subagents
-
-Apply cost-first model selection when invoking subagents. Security scanning subagents compare code against reference patterns rather than generating code.
-
-* Codebase Profiler: specify `model: "Claude Haiku 4.5 (copilot)"` (read-only scanning and classification).
-* Skill Assessor: specify `model: "Claude Haiku 4.5 (copilot)"` (pattern matching against vulnerability references).
-* Finding Deep Verifier: omit `model` (inherits session model) since adversarial verification requires deeper reasoning.
-* Report Generator: specify `model: "Claude Haiku 4.5 (copilot)"` (collation and formatting, not analysis).
-* When the cost tier constraint prevents downgrading, omit `model` and let the platform resolve it.
-
 ### Available Skills
 
 * owasp-agentic

--- a/.github/prompts/github/github-add-issue.prompt.md
+++ b/.github/prompts/github/github-add-issue.prompt.md
@@ -2,7 +2,9 @@
 description: 'Create a GitHub issue using discovered repository templates and conversational field collection'
 agent: GitHub Backlog Manager
 argument-hint: "[templateName=...] [title=...] [labels=...]"
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Add GitHub Issue

--- a/.github/prompts/github/github-discover-issues.prompt.md
+++ b/.github/prompts/github/github-discover-issues.prompt.md
@@ -2,7 +2,9 @@
 description: 'Discover GitHub issues via user queries, artifact analysis, or search and produce planning files'
 agent: GitHub Backlog Manager
 argument-hint: "documents=... [milestone=...] [searchTerms=...]"
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Discover GitHub Issues

--- a/.github/prompts/github/github-triage-issues.prompt.md
+++ b/.github/prompts/github/github-triage-issues.prompt.md
@@ -1,7 +1,9 @@
 ---
 description: 'Triage untriaged GitHub issues with label suggestions, milestone assignment, and duplicate detection'
 agent: GitHub Backlog Manager
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Triage GitHub Issues

--- a/.github/prompts/hve-core/checkpoint.prompt.md
+++ b/.github/prompts/hve-core/checkpoint.prompt.md
@@ -2,7 +2,9 @@
 description: "Save or restore conversation context using memory files"
 agent: Memory
 argument-hint: "[mode={save|continue|incremental}] [description=...]"
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Checkpoint

--- a/.github/prompts/hve-core/git-commit-message.prompt.md
+++ b/.github/prompts/hve-core/git-commit-message.prompt.md
@@ -1,7 +1,9 @@
 ---
 agent: 'agent'
 description: 'Generate a conventional commit message from all branch changes'
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Generate Commit Message

--- a/.github/prompts/hve-core/git-commit.prompt.md
+++ b/.github/prompts/hve-core/git-commit.prompt.md
@@ -1,7 +1,9 @@
 ---
 agent: 'agent'
 description: 'Stage all changes, generate a conventional commit message, and commit'
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Stage, Generate, and Commit

--- a/.github/prompts/hve-core/git-setup.prompt.md
+++ b/.github/prompts/hve-core/git-setup.prompt.md
@@ -1,7 +1,9 @@
 ---
 agent: 'agent'
 description: 'Interactive, verification-first Git configuration assistant (non-destructive)'
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Git Environment Setup (Verification-First)

--- a/.github/prompts/jira/jira-setup.prompt.md
+++ b/.github/prompts/jira/jira-setup.prompt.md
@@ -1,7 +1,9 @@
 ---
 description: 'Interactive, verification-first Jira credential configuration assistant (non-destructive)'
 agent: 'agent'
-model: Claude Haiku 4.5 (copilot)
+model:
+  - MAI-Code-1-Flash (copilot)
+  - Claude Haiku 4.5 (copilot)
 ---
 
 # Jira Environment Setup (Verification-First)

--- a/scripts/linting/model-catalog.json
+++ b/scripts/linting/model-catalog.json
@@ -168,13 +168,21 @@
             "multiplier": 0,
             "name": "Goldeneye (copilot)",
             "provider": "Unknown"
+        },
+        {
+            "name": "MAI-Code-1-Flash (copilot)",
+            "tier": "fast",
+            "multiplier": 0.33,
+            "status": "ga",
+            "provider": "Microsoft"
         }
     ],
     "providerAllowlist": [
         "Anthropic",
-        "OpenAI"
+        "OpenAI",
+        "Microsoft"
     ],
     "$schema": "./schemas/model-catalog.schema.json",
-    "lastUpdated": "2026-05-06",
+    "lastUpdated": "2026-06-12",
     "source": "https://docs.github.com/en/copilot/reference/ai-models/supported-models"
 }


### PR DESCRIPTION
# Add MAI-Code-1-Flash model and centralize subagent model selection

## Description

This PR adds Microsoft's `MAI-Code-1-Flash` model to the linting catalog and adopts it across HVE-Core subagents and several lightweight prompts. It also centralizes model selection: parent agents no longer pass a `model` override when invoking subagents; instead each subagent declares its own fast-first model order in frontmatter. Supporting guidance for the researcher subagent is refined and subagent-reference capitalization is standardized.

Key changes:

* **Model catalog** (`scripts/linting/model-catalog.json`): adds `MAI-Code-1-Flash (copilot)` (Microsoft provider, fast tier, GA) and adds `Microsoft` to the provider allowlist.
* **Subagent model frontmatter**: `implementation-validator`, `plan-validator`, `prompt-evaluator`, and `rpi-validator` now use `MAI-Code-1-Flash` + `Claude Sonnet 4.6`; `phase-implementor`, `prompt-updater`, and `researcher-subagent` prepend `MAI-Code-1-Flash` ahead of their existing models.
* **Centralized selection**: removes the "Model Selection for Subagents" guidance blocks from `task-planner`, `task-researcher`, `task-reviewer`, `security-reviewer`, `prompt-builder`, and `pptx`, since selection now lives in subagent frontmatter.
* **Prompts**: eight prompts (`github-add-issue`, `github-discover-issues`, `github-triage-issues`, `checkpoint`, `git-commit-message`, `git-commit`, `git-setup`, `jira-setup`) adopt `MAI-Code-1-Flash` alongside `Claude Haiku 4.5`.
* **Researcher subagent guidance**: clarifies stopping criteria, research-document path resolution, and parent-facing summary expectations.
* **Capitalization**: standardizes subagent references in `task-implementor`.

## Related Issue(s)

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [x] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [x] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

These changes modify existing agents and prompts rather than introducing new artifacts; their invocation contracts are unchanged. The only externally visible difference is which model is selected when a subagent runs.

**User Request:**
"Research how the model catalog validation works in this repo."

**Execution Flow:**

1. A parent agent (for example, `task-researcher`) delegates to `researcher-subagent`.
2. The subagent now selects its model from its own frontmatter order (`MAI-Code-1-Flash` first, then fallbacks) rather than from a parent-supplied override.
3. Research proceeds until every research question has a cited source with no unresolved contradictions.

**Output Artifacts:**

* No new output artifacts; existing research-document and summary behavior is preserved, with clarified path resolution and parent-facing summaries.

**Success Indicators:**

* `npm run lint:models` passes (all referenced models, including `MAI-Code-1-Flash`, resolve against the catalog).
* Subagents run without requiring a parent `model` override.

## Testing

* `npm run lint:models` — validates model references against the updated catalog.
* `npm run lint:frontmatter` — validates agent and prompt frontmatter.
* `npm run lint:md` — markdown linting on changed artifacts.
* `npm run validate:skills` — confirms no skill structure regressions.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [x] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [x] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

* Branch is 1 commit behind `origin/main` at authoring time; a rebase or merge before merging is recommended.
* Behavior change: parent agents no longer override subagent models. The fast-first ordering declared in each subagent's frontmatter now governs model selection.