### PR TITLE
docs(docs): refresh workflow, tool-checksums, and environment documentation

### DIFF
--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -67,45 +67,45 @@ flowchart TD
 | `msdate-freshness-check.yml`         | Schedule, manual        | ms.date freshness validation across documentation                 |
 | `label-sync.yml`                     | Push to main, manual    | Repository label synchronization                                  |
 | `workflow-permissions-scan.yml`      | Schedule, manual        | GitHub Actions permissions audit                                  |
-| `weekly-gh-code-scanning.yml`        | Monday 3 AM UTC, manual | Weekly GitHub code scanning alert retrieval and issue creation     |
+| `weekly-gh-code-scanning.yml`        | Monday 3 AM UTC, manual | Weekly GitHub code scanning alert retrieval and issue creation    |
 
 ### Reusable Workflows
 
 Individual validation workflows called by orchestration workflows:
 
-| Workflow                              | Purpose                          | npm Script                          |
-|---------------------------------------|----------------------------------|-------------------------------------|
-| `markdown-lint.yml`                   | Markdownlint validation          | `npm run lint:md`                   |
-| `spell-check.yml`                     | cspell dictionary check          | `npm run spell-check`               |
-| `frontmatter-validation.yml`          | AI artifact frontmatter schemas  | `npm run lint:frontmatter`          |
-| `markdown-link-check.yml`             | Broken link detection            | `npm run lint:md-links`             |
-| `link-lang-check.yml`                 | Link language validation         | `npm run lint:links`                |
-| `yaml-lint.yml`                       | YAML syntax validation           | `npm run lint:yaml`                 |
-| `ps-script-analyzer.yml`              | PowerShell static analysis       | `npm run lint:ps`                   |
-| `table-format.yml`                    | Markdown table formatting        | `npm run format:tables`             |
-| `pester-tests.yml`                    | PowerShell unit tests            | `npm run test:ps`                   |
-| `skill-validation.yml`                | Skill structure validation       | `npm run validate:skills`           |
-| `dependency-pinning-scan.yml`         | Dependency pinning validation    | N/A (PowerShell direct)             |
-| `sha-staleness-check.yml`             | SHA reference freshness*         | N/A (PowerShell direct)             |
-| `codeql-analysis.yml`                 | CodeQL security scanning*        | N/A (GitHub native)                 |
-| `dependency-review.yml`               | Dependency vulnerability review* | N/A (GitHub native)                 |
-| `gh-code-scanning.yml`                | GitHub code scanning alert retrieval | N/A (PowerShell direct)        |
-| `create-gh-code-scanning-issues.yml` | Create GitHub code scanning issues from alerts | N/A (bash + gh CLI direct) |
-| `extension-package.yml`               | VS Code extension packaging      | `npm run extension:package`         |
-| `copyright-headers.yml`               | Copyright header validation      | `npm run validate:copyright`        |
-| `gitleaks-scan.yml`                   | Secret detection scanning        | N/A (gitleaks direct)               |
-| `plugin-package.yml`                  | Plugin collection packaging      | N/A                                 |
-| `plugin-validation.yml`               | Plugin and collection metadata   | `npm run lint:collections-metadata` |
-| `extension-marketplace-publish.yml`   | Extension marketplace publishing | N/A                                 |
-| `python-lint.yml`                     | Python linting (ruff)            | `npm run lint:py`                   |
-| `pytest-tests.yml`                    | Python unit tests                | `npm run test:py`                   |
-| `pip-audit.yml`                       | Python dependency auditing       | N/A (pip-audit direct)              |
-| `fuzz-tests.yml`                      | Python fuzz testing              | N/A (pytest direct)                 |
-| `docusaurus-tests.yml`                | Docusaurus test suite            | N/A (npm test)                      |
-| `model-validation.yml`                | Model reference validation       | `npm run lint:models`               |
-| `ai-artifact-validation.yml`          | AI artifact structure validation | `npm run lint:ai-artifacts`         |
-| `devcontainer-lockfile-check.yml`     | Devcontainer lockfile integrity  | `npm run validate:devcontainer-lockfile` |
-| `action-version-consistency-scan.yml` | Action version consistency       | `npm run lint:version-consistency`  |
+| Workflow                              | Purpose                                        | npm Script                               |
+|---------------------------------------|------------------------------------------------|------------------------------------------|
+| `markdown-lint.yml`                   | Markdownlint validation                        | `npm run lint:md`                        |
+| `spell-check.yml`                     | cspell dictionary check                        | `npm run spell-check`                    |
+| `frontmatter-validation.yml`          | AI artifact frontmatter schemas                | `npm run lint:frontmatter`               |
+| `markdown-link-check.yml`             | Broken link detection                          | `npm run lint:md-links`                  |
+| `link-lang-check.yml`                 | Link language validation                       | `npm run lint:links`                     |
+| `yaml-lint.yml`                       | YAML syntax validation                         | `npm run lint:yaml`                      |
+| `ps-script-analyzer.yml`              | PowerShell static analysis                     | `npm run lint:ps`                        |
+| `table-format.yml`                    | Markdown table formatting                      | `npm run format:tables`                  |
+| `pester-tests.yml`                    | PowerShell unit tests                          | `npm run test:ps`                        |
+| `skill-validation.yml`                | Skill structure validation                     | `npm run validate:skills`                |
+| `dependency-pinning-scan.yml`         | Dependency pinning validation                  | N/A (PowerShell direct)                  |
+| `sha-staleness-check.yml`             | SHA reference freshness*                       | N/A (PowerShell direct)                  |
+| `codeql-analysis.yml`                 | CodeQL security scanning*                      | N/A (GitHub native)                      |
+| `dependency-review.yml`               | Dependency vulnerability review*               | N/A (GitHub native)                      |
+| `gh-code-scanning.yml`                | GitHub code scanning alert retrieval           | N/A (PowerShell direct)                  |
+| `create-gh-code-scanning-issues.yml`  | Create GitHub code scanning issues from alerts | N/A (bash + gh CLI direct)               |
+| `extension-package.yml`               | VS Code extension packaging                    | `npm run extension:package`              |
+| `copyright-headers.yml`               | Copyright header validation                    | `npm run validate:copyright`             |
+| `gitleaks-scan.yml`                   | Secret detection scanning                      | N/A (gitleaks direct)                    |
+| `plugin-package.yml`                  | Plugin collection packaging                    | N/A                                      |
+| `plugin-validation.yml`               | Plugin and collection metadata                 | `npm run lint:collections-metadata`      |
+| `extension-marketplace-publish.yml`   | Extension marketplace publishing               | N/A                                      |
+| `python-lint.yml`                     | Python linting (ruff)                          | `npm run lint:py`                        |
+| `pytest-tests.yml`                    | Python unit tests                              | `npm run test:py`                        |
+| `pip-audit.yml`                       | Python dependency auditing                     | N/A (pip-audit direct)                   |
+| `fuzz-tests.yml`                      | Python fuzz testing                            | N/A (pytest direct)                      |
+| `docusaurus-tests.yml`                | Docusaurus test suite                          | N/A (npm test)                           |
+| `model-validation.yml`                | Model reference validation                     | `npm run lint:models`                    |
+| `ai-artifact-validation.yml`          | AI artifact structure validation               | `npm run lint:ai-artifacts`              |
+| `devcontainer-lockfile-check.yml`     | Devcontainer lockfile integrity                | `npm run validate:devcontainer-lockfile` |
+| `action-version-consistency-scan.yml` | Action version consistency                     | `npm run lint:version-consistency`       |
 
 Workflows marked with `*` are dual-purpose: they accept `workflow_call` for reuse by orchestration workflows and also run independently via their own triggers.
 
