### PR TITLE
docs(ado-backlog): correct ADO Backlog Manager workflow documentation

### DIFF
--- a/docs/agents/ado-backlog/README.md
+++ b/docs/agents/ado-backlog/README.md
@@ -2,7 +2,7 @@
 title: ADO Backlog Manager
 description: Automated work item discovery, triage, sprint planning, and execution for Azure DevOps projects
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: concept
 keywords:
   - azure devops backlog manager
@@ -99,12 +99,12 @@ See the [PR Creation workflow guide](pr-creation.md) for the complete workflow i
 
 The backlog manager automatically detects the appropriate content format for your Azure DevOps environment:
 
-| Environment           | Format   | Detection Method                                                 |
-|-----------------------|----------|------------------------------------------------------------------|
-| Azure DevOps Services | Markdown | URL contains `dev.azure.com` or `visualstudio.com`               |
-| Azure DevOps Server   | HTML     | URL contains an on-premises hostname or uses `_apis` with a port |
+| Environment           | Format   | Detection Method                                                |
+|-----------------------|----------|-----------------------------------------------------------------|
+| Azure DevOps Services | Markdown | Organization URL contains `dev.azure.com`                       |
+| Azure DevOps Server   | HTML     | Organization URL contains a custom domain or `visualstudio.com` |
 
-All interaction templates (work item descriptions, comments, acceptance criteria) exist in both Markdown and HTML variants. The detected format determines which template variant the agent uses for API calls.
+When the format cannot be determined, the agent defaults to Markdown and notes that HTML is available for Azure DevOps Server instances. All interaction templates (work item descriptions, comments, acceptance criteria) exist in both Markdown and HTML variants. The detected format determines which template variant the agent uses for API calls.
 
 ## Autonomy Levels
 

--- a/docs/agents/ado-backlog/build-monitoring.md
+++ b/docs/agents/ado-backlog/build-monitoring.md
@@ -2,7 +2,7 @@
 title: "Build Monitoring Workflow"
 description: "How to retrieve Azure DevOps build status, logs, and failure analysis"
 author: Microsoft
-ms.date: 2026-03-07
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - ado
@@ -47,7 +47,7 @@ flowchart TD
 ```
 
 > [!NOTE]
-> Build Monitoring performs read-only operations on your pipeline data, with one exception: the `mcp_ado_pipelines_update_build_stage` tool can retry or skip a stage when you explicitly request it.
+> Build Monitoring performs read-only operations on your pipeline data, with one exception: the `mcp_ado_pipelines_update_build_stage` tool can retry, run, or cancel a stage when you explicitly request it.
 
 ### Retrieval Paths
 
@@ -133,7 +133,7 @@ commit.
 * ✅ Request targeted log reads for failed stages instead of full log dumps
 * ✅ Review the tracking file before re-running a failed build to confirm the fix addresses the right issue
 * ✅ Ask the agent to compare two build runs when investigating intermittent failures
-* ❌ Do not request stage updates unless you understand the pipeline's retry behavior
+* ❌ Do not request stage updates unless you understand the pipeline's retry and cancel behavior
 * ❌ Do not assume a passing build means all stages completed (some stages may be skipped by design)
 * ❌ Do not ignore infrastructure errors in log analysis (they may indicate transient issues, not code problems)
 
@@ -144,7 +144,7 @@ commit.
 | Agent cannot find builds for your PR       | Verify the project name and confirm the PR has triggered a pipeline run                    |
 | Build logs are empty or truncated          | Check that the build completed (in-progress builds may not have all logs)                  |
 | Wrong build selected from branch query     | Specify the build ID directly or narrow the time range                                     |
-| Stage update has no effect                 | Verify the pipeline supports the retry or skip action for that stage type                  |
+| Stage update has no effect                 | Verify the pipeline supports the retry, run, or cancel action for that stage type          |
 | Tracking file overwrites previous analysis | Each file uses a date-prefixed name; check for existing files before requesting new output |
 
 ## Next Steps

--- a/docs/agents/ado-backlog/discovery.md
+++ b/docs/agents/ado-backlog/discovery.md
@@ -2,7 +2,7 @@
 title: Discovery Workflow
 description: Discover and categorize Azure DevOps work items through user-centric, artifact-driven, and search-based paths
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager

--- a/docs/agents/ado-backlog/execution.md
+++ b/docs/agents/ado-backlog/execution.md
@@ -2,7 +2,7 @@
 title: Execution Workflow
 description: Apply triage and planning recommendations to Azure DevOps work items through structured handoff consumption
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager
@@ -111,7 +111,7 @@ Click the "Execute" handoff button in the ADO Backlog Manager agent after comple
 Reference the handoff file when starting an execution conversation:
 
 ```text
