### PR TITLE
fix(scripts): remove redundant moderation requirements.txt

### DIFF
--- a/docs/contributing/evals-ci.md
+++ b/docs/contributing/evals-ci.md
@@ -3,7 +3,7 @@ title: Evals in CI
 description: Auth contract, fork-PR policy, and how to add a new eval spec for the hve-core vally pipeline
 sidebar_position: 11
 author: Microsoft
-ms.date: 2026-06-28
+ms.date: 2026-06-29
 ms.topic: how-to
 keywords:
   - evals
@@ -165,14 +165,14 @@ Content moderation runs in two complementary CI lanes, each scoped to a differen
 
 The two lanes target different surfaces and do not overlap: the markdown-corpus lane keeps the AI artifacts that ship to contributors free of insensitive or foul language; the eval-spec stimuli lane scores adversarial test inputs against a Detoxify cutoff so a spec that probes a model with toxic content cannot itself ship unredacted.
 
-The `content-moderation` job is the only path that exercises the real Detoxify model in CI. The job installs the Python dependencies (`scripts/evals/moderation/requirements.txt`) via `uv pip install`, caches the Detoxify weights between runs, then invokes `Invoke-CorpusModeration.ps1` per spec.
+The `content-moderation` job is the only path that exercises the real Detoxify model in CI. The job installs the Python dependencies via `uv sync --locked` in `scripts/evals/moderation` (declared in its `pyproject.toml` and `uv.lock`), caches the Detoxify weights between runs, then invokes `Invoke-CorpusModeration.ps1` per spec.
 
 `Invoke-CorpusModeration.ps1` shells out to [scripts/evals/Invoke-ContentModeration.ps1](../../scripts/evals/Invoke-ContentModeration.ps1) for each stimulus. The default Detoxify threshold is `0.5`; per-spec overrides come from the `moderation.threshold` field documented above.
 
 Local opt-in for the Detoxify lane:
 
 ```pwsh
-uv pip install -r scripts/evals/moderation/requirements.txt
+uv sync --locked --project scripts/evals/moderation
 pwsh scripts/evals/Invoke-CorpusModeration.ps1 -SpecGlob 'evals/**/*.yaml'
 ```
 

--- a/scripts/evals/moderation/requirements.txt
+++ b/scripts/evals/moderation/requirements.txt
@@ -1,5 +1,0 @@
-# Content moderation dependencies for eval input/output screening
-# Pinned per hve-core security conventions
-detoxify==0.5.2
-torch==2.12.0
-transformers>=4.40,<5


### PR DESCRIPTION
## Description

Removed the redundant `scripts/evals/moderation/requirements.txt` and updated the eval docs to point at the `uv` workflow it duplicated.

The content-moderation eval project declares its dependencies in `pyproject.toml` with a hash-pinned `uv.lock`. The separate `requirements.txt` restated the same three dependencies, but its `transformers` entry used an unpinned range (`transformers>=4.40,<5`). The OpenSSF Scorecard Vulnerabilities check runs `osv-scanner`, which reads that manifest directly; without a concrete version it matched the package against its entire advisory history, surfacing a large set of `transformers` advisories that the resolved lockfile version (`4.57.6`) is already patched against.

No workflow consumed the file — the `content-moderation` CI job, `copilot-setup-steps.yml`, and the moderation script's own virtual-environment lookup all use `uv sync --locked`, and Dependabot already tracks the directory via the `uv` ecosystem. Removing the file eliminates the false-positive source while leaving dependency management unchanged.

### Changes

* Removed `scripts/evals/moderation/requirements.txt` (duplicate of `pyproject.toml` + `uv.lock`).
* Updated `docs/contributing/evals-ci.md` so the description and local opt-in steps use `uv sync --locked` instead of `uv pip install -r requirements.txt`.

## Related Issue(s)

Fixes #2272

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [x] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

**User Request:**
<!-- What natural language request would trigger this agent/prompt/instruction? -->

**Execution Flow:**
<!-- Step-by-step: what happens when invoked? Include tool usage, decision points -->

**Output Artifacts:**
<!-- What files/content are created? Show first 10-20 lines as preview -->

**Success Indicators:**
<!-- How does user know it worked correctly? What validation should they perform? -->

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

Agent-run validation on the changed files:

* `npm run lint:md` — passed (0 errors).
* `npm run lint:frontmatter` — passed (0 warnings).
* `npm run spell-check` — passed (0 issues).
* `npm run lint:dependency-pinning` — passed; compliance improved to 99.34% after removing the manifest.

Diff-based assessment:

* Confirmed no workflow, script, or `package.json`/`justfile` target installs from the removed `requirements.txt`; all consumers use `uv sync --locked`.
* Confirmed no remaining repository references to `scripts/evals/moderation/requirements.txt`.

> [!NOTE]
> Manual testing was not performed. Final confirmation comes from re-running the OpenSSF Scorecard workflow on `main` after merge.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable) (N/A — no new functionality)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills` (N/A — no skills changed)
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps` (N/A — no PowerShell changed)
* [ ] Eval spec schema and coverage (if AI artifacts changed): `npm run eval:lint:schema` (N/A — no AI artifacts changed)
* [ ] Plugin freshness: `npm run plugin:generate` (N/A — no collection manifests changed)
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues (no new dependencies; removes a redundant manifest)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

This change clears the version-fixed false positives only. Three genuine advisories remain because no released version fixes them at the resolved lockfile versions; they are tracked for separate suppression with justification and a review date:

* `GHSA-rrmf-rvhw-rf47` (torch — no fixed version disclosed)
* `GHSA-69w3-r845-3855` / `PYSEC-2025-217` (transformers — fixed only in a `5.0.0` prerelease)