@@ -241,14 +241,14 @@ The `weekly-security-maintenance.yml` workflow runs every Sunday at 2AM UTC, pro
 
 ### Security Validation Tools
 
-| Tool               | Script                       | Checks                                        |
-|--------------------|------------------------------|-----------------------------------------------|
-| Dependency Pinning | `Test-DependencyPinning.ps1` | Actions use SHA refs; npm uses exact versions |
-| SHA Staleness      | `Test-SHAStaleness.ps1`      | SHAs reference recent commits                 |
+| Tool               | Script                            | Checks                                                                        |
+|--------------------|-----------------------------------|-------------------------------------------------------------------------------|
+| Dependency Pinning | `Test-DependencyPinning.ps1`      | Actions use SHA refs; npm uses exact versions                                 |
+| SHA Staleness      | `Test-SHAStaleness.ps1`           | SHAs reference recent commits                                                 |
 | audit-ci           | `audit-ci --config audit-ci.json` | Known vulnerabilities in dependencies, using the allowlist in `audit-ci.json` |
-| CodeQL             | GitHub native                | Code patterns indicating security issues      |
-| Gitleaks           | `gitleaks`                   | Secret detection in repository history        |
-| Dependency Review  | GitHub native                | Dependency vulnerability analysis             |
+| CodeQL             | GitHub native                     | Code patterns indicating security issues                                      |
+| Gitleaks           | `gitleaks`                        | Secret detection in repository history                                        |
+| Dependency Review  | GitHub native                     | Dependency vulnerability analysis                                             |
 
 ## Extension Publishing
 