-Execute the handoff at .copilot-tracking/workitems/triage/2026-02-26/work-items.md
+Execute the handoff at .copilot-tracking/workitems/triage/2026-02-26/triage-plan.md
 ```
 
 ## Example Prompts

--- a/docs/agents/ado-backlog/pr-creation.md
+++ b/docs/agents/ado-backlog/pr-creation.md
@@ -2,7 +2,7 @@
 title: "PR Creation Workflow"
 description: "How to create Azure DevOps pull requests with automated work item discovery and reviewer identification"
 author: Microsoft
-ms.date: 2026-03-07
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - ado
@@ -76,7 +76,7 @@ When no existing work items match, the agent enters an automatic creation phase,
 ## Output Artifacts
 
 ```text
-.copilot-tracking/pr/new/<branch-name>/
+.copilot-tracking/pr/new/<normalized-branch-name>/
 ├── pr-reference.xml       # Full diff between source and base branches
 ├── pr.md                  # Generated PR title and description
 ├── pr-analysis.md         # Work item discovery results with relevance scores
@@ -114,7 +114,7 @@ Full PR with automated work item discovery:
 ```text
 Create a pull request for my feature branch against develop. Search
 for related work items in the Active and New states with a similarity
-threshold of 0.7. Include:
+threshold of 70. Include:
 - Conventional commit title based on the diff summary
 - Work item links for all matched items
 - Reviewer suggestions based on git blame history

--- a/docs/agents/ado-backlog/prd-planning.md
+++ b/docs/agents/ado-backlog/prd-planning.md
@@ -2,7 +2,7 @@
 title: PRD Planning Workflow
 description: Convert product requirements documents into Azure DevOps work item hierarchies with structured decomposition
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager
@@ -13,7 +13,7 @@ estimated_reading_time: 4
 sidebar_position: 6
 ---
 
-The PRD Planning workflow converts product requirements documents into Azure DevOps work item hierarchies, decomposing requirements into the four-level structure (Epic > Feature > Story > Task) that Azure DevOps supports natively.
+The PRD Planning workflow converts product requirements documents into Azure DevOps work item hierarchies, decomposing requirements into a three-level structure (Epic > Feature > User Story) that the `@AzDO PRD to WIT` agent supports.
 
 ## When to Use
 
@@ -26,8 +26,8 @@ The PRD Planning workflow converts product requirements documents into Azure Dev
 
 1. Accepts a PRD, specification, or requirements document as input
 2. Delegates to the `@AzDO PRD to WIT` agent for parsing and decomposition
-3. Maps requirements to Azure DevOps work item types (Epic, Feature, User Story, Task)
-4. Builds parent-child relationships following the four-level hierarchy
+3. Maps requirements to Azure DevOps work item types (Epic, Feature, User Story)
+4. Builds parent-child relationships following the three-level hierarchy
 5. Produces a handoff file with the complete work item hierarchy ready for execution
 
 > [!NOTE]
@@ -35,16 +35,15 @@ The PRD Planning workflow converts product requirements documents into Azure Dev
 
 ## Hierarchy Model
 
-Azure DevOps supports a four-level work item hierarchy. PRD Planning maps requirements to the appropriate level based on scope and granularity:
+The `@AzDO PRD to WIT` agent maps requirements to three work item types based on scope and granularity:
 
 | Level   | Work Item Type | Typical Scope                          |
 |---------|----------------|----------------------------------------|
 | Level 1 | Epic           | Business initiative or major objective |
 | Level 2 | Feature        | Functional capability or component     |
 | Level 3 | User Story     | User-facing requirement or scenario    |
-| Level 4 | Task           | Implementation step or technical work  |
 
-Requirements that span multiple features become Epics. Requirements with clear user value become User Stories. Implementation details become Tasks under their parent Stories.
+Requirements that span multiple features become Epics. Requirements with clear user value become User Stories. Implementation detail is captured within each User Story rather than as separate Task work items.
 
 ## Output Artifacts
 
@@ -89,10 +88,10 @@ Full PRD conversion to work item hierarchy:
 Parse the product requirements document at docs/prd-v2.md and create
 an Azure DevOps work item hierarchy. Structure as:
 - Epics for major feature areas
-- Stories for user-facing capabilities within each Epic
-- Tasks for implementation steps within each Story
+- Features for functional capabilities within each Epic
+- User Stories for user-facing scenarios within each Feature
 
-Include acceptance criteria from the PRD as Story descriptions.
+Include acceptance criteria from the PRD as User Story descriptions.
 ```
 
 Incremental update from a revised PRD section:
@@ -108,8 +107,8 @@ Schema-guided decomposition with depth control:
 
 ```text
 Convert the requirements in docs/api-spec.md into a two-level hierarchy
-only: Epics and Stories. Do not create Tasks. Group Stories by API
-endpoint and include the HTTP method and path in each Story title.
+only: Epics and User Stories. Skip Feature-level grouping. Group Stories
+by API endpoint and include the HTTP method and path in each Story title.
 ```
 
 **Output artifacts:** PRD planning creates a hierarchy handoff file mapping requirements to proposed work items with parent-child relationships. Review the hierarchy structure and verify parent links before executing.

--- a/docs/agents/ado-backlog/sprint-planning.md
+++ b/docs/agents/ado-backlog/sprint-planning.md
@@ -2,7 +2,7 @@
 title: Sprint Planning Workflow
 description: Organize triaged work items into Azure DevOps iterations with coverage analysis, capacity tracking, and gap detection
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager
@@ -81,9 +81,8 @@ Burndown metrics appear when `CompletedWork` data is available, showing original
 
 ```text
 .copilot-tracking/workitems/sprint/<iteration-kebab>/
-├── planning-log.md     # Progress tracking and analysis results
-├── work-items.md       # Iteration mapping and capacity review
-└── handoff.md          # Execution-ready assignments
+├── planning-log.md   # Progress tracking and analysis results
+└── sprint-plan.md    # Iteration mapping, coverage matrices, and capacity analysis
 ```
 
 ## How to Use

--- a/docs/agents/ado-backlog/task-planning.md
+++ b/docs/agents/ado-backlog/task-planning.md
@@ -2,7 +2,7 @@
 title: "Task Planning Workflow"
 description: "How to use AI-assisted task planning for Azure DevOps work items"
 author: Microsoft
-ms.date: 2026-03-07
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - ado
@@ -59,13 +59,13 @@ Field conventions follow Azure DevOps work item types. User Stories carry title,
 
 The agent supports creation, updates, batch operations, and linking through MCP ADO tools.
 
-For retrieval, `mcp_ado_wit_get_work_item` and `mcp_ado_wit_get_work_items` (batch) hydrate work items with full field values. Batch retrieval reduces API calls when processing multiple items.
+For retrieval, `mcp_ado_wit_get_work_item` and `mcp_ado_wit_get_work_items_batch_by_ids` (batch) hydrate work items with full field values. Batch retrieval reduces API calls when processing multiple items.
 
 The search workflow uses `mcp_ado_search_workitem` with keyword groups composed from your codebase, commit messages, and existing work item fields. The search protocol supports OR/AND syntax and paging for large result sets.
 
 New work items are created through `mcp_ado_wit_create_work_item`, and `mcp_ado_wit_add_child_work_items` decomposes a parent into child tasks. Created items inherit the parent's area path and iteration path unless you override them.
 
-Field changes go through `mcp_ado_wit_update_work_item`, and `mcp_ado_wit_add_work_item_relation` handles linking related items. Comments posted through `mcp_ado_wit_create_work_item_comment` record implementation context directly on the work item.
+Field changes go through `mcp_ado_wit_update_work_item`, and `mcp_ado_wit_work_items_link` handles linking related items. Comments posted through `mcp_ado_wit_add_work_item_comment` record implementation context directly on the work item.
 
 ## Output Artifacts
 

--- a/docs/agents/ado-backlog/triage.md
+++ b/docs/agents/ado-backlog/triage.md
@@ -2,7 +2,7 @@
 title: Triage Workflow
 description: Classify, prioritize, and detect duplicate Azure DevOps work items using structured triage analysis
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager
@@ -111,7 +111,7 @@ When confidence exceeds the threshold, the workflow links the duplicate pair in 
 ```text
 .copilot-tracking/workitems/triage/<YYYY-MM-DD>/
 ├── planning-log.md    # Progress tracking and analysis results
-└── work-items.md      # Classification suggestions, duplicate findings, and recommended operations
+└── triage-plan.md     # Classification suggestions, duplicate findings, and recommended operations
 ```
 
 The triage plan includes reasoning for each classification, making it possible to adjust recommendations before execution applies them.

