### PR TITLE
fix(evals): add missing eval coverage for vex-scan and vex-triage prompts

### DIFF
--- a/evals/behavior-conformance/prompts.eval.yaml
+++ b/evals/behavior-conformance/prompts.eval.yaml
@@ -1305,7 +1305,7 @@ stimuli:
       - type: output-matches
         name: scope-language
         config:
-          pattern: "(?i)VEX|vulnerabilit|exploitabilit|OpenVEX|scan|vex-scan"
+          pattern: "(?i)VEX|vulnerabilit|exploitability|OpenVEX|scan|vex-scan"
 
   - name: prompt-vex-triage-conformance
     prompt: |

--- a/evals/behavior-conformance/prompts.eval.yaml
+++ b/evals/behavior-conformance/prompts.eval.yaml
@@ -1288,3 +1288,39 @@ stimuli:
         name: scope-language
         config:
           pattern: "(?i)(finding|severity|verdict|approve|request changes|comment)"
+
+  - name: prompt-vex-scan-conformance
+    prompt: |
+      Invoke the `vex-scan` prompt with minimal arguments and explain how it
+      coordinates the workflow.
+    tags:
+      category: behavior-conformance
+      prompt: vex-scan
+      advisory: "true"
+    graders:
+      - type: output-matches
+        name: agent-attribution
+        config:
+          pattern: "(?i)VEX\\s+Generator|vex-scan"
+      - type: output-matches
+        name: scope-language
+        config:
+          pattern: "(?i)VEX|vulnerabilit|exploitabilit|OpenVEX|scan|vex-scan"
+
+  - name: prompt-vex-triage-conformance
+    prompt: |
+      Invoke the `vex-triage` prompt with minimal arguments and explain how it
+      coordinates the workflow.
+    tags:
+      category: behavior-conformance
+      prompt: vex-triage
+      advisory: "true"
+    graders:
+      - type: output-matches
+        name: agent-attribution
+        config:
+          pattern: "(?i)VEX\\s+Generator|vex-triage"
+      - type: output-matches
+        name: scope-language
+        config:
+          pattern: "(?i)VEX|triage|OpenVEX|SBOM|report|vex-triage"


### PR DESCRIPTION
# Pull Request

## Description

The `Eval Validation / Eval Execute (prompt)` matrix job, and the aggregate `PR Validation Success` gate, failed on every pull request because two security prompts on `main` had no behavior-conformance eval coverage:

```text
Missing eval coverage for prompt 'vex-scan' (no stimulus declares tags.prompt = vex-scan)
Missing eval coverage for prompt 'vex-triage' (no stimulus declares tags.prompt = vex-triage)
```

The prompt coverage gate (`scripts/evals/Test-StimulusPresence.ps1`) enforces full-repository coverage for the `prompt` kind: every collection-scoped `*.prompt.md` must have a behavior-conformance stimulus that declares `tags.prompt = <slug>`. The VEX scan and triage prompts shipped without matching stimuli in `evals/behavior-conformance/prompts.eval.yaml`, so the gate exited non-zero on every PR and cascaded to `PR Validation Success`. This was a repository-wide gate breaker unrelated to any individual PR.

This change adds the minimum coverage to close the gap. Two advisory-tier stimuli were appended to the canonical prompt eval spec, mirroring the existing `prompt-security-review-llm-conformance` pattern exactly (a minimal-arguments invocation plus two `output-matches` graders for agent attribution and scope language). The stimuli verify benign, documented prompt behavior only; the eval gate logic was not modified.

## Related Issue(s)

Closes #2293

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [x] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Validation performed with the same checks CI runs for prompt eval coverage and eval specs:

* `npm run eval:presence` — **PASS**: 73 covered, 0 missing, 0 skipped (exit 0). The two `Missing eval coverage` errors for `vex-scan` and `vex-triage` are gone.
* `npm run eval:lint:schema` — **PASS**: 10 eval specs validated, 0 failed; the `prompt=vex-scan` and `prompt=vex-triage` backlinks resolve to the prompt files under `.github/prompts/security/`.
* `npm run eval:lint:safety` — **PASS**: 186 files scanned, 0 matches (exit 0); both stimuli are benign documented-behavior invocations.
* `npm run eval:lint:text` — pre-existing repository findings only; **0** findings reference the changed file or any `evals/` path (no regression introduced by this change).
* `npm run lint:frontmatter` — **PASS**: 801 files validated, 0 errors, 0 warnings.
* `npm run lint:yaml` — **PASS**: workflow YAML linting clean.

Manual testing was not performed; the change is a declarative eval-spec addition validated entirely by the commands above.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — no documentation changes)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md` (N/A — no markdown changes)
* [ ] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills` (N/A — no skill changes)
* [ ] Link validation: `npm run lint:md-links` (N/A — no markdown changes)
* [ ] PowerShell analysis: `npm run lint:ps` (N/A — no PowerShell changes)
* [x] Eval spec schema and coverage (if AI artifacts changed): `npm run eval:lint:schema`
* [ ] Plugin freshness: `npm run plugin:generate` (N/A — no collection or plugin changes)
* [ ] Docusaurus tests: `npm run docs:test` (N/A — no docs changes)

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

* Single-file change: `evals/behavior-conformance/prompts.eval.yaml` (+36 lines, two stimuli appended).
* The stimuli were authored through the canonical `vally-tests` skill (safety self-check clean, SHA-256 dedupe verified, append-only).
* These VEX prompts cover benign vulnerability-exploitability documentation behavior; the stimuli assert only agent attribution and domain vocabulary and contain no sensitive content. See the Microsoft content policy: <https://learn.microsoft.com/legal/ai-code-of-conduct>.
* Follow-up (out of scope): a repository-wide audit for other collection-scoped prompts lacking `tags.prompt` coverage would prevent recurrence of this gate breaker.