@@ -313,51 +313,51 @@ Maturity filtering rules:
 
 Workflows invoke validation through npm scripts defined in `package.json`:
 
-| npm Script                     | Command                                                                | Used By                       |
-|--------------------------------|------------------------------------------------------------------------|-------------------------------|
-| `lint:md`                      | `markdownlint-cli2`                                                    | markdown-lint.yml             |
-| `lint:md:fix`                  | `markdownlint-cli2 --fix`                                              | Local                         |
-| `spell-check`                  | `cspell`                                                               | spell-check.yml               |
-| `spell-check:fix`              | `cspell --show-suggestions`                                            | Local                         |
-| `lint:frontmatter`             | `Validate-MarkdownFrontmatter.ps1`                                     | frontmatter-validation.yml    |
-| `lint:md-links`                | `Markdown-Link-Check.ps1`                                              | markdown-link-check.yml       |
-| `lint:links`                   | `Invoke-LinkLanguageCheck.ps1`                                         | link-lang-check.yml           |
-| `lint:yaml`                    | `Invoke-YamlLint.ps1`                                                  | yaml-lint.yml                 |
-| `lint:ps`                      | `Invoke-PSScriptAnalyzer.ps1`                                          | ps-script-analyzer.yml        |
-| `lint:collections-metadata`    | `Validate-Collections.ps1`                                             | plugin-validation.yml         |
-| `lint:marketplace`             | `Validate-Marketplace.ps1`                                             | plugin-validation.yml         |
-| `lint:version-consistency`     | `Test-ActionVersionConsistency.ps1`                                    | Local                         |
-| `lint:all`                     | Chains all linters (incl. `eval:lint:*`)                               | Local                         |
-| `format:tables`                | `markdown-table-formatter`                                             | table-format.yml              |
-| `test:ps`                      | `Invoke-PesterTests.ps1`                                               | pester-tests.yml              |
-| `validate:skills`              | `Validate-SkillStructure.ps1`                                          | skill-validation.yml          |
-| `validate:copyright`           | `Test-CopyrightHeaders.ps1`                                            | copyright-headers.yml         |
-| `extension:prepare`            | `pwsh ./scripts/extension/Prepare-Extension.ps1 && npm run extension:postprocess` | extension-package.yml         |
+| npm Script                     | Command                                                                                               | Used By                       |
+|--------------------------------|-------------------------------------------------------------------------------------------------------|-------------------------------|
+| `lint:md`                      | `markdownlint-cli2`                                                                                   | markdown-lint.yml             |
+| `lint:md:fix`                  | `markdownlint-cli2 --fix`                                                                             | Local                         |
+| `spell-check`                  | `cspell`                                                                                              | spell-check.yml               |
+| `spell-check:fix`              | `cspell --show-suggestions`                                                                           | Local                         |
+| `lint:frontmatter`             | `Validate-MarkdownFrontmatter.ps1`                                                                    | frontmatter-validation.yml    |
+| `lint:md-links`                | `Markdown-Link-Check.ps1`                                                                             | markdown-link-check.yml       |
+| `lint:links`                   | `Invoke-LinkLanguageCheck.ps1`                                                                        | link-lang-check.yml           |
+| `lint:yaml`                    | `Invoke-YamlLint.ps1`                                                                                 | yaml-lint.yml                 |
+| `lint:ps`                      | `Invoke-PSScriptAnalyzer.ps1`                                                                         | ps-script-analyzer.yml        |
+| `lint:collections-metadata`    | `Validate-Collections.ps1`                                                                            | plugin-validation.yml         |
+| `lint:marketplace`             | `Validate-Marketplace.ps1`                                                                            | plugin-validation.yml         |
+| `lint:version-consistency`     | `Test-ActionVersionConsistency.ps1`                                                                   | Local                         |
+| `lint:all`                     | Chains all linters (incl. `eval:lint:*`)                                                              | Local                         |
+| `format:tables`                | `markdown-table-formatter`                                                                            | table-format.yml              |
+| `test:ps`                      | `Invoke-PesterTests.ps1`                                                                              | pester-tests.yml              |
+| `validate:skills`              | `Validate-SkillStructure.ps1`                                                                         | skill-validation.yml          |
+| `validate:copyright`           | `Test-CopyrightHeaders.ps1`                                                                           | copyright-headers.yml         |
+| `extension:prepare`            | `pwsh ./scripts/extension/Prepare-Extension.ps1 && npm run extension:postprocess`                     | extension-package.yml         |
 | `extension:prepare:prerelease` | `pwsh ./scripts/extension/Prepare-Extension.ps1 -Channel PreRelease && npm run extension:postprocess` | extension-package.yml         |