--- a/docs/agents/ado-backlog/using-together.md
+++ b/docs/agents/ado-backlog/using-together.md
@@ -2,7 +2,7 @@
 title: Using Workflows Together
 description: Connect discovery, triage, sprint planning, and execution into a complete Azure DevOps backlog management pipeline
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: tutorial
 keywords:
   - azure devops backlog manager
@@ -75,7 +75,7 @@ Triage the work items from my latest discovery session. Assign Area Paths,
 reclassify priorities, and flag duplicates with confidence scores.
 ```
 
-Review the triage results at `.copilot-tracking/workitems/triage/<YYYY-MM-DD>/work-items.md`. Adjust any classification suggestions before continuing.
+Review the triage results at `.copilot-tracking/workitems/triage/<YYYY-MM-DD>/triage-plan.md`. Adjust any classification suggestions before continuing.
 
 ### Step 3: Clear and Plan Sprint
 
@@ -154,13 +154,13 @@ Run discovery periodically to monitor for new items without immediate action.
 
 Planning files move through states during the pipeline:
 
-| State          | Location                                 | Created By      | Consumed By    |
-|----------------|------------------------------------------|-----------------|----------------|
-| Analysis       | `discovery/<scope>/planning-log.md`      | Discovery       | Triage         |
-| Classification | `triage/<YYYY-MM-DD>/work-items.md`      | Triage          | Sprint/Execute |
-| Sprint Plan    | `sprint/<iteration-kebab>/handoff.md`    | Sprint Planning | Execution      |
-| PRD Hierarchy  | `prds/<name>/handoff.md`                 | PRD Planning    | Execution      |
-| Execution Log  | `execution/<YYYY-MM-DD>/handoff-logs.md` | Execution       | User review    |
+| State          | Location                                  | Created By      | Consumed By    |
+|----------------|-------------------------------------------|-----------------|----------------|
+| Analysis       | `discovery/<scope>/planning-log.md`       | Discovery       | Triage         |
+| Classification | `triage/<YYYY-MM-DD>/triage-plan.md`      | Triage          | Sprint/Execute |
+| Sprint Plan    | `sprint/<iteration-kebab>/sprint-plan.md` | Sprint Planning | Execution      |
+| PRD Hierarchy  | `prds/<name>/handoff.md`                  | PRD Planning    | Execution      |
+| Execution Log  | `execution/<YYYY-MM-DD>/handoff-logs.md`  | Execution       | User review    |
 
 Files are created once and updated in place. The execution workflow marks checkboxes in handoff files as it processes each operation, providing a built-in audit trail.
 
@@ -183,16 +183,16 @@ The ADO Backlog Manager provides handoff buttons for quick workflow transitions:
 
 ## Artifact Summary
 
-| Workflow         | Input            | Output                                      | Key File          |
-|------------------|------------------|---------------------------------------------|-------------------|
-| Discovery        | Project scope    | Work item inventory and recommendations     | `planning-log.md` |
-| Triage           | Discovery output | Field suggestions and duplicate flags       | `work-items.md`   |
-| PRD Planning     | Requirements doc | Work item hierarchy with parent-child links | `handoff.md`      |
-| Sprint Planning  | Triage output    | Iteration assignments and capacity analysis | `handoff.md`      |
-| Execution        | Handoff files    | Applied changes and operation log           | `handoff-logs.md` |
-| Task Planning    | Assigned items   | Prioritized task list with reasoning        | `task-list.md`    |
-| Build Monitoring | PR or branch     | Pipeline status, logs, and failure details  | `build-status.md` |
-| PR Creation      | Local changes    | Pull request with work item links           | `pr-details.md`   |
+| Workflow         | Input            | Output                                      | Key File                |
+|------------------|------------------|---------------------------------------------|-------------------------|
+| Discovery        | Project scope    | Work item inventory and recommendations     | `planning-log.md`       |
+| Triage           | Discovery output | Field suggestions and duplicate flags       | `triage-plan.md`        |
+| PRD Planning     | Requirements doc | Work item hierarchy with parent-child links | `handoff.md`            |
+| Sprint Planning  | Triage output    | Iteration assignments and capacity analysis | `sprint-plan.md`        |
+| Execution        | Handoff files    | Applied changes and operation log           | `handoff-logs.md`       |
+| Task Planning    | Assigned items   | Prioritized task list with reasoning        | `task-planning-logs.md` |
+| Build Monitoring | PR or branch     | Pipeline status, logs, and failure details  | `<date>-build-<id>.md`  |
+| PR Creation      | Local changes    | Pull request with work item links           | `pr.md`                 |
 
 ## Quick Reference
 

--- a/docs/agents/ado-backlog/why-backlog-manager.md
+++ b/docs/agents/ado-backlog/why-backlog-manager.md
@@ -2,7 +2,7 @@
 title: Why the ADO Backlog Manager Works
 description: Design principles and cognitive foundations behind the Azure DevOps Backlog Manager workflow separation
 author: Microsoft
-ms.date: 2026-02-26
+ms.date: 2026-06-26
 ms.topic: concept
 keywords:
   - azure devops backlog manager
@@ -31,7 +31,7 @@ Triage applies consistent classification. Working from discovery output rather t
 
 Sprint planning builds on classified data. With fields and duplicates resolved, iteration assignment becomes a mapping exercise rather than a judgment call. The workflow can reason about capacity, hierarchy coverage, and area path gaps because triage has already done the classification work.
 
-PRD planning bridges requirements and backlogs. Converting a product requirements document into a work item hierarchy is a distinct skill from managing existing items. A separate workflow ensures the decomposition (Epic > Feature > Story > Task) follows Azure DevOps conventions without interference from ongoing triage.
+PRD planning bridges requirements and backlogs. Converting a product requirements document into a work item hierarchy is a distinct skill from managing existing items. A separate workflow ensures the decomposition (Epic > Feature > User Story) follows Azure DevOps conventions without interference from ongoing triage.
 
 Execution applies changes mechanically. By the time you reach execution, every change has been reviewed and approved in a handoff file. The workflow processes checkboxes, not decisions. Content sanitization strips internal tracking references before API calls, preventing accidental leakage of planning metadata. This separation means bulk changes are safe because the decision-making happened in earlier phases with full context.
 


### PR DESCRIPTION
# Pull Request

## Description

Refreshes and corrects the eleven ADO Backlog Manager documentation pages under `docs/agents/ado-backlog/`, which were flagged as stale (>90 days). Rather than only bumping `ms.date`, each page was verified against its source-of-truth agent and instruction files using the documentation drift method, and factual drift was corrected.

Substantive accuracy corrections (10 of 11 files):

* `triage.md` — output artifact `work-items.md` → `triage-plan.md` (matches `ado-backlog-triage.instructions.md`).
* `sprint-planning.md` — output artifacts corrected to `sprint-plan.md` + `planning-log.md`.
* `prd-planning.md` and `why-backlog-manager.md` — PRD hierarchy corrected from `Epic > Feature > Story > Task` to `Epic > Feature > User Story` (the `@AzDO PRD to WIT` agent does not produce Tasks).
* `task-planning.md` — three MCP tool names corrected (`get_work_items` → `get_work_items_batch_by_ids`, `add_work_item_relation` → `work_items_link`, `create_work_item_comment` → `add_work_item_comment`).
* `pr-creation.md` — output path `<branch-name>` → `<normalized-branch-name>`; example similarity threshold `0.7` → `70` (source uses a 0-100 scale, default 50).
* `execution.md` — example handoff path corrected to `triage-plan.md`.
* `using-together.md` — six artifact filenames corrected across the pipeline and summary tables.
* `build-monitoring.md` — `update_build_stage` action described as "retry or skip" corrected to the actual statuses (`Retry`, `Run`, `Cancel`).
* `README.md` — Content Format Detection corrected: `visualstudio.com` now maps to Azure DevOps Server/HTML (was incorrectly under Services/Markdown), removed the unsupported `_apis`-with-a-port heuristic, and added the documented default-to-Markdown fallback.

`discovery.md` was verified accurate at the parameter level and received only the date refresh. All eleven pages have `ms.date` refreshed to 2026-06-26.

## Related Issue(s)

Closes #1753
Closes #1754
Closes #1755
Closes #1756
Closes #1757
Closes #1758
Closes #1759
Closes #1760
Closes #1954
Closes #1955
Closes #1956

## Type of Change

**Code & Documentation:**

* [x] Documentation update

## Testing

* `npm run format:tables` — applied; table alignment normalized.
* `npx markdownlint-cli2 "docs/agents/ado-backlog/*.md"` — 11 files, 0 errors.
* Editor diagnostics on edited files — no errors.
* Each page cross-checked against its source agent (`.github/agents/ado/ado-backlog-manager.agent.md`, `ado-prd-to-wit.agent.md`) and instruction files (`.github/instructions/ado/*.instructions.md`) for artifact names, tool names, parameter scales, status enums, and hierarchy types.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)

### Required Automated Checks

* [x] Markdown linting: `npm run lint:md`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information

## Additional Notes

Documentation-only change; no source code, dependencies, or workflows are modified. Branch is freshly based on `origin/main`.