-| `extension:postprocess`        | `markdownlint-cli2 + markdown-table-formatter (extension/**/*.md, collections/*.md)` | extension-package.yml         |
-| `extension:package`            | `Package-Extension.ps1`                                                | extension-package.yml         |
-| `package:extension`            | Alias for `extension:package`                                          | extension-package.yml         |
-| `extension:package:prerelease` | `Package-Extension.ps1 -PreRelease`                                    | extension-package.yml         |
-| `plugin:generate`              | `Generate-Plugins.ps1` + post-process                                  | plugin-package.yml            |
-| `plugin:validate`              | Alias for `lint:collections-metadata`                                  | plugin-validation.yml         |
-| `lint:py`                      | `ruff check`                                                           | python-lint.yml               |
-| `lint:models`                  | `Validate-ModelReferences.ps1`                                         | model-validation.yml          |
-| `lint:ai-artifacts`            | `Validate-PlannerArtifacts.ps1 -FailOnMissing`                        | ai-artifact-validation.yml    |
-| `lint:permissions`             | `Test-WorkflowPermissions.ps1`                                         | workflow-permissions-scan.yml |
-| `lint:ps-module-pins`          | `Test-PSModulePins.ps1`                                                | Local                         |
-| `lint:dependency-pinning`      | `Test-DependencyPinning.ps1`                                           | dependency-pinning-scan.yml   |
-| `audit:npm`                    | `audit-ci --config audit-ci.json`                                      | pr-validation.yml             |
-| `test:py`                      | `uv run pytest`                                                        | pytest-tests.yml              |
-| `eval:lint:vally`              | `Build-AgentBehaviorSpec.ps1 -WhatIf && vally lint --eval-spec evals/` | Local                         |
-| `eval:lint:schema`             | `Test-EvalSpec.ps1`                                                    | Local                         |
-| `eval:lint:text`               | `Test-EvalSpecText.ps1`                                                | Local                         |
-| `eval:lint:safety`             | `Test-VallyTestSafety.ps1`                                             | Local                         |
-| `eval:lint:skills`             | `vally lint .github/skills/`                                           | Local                         |
-| `eval:run`                     | Runs all eval suites                                                   | Local                         |
-| `eval:run:skills`              | `vally eval --suite skill-quality`                                     | Local                         |
-| `eval:run:agents`              | `vally eval --suite agent-behavior`                                    | Local                         |
-| `eval:run:scripts`             | `vally eval --suite script-validation`                                 | Local                         |
-| `eval:compare`                 | `vally compare`                                                        | Local                         |
+| `extension:postprocess`        | `markdownlint-cli2 + markdown-table-formatter (extension/**/*.md, collections/*.md)`                  | extension-package.yml         |
+| `extension:package`            | `Package-Extension.ps1`                                                                               | extension-package.yml         |
+| `package:extension`            | Alias for `extension:package`                                                                         | extension-package.yml         |
+| `extension:package:prerelease` | `Package-Extension.ps1 -PreRelease`                                                                   | extension-package.yml         |
+| `plugin:generate`              | `Generate-Plugins.ps1` + post-process                                                                 | plugin-package.yml            |
+| `plugin:validate`              | Alias for `lint:collections-metadata`                                                                 | plugin-validation.yml         |
+| `lint:py`                      | `ruff check`                                                                                          | python-lint.yml               |
+| `lint:models`                  | `Validate-ModelReferences.ps1`                                                                        | model-validation.yml          |
+| `lint:ai-artifacts`            | `Validate-PlannerArtifacts.ps1 -FailOnMissing`                                                        | ai-artifact-validation.yml    |
+| `lint:permissions`             | `Test-WorkflowPermissions.ps1`                                                                        | workflow-permissions-scan.yml |
+| `lint:ps-module-pins`          | `Test-PSModulePins.ps1`                                                                               | Local                         |
+| `lint:dependency-pinning`      | `Test-DependencyPinning.ps1`                                                                          | dependency-pinning-scan.yml   |
+| `audit:npm`                    | `audit-ci --config audit-ci.json`                                                                     | pr-validation.yml             |
+| `test:py`                      | `uv run pytest`                                                                                       | pytest-tests.yml              |
+| `eval:lint:vally`              | `Build-AgentBehaviorSpec.ps1 -WhatIf && vally lint --eval-spec evals/`                                | Local                         |
+| `eval:lint:schema`             | `Test-EvalSpec.ps1`                                                                                   | Local                         |
+| `eval:lint:text`               | `Test-EvalSpecText.ps1`                                                                               | Local                         |
+| `eval:lint:safety`             | `Test-VallyTestSafety.ps1`                                                                            | Local                         |
+| `eval:lint:skills`             | `vally lint .github/skills/`                                                                          | Local                         |
+| `eval:run`                     | Runs all eval suites                                                                                  | Local                         |
+| `eval:run:skills`              | `vally eval --suite skill-quality`                                                                    | Local                         |
+| `eval:run:agents`              | `vally eval --suite agent-behavior`                                                                   | Local                         |
+| `eval:run:scripts`             | `vally eval --suite script-validation`                                                                | Local                         |
+| `eval:compare`                 | `vally compare`                                                                                       | Local                         |
 
 ## Related Documentation
 

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -3,7 +3,7 @@ title: Build Workflows
 description: GitHub Actions CI/CD pipeline architecture for validation, security, and release automation
 sidebar_position: 3
 author: WilliamBerryiii
-ms.date: 2026-06-25
+ms.date: 2026-06-26
 ms.topic: overview
 ---
 
@@ -67,6 +67,7 @@ flowchart TD
 | `msdate-freshness-check.yml`         | Schedule, manual        | ms.date freshness validation across documentation                 |
 | `label-sync.yml`                     | Push to main, manual    | Repository label synchronization                                  |
 | `workflow-permissions-scan.yml`      | Schedule, manual        | GitHub Actions permissions audit                                  |
+| `weekly-gh-code-scanning.yml`        | Monday 3 AM UTC, manual | Weekly GitHub code scanning alert retrieval and issue creation     |
 
 ### Reusable Workflows
 
@@ -88,6 +89,8 @@ Individual validation workflows called by orchestration workflows:
 | `sha-staleness-check.yml`             | SHA reference freshness*         | N/A (PowerShell direct)             |
 | `codeql-analysis.yml`                 | CodeQL security scanning*        | N/A (GitHub native)                 |
 | `dependency-review.yml`               | Dependency vulnerability review* | N/A (GitHub native)                 |
+| `gh-code-scanning.yml`                | GitHub code scanning alert retrieval | N/A (PowerShell direct)        |
+| `create-gh-code-scanning-issues.yml` | Create GitHub code scanning issues from alerts | N/A (bash + gh CLI direct) |
 | `extension-package.yml`               | VS Code extension packaging      | `npm run extension:package`         |
 | `copyright-headers.yml`               | Copyright header validation      | `npm run validate:copyright`        |
 | `gitleaks-scan.yml`                   | Secret detection scanning        | N/A (gitleaks direct)               |
@@ -101,7 +104,7 @@ Individual validation workflows called by orchestration workflows:
 | `docusaurus-tests.yml`                | Docusaurus test suite            | N/A (npm test)                      |
 | `model-validation.yml`                | Model reference validation       | `npm run lint:models`               |
 | `ai-artifact-validation.yml`          | AI artifact structure validation | `npm run lint:ai-artifacts`         |
-| `devcontainer-lockfile-check.yml`     | Devcontainer lockfile integrity  | N/A (bash + jq direct)              |
+| `devcontainer-lockfile-check.yml`     | Devcontainer lockfile integrity  | `npm run validate:devcontainer-lockfile` |
 | `action-version-consistency-scan.yml` | Action version consistency       | `npm run lint:version-consistency`  |
 
 Workflows marked with `*` are dual-purpose: they accept `workflow_call` for reuse by orchestration workflows and also run independently via their own triggers.
@@ -242,7 +245,7 @@ The `weekly-security-maintenance.yml` workflow runs every Sunday at 2AM UTC, pro
 |--------------------|------------------------------|-----------------------------------------------|
 | Dependency Pinning | `Test-DependencyPinning.ps1` | Actions use SHA refs; npm uses exact versions |
 | SHA Staleness      | `Test-SHAStaleness.ps1`      | SHAs reference recent commits                 |
-| npm Audit          | `npm audit`                  | Known vulnerabilities in dependencies         |
+| audit-ci           | `audit-ci --config audit-ci.json` | Known vulnerabilities in dependencies, using the allowlist in `audit-ci.json` |
 | CodeQL             | GitHub native                | Code patterns indicating security issues      |
 | Gitleaks           | `gitleaks`                   | Secret detection in repository history        |
 | Dependency Review  | GitHub native                | Dependency vulnerability analysis             |
@@ -329,8 +332,9 @@ Workflows invoke validation through npm scripts defined in `package.json`:
 | `test:ps`                      | `Invoke-PesterTests.ps1`                                               | pester-tests.yml              |
 | `validate:skills`              | `Validate-SkillStructure.ps1`                                          | skill-validation.yml          |
 | `validate:copyright`           | `Test-CopyrightHeaders.ps1`                                            | copyright-headers.yml         |
-| `extension:prepare`            | `Prepare-Extension.ps1`                                                | extension-package.yml         |
-| `extension:prepare:prerelease` | `Prepare-Extension.ps1 -Channel PreRelease`                            | extension-package.yml         |
+| `extension:prepare`            | `pwsh ./scripts/extension/Prepare-Extension.ps1 && npm run extension:postprocess` | extension-package.yml         |
+| `extension:prepare:prerelease` | `pwsh ./scripts/extension/Prepare-Extension.ps1 -Channel PreRelease && npm run extension:postprocess` | extension-package.yml         |
+| `extension:postprocess`        | `markdownlint-cli2 + markdown-table-formatter (extension/**/*.md, collections/*.md)` | extension-package.yml         |
 | `extension:package`            | `Package-Extension.ps1`                                                | extension-package.yml         |
 | `package:extension`            | Alias for `extension:package`                                          | extension-package.yml         |
 | `extension:package:prerelease` | `Package-Extension.ps1 -PreRelease`                                    | extension-package.yml         |
@@ -338,10 +342,12 @@ Workflows invoke validation through npm scripts defined in `package.json`:
 | `plugin:validate`              | Alias for `lint:collections-metadata`                                  | plugin-validation.yml         |
 | `lint:py`                      | `ruff check`                                                           | python-lint.yml               |
 | `lint:models`                  | `Validate-ModelReferences.ps1`                                         | model-validation.yml          |
-| `lint:ai-artifacts`            | `Validate-AIArtifacts.ps1`                                             | ai-artifact-validation.yml    |
+| `lint:ai-artifacts`            | `Validate-PlannerArtifacts.ps1 -FailOnMissing`                        | ai-artifact-validation.yml    |
 | `lint:permissions`             | `Test-WorkflowPermissions.ps1`                                         | workflow-permissions-scan.yml |
+| `lint:ps-module-pins`          | `Test-PSModulePins.ps1`                                                | Local                         |
 | `lint:dependency-pinning`      | `Test-DependencyPinning.ps1`                                           | dependency-pinning-scan.yml   |
-| `test:py`                      | `pytest`                                                               | pytest-tests.yml              |
+| `audit:npm`                    | `audit-ci --config audit-ci.json`                                      | pr-validation.yml             |
+| `test:py`                      | `uv run pytest`                                                        | pytest-tests.yml              |
 | `eval:lint:vally`              | `Build-AgentBehaviorSpec.ps1 -WhatIf && vally lint --eval-spec evals/` | Local                         |
 | `eval:lint:schema`             | `Test-EvalSpec.ps1`                                                    | Local                         |
 | `eval:lint:text`               | `Test-EvalSpecText.ps1`                                                | Local                         |

--- a/docs/customization/environment.md
+++ b/docs/customization/environment.md
@@ -30,6 +30,7 @@ The DevContainer ships with these tools:
 * Azure CLI
 * shellcheck for bash validation
 * actionlint for GitHub Actions workflow validation
+* cosign for artifact signing and verification
 * gitleaks for secret scanning
 
 ### Customizing for Your Team
@@ -254,6 +255,7 @@ The coding agent environment includes:
 * PowerShell 7 with PSScriptAnalyzer 1.25.0, PowerShell-Yaml 0.4.7, and Pester 5.7.1
 * shellcheck (pre-installed on ubuntu-latest)
 * actionlint for GitHub Actions workflow validation
+* cosign for artifact signing and verification
 
 ### Adding Tools for the Coding Agent
 
@@ -293,6 +295,7 @@ share most tools but differ intentionally in a few areas.
 | Pester 5.7.1            | Yes          | Yes          |
 | shellcheck              | Yes          | Yes          |
 | actionlint              | Yes          | Yes          |
+| cosign                  | Yes          | Yes          |
 
 ### Intentional Differences
 

--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -2,7 +2,7 @@
 title: Security Scripts
 description: PowerShell scripts for dependency pinning validation, SHA staleness monitoring, supply chain security, and centralized PS module installation
 author: HVE Core Team
-ms.date: 2026-06-22
+ms.date: 2026-06-26
 ms.topic: reference
 keywords:
   - powershell
@@ -28,6 +28,7 @@ The security scripts share common modules and follow a consistent pattern:
 * `CIHelpers.psm1` (from `scripts/lib/`) provides CI platform detection and
   GitHub Actions output formatting
 * `tool-checksums.json` stores SHA256 checksums for verified tool downloads
+  (see [tool-checksums.json schema](#tool-checksumsjson-schema))
 
 ## Scripts
 
@@ -349,6 +350,22 @@ Shared utility functions used across security scripts:
 | Function            | Purpose                                                                   |
 |---------------------|---------------------------------------------------------------------------|
 | `Write-SecurityLog` | Outputs timestamped, color-coded log entries with optional CI annotations |
+
+## tool-checksums.json schema
+
+`tool-checksums.json` supports a dual schema for tool download metadata. Legacy
+scalar fields remain available for compatibility, while per-arch maps are
+preferred for new entries.
+
+* Legacy scalar fields: `sha256` and `downloadUrlTemplate`. These fields are
+  deprecated for new entries, but they remain the values the current tooling
+  consumes; for example, `Test-SHAStaleness.ps1` reads `sha256`.
+* Preferred per-arch maps: `sha256ByArch` and `assetTemplateByArch`. New entries
+  should populate these maps to carry architecture-specific download metadata.
+  The current scripts do not yet read these fields, so populate the legacy
+  scalar fields alongside them until a consumer adopts the maps.
+* This documentation describes the manifest schema only and does not change
+  runtime behavior.
 
 ## GitHub Actions Integration
 


### PR DESCRIPTION
This PR brings three documentation pages back in line with the current repository state. It refreshes the workflow architecture tables to match *package.json* and the workflows in *.github/workflows/*, documents the dual schema used by *tool-checksums.json*, and records **cosign** as part of both the DevContainer and coding agent tool stacks. All changes are documentation-only and were verified against their source-of-truth files.

## Description

### Workflow architecture tables (*docs/architecture/workflows.md*)

Realigned the workflow inventory, reusable-workflows, and npm-script mapping tables with the actual scripts in *package.json* and the workflow files in *.github/workflows/*.

- Added the **weekly-gh-code-scanning.yml** inventory row and the **gh-code-scanning.yml** and **create-gh-code-scanning-issues.yml** reusable-workflow rows.
- Corrected the **devcontainer-lockfile-check.yml** local equivalent to `npm run validate:devcontainer-lockfile`.
- Replaced the *npm audit* security-tools entry with **audit-ci** (`audit-ci --config audit-ci.json`), noting the allowlist in *audit-ci.json*.
- Updated the npm-script mapping: **lint:ai-artifacts** now maps to `Validate-PlannerArtifacts.ps1 -FailOnMissing`, added **lint:ps-module-pins** and **audit:npm** rows, changed **test:py** to `uv run pytest`, and expanded **extension:prepare**/**extension:prepare:prerelease** to include `&& npm run extension:postprocess` alongside a new **extension:postprocess** row.

### tool-checksums.json schema (*scripts/security/README.md*)

Added a dedicated *tool-checksums.json schema* section describing the manifest's dual schema and linked to it from the Architecture file list.

- Documented the legacy scalar fields (*sha256*, *downloadUrlTemplate*) and the preferred per-arch maps (*sha256ByArch*, *assetTemplateByArch*).
- The wording reflects current behavior: tooling such as *Test-SHAStaleness.ps1* reads the legacy *sha256* scalar, and no consumer reads the per-arch maps yet, so new entries should populate both.

### Tool stack documentation (*docs/customization/environment.md*)

Recorded **cosign** in the DevContainer Default Tool Stack list, the Coding Agent Pre-Installed Tools list, and the Shared Tools table (Yes/Yes), matching its installation in *.devcontainer/scripts/on-create.sh* and *.github/workflows/copilot-setup-steps.yml*.

## Related Issue(s)

Closes #1380
Closes #1425
Closes #1436
Closes #1438
Closes #1439
Closes #1682
Closes #1765
Closes #1928
Closes #2005
Closes #2036
Closes #2127

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Ran `npm run lint:md` (0 errors), `npm run lint:frontmatter` (0 errors), and `npm run spell-check` (0 issues). Validated links in the three changed files with the markdown link checker; all links, including the new *tool-checksums.json schema* anchor, resolved.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Eval spec schema and coverage (if AI artifacts changed): `npm run eval:lint:schema`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

These changes are documentation-only and introduce no runtime or dependency changes. The *tool-checksums.json* per-arch maps (*sha256ByArch*, *assetTemplateByArch*) are present in the manifest but not yet read by any script; a follow-up could wire a consumer to honor them or mark the fields experimental.

