### PR TITLE
feat(evals): execute changed stimuli when eval specs are modified

### DIFF
--- a/.github/workflows/eval-validation.yml
+++ b/.github/workflows/eval-validation.yml
@@ -382,6 +382,15 @@ jobs:
           pwsh -NoProfile -File scripts/evals/Get-ChangedAIArtifact.ps1 `
             -BaseRef $base -HeadRef HEAD -OutFile logs/changed-ai-artifacts.json
 
+      - name: Generate changed-spec stimulus manifest
+        if: env.EVAL_EXECUTE == 'true'
+        shell: pwsh
+        run: |
+          $base = '${{ inputs.base-branch }}'
+          if ([string]::IsNullOrWhiteSpace($base)) { $base = 'origin/main' }
+          pwsh -NoProfile -File scripts/evals/Get-ChangedSpecStimulus.ps1 `
+            -BaseRef $base -HeadRef HEAD -OutFile logs/changed-spec-stimuli.json
+
       - name: Probe Copilot token
         if: env.EVAL_EXECUTE == 'true'
         shell: pwsh
@@ -396,7 +405,7 @@ jobs:
         if: env.EVAL_EXECUTE == 'true'
         shell: pwsh
         run: |
-          npm run eval:execute -- -Kind ${{ matrix.kind }} -Model claude-haiku-4.5 -SkipInputModeration
+          npm run eval:execute -- -Kind ${{ matrix.kind }} -ChangedSpecManifestPath logs/changed-spec-stimuli.json -Model claude-haiku-4.5 -SkipInputModeration
           if ($LASTEXITCODE -ne 0) {
             'EVAL_EXECUTE_FAILED=true' >> $env:GITHUB_ENV
           }
@@ -409,6 +418,7 @@ jobs:
           name: eval-execution-results-${{ matrix.kind }}
           path: |
             logs/changed-ai-artifacts.json
+            logs/changed-spec-stimuli.json
             logs/stimulus-presence.json
             logs/eval-summary.json
             logs/eval-results-*.json

--- a/scripts/evals/Get-ChangedSpecStimulus.ps1
+++ b/scripts/evals/Get-ChangedSpecStimulus.ps1
@@ -1,0 +1,119 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Emits a JSON manifest of synthetic artifacts derived from changed eval specs.
+
+.DESCRIPTION
+    Diffs `evals/` between two git refs and resolves every added or modified
+    stimulus to a synthetic artifact descriptor via the `ChangedSpecStimulus`
+    module. The output mirrors the shape of `Get-ChangedAIArtifact.ps1`
+    (`@{ baseRef; headRef; artifacts = @(...) }`) so `Invoke-VallyEvals.ps1` can
+    union the entries into its execution set and run a changed test even when the
+    underlying AI artifact is unchanged (issue #2297).
+
+    Exit codes:
+      0 = manifest written successfully (manifest may be empty).
+      2 = git invocation failed.
+
+.PARAMETER BaseRef
+    Base git ref for the diff. Defaults to `origin/main`.
+
+.PARAMETER HeadRef
+    Head git ref for the diff. Defaults to `HEAD`.
+
+.PARAMETER EvalRoot
+    Eval spec root relative to the repository root. Defaults to `evals`.
+
+.PARAMETER OutFile
+    Output JSON path. Defaults to `logs/changed-spec-stimuli.json`.
+
+.PARAMETER RepoRoot
+    Repository root. Defaults to the git toplevel.
+
+.EXAMPLE
+    pwsh -File scripts/evals/Get-ChangedSpecStimulus.ps1
+    Diff origin/main...HEAD and emit logs/changed-spec-stimuli.json.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$BaseRef = 'origin/main',
+
+    [Parameter(Mandatory = $false)]
+    [string]$HeadRef = 'HEAD',
+
+    [Parameter(Mandatory = $false)]
+    [string]$EvalRoot = 'evals',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutFile,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Modules/ChangedSpecStimulus.psm1') -Force
+
+function Resolve-RepoRoot {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([string]$Hint)
+
+    if (-not [string]::IsNullOrWhiteSpace($Hint)) {
+        return (Resolve-Path -LiteralPath $Hint).ProviderPath
+    }
+
+    try {
+        $gitRoot = git rev-parse --show-toplevel 2>$null
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+            return (Resolve-Path -LiteralPath $gitRoot.Trim()).ProviderPath
+        }
+    }
+    catch {
+        $null = $_
+    }
+
+    return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '../..')).ProviderPath
+}
+
+$resolvedRepoRoot = Resolve-RepoRoot -Hint $RepoRoot
+
+if ([string]::IsNullOrWhiteSpace($OutFile)) {
+    $OutFile = Join-Path -Path $resolvedRepoRoot -ChildPath 'logs/changed-spec-stimuli.json'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutFile)) {
+    $OutFile = Join-Path -Path $resolvedRepoRoot -ChildPath $OutFile
+}
+
+try {
+    $artifacts = Get-ChangedSpecStimulusArtifact -BaseRef $BaseRef -HeadRef $HeadRef -RepoRoot $resolvedRepoRoot -EvalRoot $EvalRoot
+}
+catch {
+    Write-Error $_.Exception.Message
+    exit 2
+}
+
+$manifest = @{
+    baseRef   = $BaseRef
+    headRef   = $HeadRef
+    artifacts = @($artifacts)
+}
+
+$outDir = Split-Path -Path $OutFile -Parent
+if (-not [string]::IsNullOrWhiteSpace($outDir) -and -not (Test-Path -LiteralPath $outDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
+
+$manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $OutFile -Encoding UTF8
+
+Write-Host "Detected $($manifest.artifacts.Count) changed eval-spec stimulus artifact(s) between $BaseRef and $HeadRef."
+Write-Host "Manifest: $OutFile"
+exit 0

--- a/scripts/evals/Invoke-VallyEvals.ps1
+++ b/scripts/evals/Invoke-VallyEvals.ps1
@@ -31,6 +31,14 @@
     `logs/changed-ai-artifacts.json`. Resolved relative to the repository root
     when not absolute.
 
+.PARAMETER ChangedSpecManifestPath
+    Optional path to a synthetic-artifact manifest produced by
+    `Get-ChangedSpecStimulus.ps1`. Its entries (one per stimulus added or
+    modified in a changed eval spec) are unioned into the execution set, deduped
+    by `kind:artifactId`, so a changed test runs even when the underlying AI
+    artifact is unchanged (issue #2297). Resolved relative to the repository
+    root when not absolute. Ignored when empty or missing.
+
 .PARAMETER EvalRoot
     Filesystem path to the eval spec root. Defaults to `evals/`. Resolved
     relative to the repository root when not absolute.
@@ -95,6 +103,7 @@
 [CmdletBinding()]
 param(
     [string]$ManifestPath,
+    [string]$ChangedSpecManifestPath,
     [string]$EvalRoot,
     [string]$LogsDir,
     [ValidateSet('agent','prompt','instruction','skill')]
@@ -378,6 +387,38 @@ if ($null -ne $manifest -and $null -ne $manifest.artifacts) {
 $artifacts = @($artifacts | Where-Object {
     -not (Test-RepoRootArtifact -Kind ([string]$_.kind) -Path ([string]$_.path))
 })
+
+# Issue #2297: a stimulus added or modified in an otherwise-unchanged eval spec
+# does not appear in the changed-artifact manifest, so it would never execute.
+# Union in synthetic artifacts derived from changed specs (one per changed
+# stimulus backlink), deduped by `kind:artifactId` so a stimulus whose artifact
+# also changed runs only once. The existing run plan scopes each to its spec via
+# `--tag kind=slug`, keeping execution diff-scoped to the changed stimuli.
+if (-not [string]::IsNullOrWhiteSpace($ChangedSpecManifestPath)) {
+    $resolvedChangedSpec = Resolve-PathFromRoot -Path $ChangedSpecManifestPath -RepoRoot $resolvedRoot
+    if (Test-Path -LiteralPath $resolvedChangedSpec -PathType Leaf) {
+        $changedSpecManifest = Get-Content -LiteralPath $resolvedChangedSpec -Raw | ConvertFrom-Json
+        $synthetic = @()
+        if ($null -ne $changedSpecManifest -and $null -ne $changedSpecManifest.artifacts) {
+            $synthetic = @($changedSpecManifest.artifacts | Where-Object { [string]$_.status -ne 'D' })
+        }
+        if ($synthetic.Count -gt 0) {
+            $existingKeys = @{}
+            foreach ($existing in $artifacts) {
+                $existingKeys["$([string]$existing.kind):$([string]$existing.artifactId)"] = $true
+            }
+            $merged = [System.Collections.Generic.List[object]]::new()
+            foreach ($existing in $artifacts) { $merged.Add($existing) }
+            foreach ($candidate in $synthetic) {
+                $key = "$([string]$candidate.kind):$([string]$candidate.artifactId)"
+                if ($existingKeys.ContainsKey($key)) { continue }
+                $existingKeys[$key] = $true
+                $merged.Add($candidate)
+            }
+            $artifacts = @($merged.ToArray())
+        }
+    }
+}
 
 # Per-kind shard filter. When -Kind is supplied, the stimulus artifacts[] loop
 # is narrowed to the matching kind(s) only. Baseline equivalence is cross-kind

--- a/scripts/evals/Modules/ChangedSpecStimulus.psm1
+++ b/scripts/evals/Modules/ChangedSpecStimulus.psm1
@@ -1,0 +1,342 @@
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# ChangedSpecStimulus.psm1
+#
+# Purpose: Resolve eval stimuli that were added or modified in a pull request's
+#          changed eval specs into synthetic artifact descriptors, so the
+#          PR-time eval executor runs a changed test even when the underlying
+#          AI artifact is unchanged (issue #2297).
+#
+#          A stimulus declares its artifact backlink via `tags.<kind>: <slug>`
+#          (kind in skill/agent/prompt/instruction). The executor already maps
+#          an artifact to its covering spec and scopes the run with
+#          `--tag kind=slug`, so emitting a synthetic `{ kind, artifactId }` for
+#          each changed stimulus reuses that machinery and keeps execution
+#          diff-scoped to the changed stimuli.
+# Author: HVE Core Team
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot 'StimulusIndex.psm1') -Force
+
+if (-not (Get-Module -ListAvailable -Name 'powershell-yaml')) {
+    throw "ChangedSpecStimulus requires the 'powershell-yaml' module."
+}
+Import-Module powershell-yaml -ErrorAction Stop
+
+function ConvertTo-CanonicalString {
+    <#
+    .SYNOPSIS
+    Serializes a parsed YAML value into an order-independent string for comparison.
+
+    .DESCRIPTION
+    Recursively sorts dictionary keys and serializes the result as compact JSON so
+    two semantically equal stimuli produce the same string regardless of key order.
+
+    .PARAMETER Value
+    A value produced by `ConvertFrom-Yaml` (dictionary, list, or scalar).
+
+    .OUTPUTS
+    [string] Canonical JSON representation.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([AllowNull()]$Value)
+
+    $normalized = ConvertTo-CanonicalObject -Value $Value
+    return ($normalized | ConvertTo-Json -Depth 32 -Compress)
+}
+
+function ConvertTo-CanonicalObject {
+    [CmdletBinding()]
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        $ordered = [ordered]@{}
+        foreach ($key in ($Value.Keys | Sort-Object { [string]$_ })) {
+            $ordered[[string]$key] = ConvertTo-CanonicalObject -Value $Value[$key]
+        }
+        return $ordered
+    }
+
+    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+        $list = [System.Collections.Generic.List[object]]::new()
+        foreach ($item in $Value) {
+            $list.Add((ConvertTo-CanonicalObject -Value $item))
+        }
+        return $list.ToArray()
+    }
+
+    return $Value
+}
+
+function Get-SpecStimulusSignatureMap {
+    <#
+    .SYNOPSIS
+    Maps each named stimulus in an eval spec to a canonical signature string.
+
+    .DESCRIPTION
+    Parses the supplied spec YAML and returns a hashtable of `name -> canonical
+    string` for every stimulus that declares a non-empty `name`. Empty input,
+    parse failures, and specs without a `stimuli` array yield an empty map so the
+    caller can treat them as "no stimuli".
+
+    .PARAMETER Yaml
+    The full eval-spec YAML text.
+
+    .OUTPUTS
+    [hashtable] `@{ <stimulus-name> = <canonical-string> }`.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([AllowNull()][AllowEmptyString()][string]$Yaml)
+
+    $map = @{}
+    if ([string]::IsNullOrWhiteSpace($Yaml)) { return $map }
+
+    try {
+        $parsed = ConvertFrom-Yaml -Yaml $Yaml
+    }
+    catch {
+        Write-Verbose "Get-SpecStimulusSignatureMap: parse failed: $($_.Exception.Message)"
+        return $map
+    }
+
+    if ($null -eq $parsed -or -not ($parsed -is [System.Collections.IDictionary])) { return $map }
+    if (-not $parsed.Contains('stimuli')) { return $map }
+    $stimuli = $parsed['stimuli']
+    if ($null -eq $stimuli -or -not ($stimuli -is [System.Collections.IEnumerable]) -or $stimuli -is [string]) { return $map }
+
+    foreach ($stimulus in $stimuli) {
+        if (-not ($stimulus -is [System.Collections.IDictionary])) { continue }
+        if (-not $stimulus.Contains('name')) { continue }
+        $name = [string]$stimulus['name']
+        if ([string]::IsNullOrWhiteSpace($name)) { continue }
+        $map[$name] = ConvertTo-CanonicalString -Value $stimulus
+    }
+
+    return $map
+}
+
+function Get-ChangedStimulusName {
+    <#
+    .SYNOPSIS
+    Returns the names of stimuli added or modified between a base and head spec.
+
+    .DESCRIPTION
+    Compares two signature maps (from `Get-SpecStimulusSignatureMap`) and returns
+    every name present in head that is absent from base (added) or whose canonical
+    signature differs (modified). Deletions are intentionally ignored: a removed
+    stimulus has nothing to execute.
+
+    .PARAMETER BaseMap
+    Signature map of the base (pre-change) spec.
+
+    .PARAMETER HeadMap
+    Signature map of the head (post-change) spec.
+
+    .OUTPUTS
+    [string[]] Names of added or modified stimuli.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)][hashtable]$BaseMap,
+        [Parameter(Mandatory)][hashtable]$HeadMap
+    )
+
+    $changed = [System.Collections.Generic.List[string]]::new()
+    foreach ($name in $HeadMap.Keys) {
+        if (-not $BaseMap.ContainsKey($name)) {
+            $changed.Add($name)
+            continue
+        }
+        if ([string]$HeadMap[$name] -ne [string]$BaseMap[$name]) {
+            $changed.Add($name)
+        }
+    }
+
+    return , [string[]]$changed.ToArray()
+}
+
+function Get-StimulusBacklinkForName {
+    <#
+    .SYNOPSIS
+    Extracts the artifact backlinks for a named subset of stimuli in a spec.
+
+    .DESCRIPTION
+    Parses the head spec YAML and, for each requested stimulus name, returns its
+    `tags.<kind>` backlinks via the shared `Get-StimulusBacklink` helper. Stimuli
+    without a backlink are skipped: there is no `kind=slug` tag to scope a run, so
+    they cannot be diff-scoped and are out of scope for this resolver.
+
+    .PARAMETER Yaml
+    The head eval-spec YAML text.
+
+    .PARAMETER Name
+    The stimulus names to resolve.
+
+    .OUTPUTS
+    [hashtable[]] Each entry is `@{ kind; slug; name }`.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param(
+        [AllowNull()][AllowEmptyString()][string]$Yaml,
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Name
+    )
+
+    $results = [System.Collections.Generic.List[hashtable]]::new()
+    if ([string]::IsNullOrWhiteSpace($Yaml) -or $Name.Count -eq 0) { return , $results.ToArray() }
+
+    try {
+        $parsed = ConvertFrom-Yaml -Yaml $Yaml
+    }
+    catch {
+        Write-Verbose "Get-StimulusBacklinkForName: parse failed: $($_.Exception.Message)"
+        return , $results.ToArray()
+    }
+
+    if ($null -eq $parsed -or -not ($parsed -is [System.Collections.IDictionary])) { return , $results.ToArray() }
+    if (-not $parsed.Contains('stimuli')) { return , $results.ToArray() }
+    $stimuli = $parsed['stimuli']
+    if ($null -eq $stimuli -or -not ($stimuli -is [System.Collections.IEnumerable]) -or $stimuli -is [string]) { return , $results.ToArray() }
+
+    $wanted = @{}
+    foreach ($n in $Name) { $wanted[$n] = $true }
+
+    foreach ($stimulus in $stimuli) {
+        if (-not ($stimulus -is [System.Collections.IDictionary])) { continue }
+        if (-not $stimulus.Contains('name')) { continue }
+        $stimName = [string]$stimulus['name']
+        if (-not $wanted.ContainsKey($stimName)) { continue }
+
+        foreach ($link in (Get-StimulusBacklink -Stimulus $stimulus)) {
+            if ($null -eq $link) { continue }
+            $results.Add(@{ kind = [string]$link['kind']; slug = [string]$link['slug']; name = $stimName })
+        }
+    }
+
+    return , $results.ToArray()
+}
+
+function Get-ChangedSpecStimulusArtifact {
+    <#
+    .SYNOPSIS
+    Resolves changed eval-spec stimuli into synthetic artifact descriptors.
+
+    .DESCRIPTION
+    Diffs `EvalRoot` between two git refs, and for each changed spec compares the
+    base and head stimulus signatures to find added or modified stimuli. Each
+    changed stimulus's `tags.<kind>: <slug>` backlink becomes a synthetic artifact
+    `@{ kind; artifactId; path; status; stimulusName; source }` that the executor
+    runs scoped to that stimulus. Results are deduplicated by `kind:artifactId`.
+
+    .PARAMETER BaseRef
+    Base git ref for the diff. Defaults to `origin/main`.
+
+    .PARAMETER HeadRef
+    Head git ref for the diff. Defaults to `HEAD`. Change detection uses the
+    three-dot `BaseRef...HeadRef` diff (matching `Get-ChangedAIArtifact.ps1`), so
+    the head change must be committed (as it always is for a PR head).
+
+    .PARAMETER RepoRoot
+    Repository root. Defaults to `git rev-parse --show-toplevel`.
+
+    .PARAMETER EvalRoot
+    Eval spec root relative to the repository root. Defaults to `evals`.
+
+    .PARAMETER GitCommand
+    Path or name of the git executable. Defaults to `git`. Overridable for tests.
+
+    .OUTPUTS
+    [hashtable[]] Synthetic artifact descriptors.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable[]])]
+    param(
+        [string]$BaseRef = 'origin/main',
+        [string]$HeadRef = 'HEAD',
+        [string]$RepoRoot,
+        [string]$EvalRoot = 'evals',
+        [string]$GitCommand = 'git'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        $top = & $GitCommand rev-parse --show-toplevel 2>$null
+        $RepoRoot = if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($top)) {
+            (Resolve-Path -LiteralPath $top.Trim()).ProviderPath
+        }
+        else {
+            (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '../../..')).ProviderPath
+        }
+    }
+
+    $evalPrefix = ($EvalRoot.TrimEnd('/', '\') -replace '\\', '/') + '/'
+
+    Push-Location -LiteralPath $RepoRoot
+    try {
+        $diff = & $GitCommand diff --name-only "$BaseRef...$HeadRef" -- $EvalRoot 2>&1
+        $exit = $LASTEXITCODE
+        if ($exit -ne 0) {
+            throw "git diff failed (exit $exit): $($diff -join [Environment]::NewLine)"
+        }
+
+        $specFiles = @($diff |
+                Where-Object { $_ -is [string] -and -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { ($_ -replace '\\', '/').Trim() } |
+                Where-Object { $_ -match '\.ya?ml$' -and $_.StartsWith($evalPrefix) })
+
+        $artifacts = [System.Collections.Generic.List[hashtable]]::new()
+        $seen = @{}
+
+        foreach ($spec in $specFiles) {
+            $headPath = Join-Path -Path $RepoRoot -ChildPath $spec
+            if (-not (Test-Path -LiteralPath $headPath -PathType Leaf)) { continue }
+            $headYaml = Get-Content -LiteralPath $headPath -Raw -Encoding utf8
+
+            $baseYaml = & $GitCommand show "$BaseRef`:$spec" 2>$null
+            if ($LASTEXITCODE -ne 0) { $baseYaml = '' }
+            else { $baseYaml = ($baseYaml -join [Environment]::NewLine) }
+
+            $baseMap = Get-SpecStimulusSignatureMap -Yaml $baseYaml
+            $headMap = Get-SpecStimulusSignatureMap -Yaml $headYaml
+            $changedNames = Get-ChangedStimulusName -BaseMap $baseMap -HeadMap $headMap
+            if ($changedNames.Count -eq 0) { continue }
+
+            foreach ($link in (Get-StimulusBacklinkForName -Yaml $headYaml -Name $changedNames)) {
+                $kind = [string]$link['kind']
+                $slug = [string]$link['slug']
+                if ([string]::IsNullOrWhiteSpace($kind) -or [string]::IsNullOrWhiteSpace($slug)) { continue }
+                $key = "$kind`:$slug"
+                if ($seen.ContainsKey($key)) { continue }
+                $seen[$key] = $true
+                $artifacts.Add(@{
+                        kind         = $kind
+                        artifactId   = $slug
+                        path         = $spec
+                        status       = 'M'
+                        stimulusName = [string]$link['name']
+                        source       = 'changed-spec'
+                    })
+            }
+        }
+
+        return , $artifacts.ToArray()
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-SpecStimulusSignatureMap',
+    'Get-ChangedStimulusName',
+    'Get-StimulusBacklinkForName',
+    'Get-ChangedSpecStimulusArtifact'
+)

--- a/scripts/tests/evals/ChangedSpecStimulus.Tests.ps1
+++ b/scripts/tests/evals/ChangedSpecStimulus.Tests.ps1
@@ -1,0 +1,371 @@
+#Requires -Modules Pester
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+BeforeAll {
+    $script:ModulePath = Join-Path $PSScriptRoot '../../evals/Modules/ChangedSpecStimulus.psm1'
+    $script:ExecutorPath = Join-Path $PSScriptRoot '../../evals/Invoke-VallyEvals.ps1'
+    $script:ResolverScript = Join-Path $PSScriptRoot '../../evals/Get-ChangedSpecStimulus.ps1'
+    $script:StubPath = Join-Path $PSScriptRoot 'fixtures/stub-vally.ps1'
+
+    Import-Module $script:ModulePath -Force
+    if (-not (Get-Module -ListAvailable -Name 'powershell-yaml')) {
+        throw "Tests require the 'powershell-yaml' module to be installed."
+    }
+    Import-Module powershell-yaml -ErrorAction Stop
+
+    function New-StimulusSpec {
+        param([string[]]$Stimuli)
+        return @"
+name: changed-spec-fixture
+type: capability
+defaults:
+  executor: copilot-sdk
+stimuli:
+$($Stimuli -join "`n")
+"@
+    }
+
+    function New-PromptStimulus {
+        param(
+            [string]$Name,
+            [string]$Slug,
+            [string]$Pattern = 'VEX'
+        )
+        return @"
+  - name: $Name
+    prompt: |
+      Invoke the prompt with minimal arguments.
+    tags:
+      category: behavior-conformance
+      prompt: $Slug
+      advisory: "true"
+    graders:
+      - type: output-matches
+        name: scope-language
+        config:
+          pattern: "(?i)$Pattern"
+"@
+    }
+}
+
+Describe 'ChangedSpecStimulus pure functions' -Tag 'Unit' {
+
+    Context 'Get-SpecStimulusSignatureMap' {
+        It 'Returns an empty map for empty or whitespace input' {
+            (Get-SpecStimulusSignatureMap -Yaml '').Count | Should -Be 0
+            (Get-SpecStimulusSignatureMap -Yaml "   `n  ").Count | Should -Be 0
+        }
+
+        It 'Returns an empty map when there is no stimuli array' {
+            (Get-SpecStimulusSignatureMap -Yaml "name: noop").Count | Should -Be 0
+        }
+
+        It 'Maps each named stimulus to a signature' {
+            $yaml = New-StimulusSpec -Stimuli @(
+                (New-PromptStimulus -Name 'prompt-a-conformance' -Slug 'a'),
+                (New-PromptStimulus -Name 'prompt-b-conformance' -Slug 'b')
+            )
+            $map = Get-SpecStimulusSignatureMap -Yaml $yaml
+            $map.Count | Should -Be 2
+            $map.ContainsKey('prompt-a-conformance') | Should -BeTrue
+            $map.ContainsKey('prompt-b-conformance') | Should -BeTrue
+        }
+
+        It 'Skips stimuli without a name' {
+            $yaml = @"
+name: x
+stimuli:
+  - prompt: no-name-here
+    tags:
+      prompt: orphan
+"@
+            (Get-SpecStimulusSignatureMap -Yaml $yaml).Count | Should -Be 0
+        }
+    }
+
+    Context 'Get-ChangedStimulusName' {
+        It 'Detects an added stimulus' {
+            $base = @{ 'a' = 'sig-a' }
+            $head = @{ 'a' = 'sig-a'; 'b' = 'sig-b' }
+            $changed = Get-ChangedStimulusName -BaseMap $base -HeadMap $head
+            $changed | Should -Be @('b')
+        }
+
+        It 'Detects a modified stimulus by signature change' {
+            $base = @{ 'a' = 'sig-a-old' }
+            $head = @{ 'a' = 'sig-a-new' }
+            $changed = Get-ChangedStimulusName -BaseMap $base -HeadMap $head
+            $changed | Should -Be @('a')
+        }
+
+        It 'Ignores unchanged stimuli' {
+            $base = @{ 'a' = 'sig-a'; 'b' = 'sig-b' }
+            $head = @{ 'a' = 'sig-a'; 'b' = 'sig-b' }
+            (Get-ChangedStimulusName -BaseMap $base -HeadMap $head).Count | Should -Be 0
+        }
+
+        It 'Ignores deletions (present in base, absent in head)' {
+            $base = @{ 'a' = 'sig-a'; 'b' = 'sig-b' }
+            $head = @{ 'a' = 'sig-a' }
+            (Get-ChangedStimulusName -BaseMap $base -HeadMap $head).Count | Should -Be 0
+        }
+    }
+
+    Context 'Signature stability' {
+        It 'Produces identical signatures regardless of tag key order' {
+            $yamlA = @"
+name: x
+stimuli:
+  - name: s
+    prompt: hi
+    tags:
+      category: behavior-conformance
+      prompt: slug
+      advisory: "true"
+"@
+            $yamlB = @"
+name: x
+stimuli:
+  - name: s
+    prompt: hi
+    tags:
+      advisory: "true"
+      prompt: slug
+      category: behavior-conformance
+"@
+            $a = Get-SpecStimulusSignatureMap -Yaml $yamlA
+            $b = Get-SpecStimulusSignatureMap -Yaml $yamlB
+            [string]$a['s'] | Should -Be ([string]$b['s'])
+        }
+
+        It 'Produces a different signature when a grader pattern changes' {
+            $yamlA = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 's' -Slug 'slug' -Pattern 'VEX'))
+            $yamlB = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 's' -Slug 'slug' -Pattern 'OpenVEX'))
+            $a = Get-SpecStimulusSignatureMap -Yaml $yamlA
+            $b = Get-SpecStimulusSignatureMap -Yaml $yamlB
+            [string]$a['s'] | Should -Not -Be ([string]$b['s'])
+        }
+    }
+
+    Context 'Get-StimulusBacklinkForName' {
+        It 'Resolves backlinks for named stimuli only' {
+            $yaml = New-StimulusSpec -Stimuli @(
+                (New-PromptStimulus -Name 'prompt-a-conformance' -Slug 'a'),
+                (New-PromptStimulus -Name 'prompt-b-conformance' -Slug 'b')
+            )
+            $links = Get-StimulusBacklinkForName -Yaml $yaml -Name @('prompt-a-conformance')
+            @($links).Count | Should -Be 1
+            $links[0].kind | Should -Be 'prompt'
+            $links[0].slug | Should -Be 'a'
+            $links[0].name | Should -Be 'prompt-a-conformance'
+        }
+
+        It 'Skips a changed stimulus that has no backlink tag' {
+            $yaml = @"
+name: x
+stimuli:
+  - name: no-backlink
+    prompt: hi
+    tags:
+      category: behavior-conformance
+"@
+            (Get-StimulusBacklinkForName -Yaml $yaml -Name @('no-backlink')).Count | Should -Be 0
+        }
+
+        It 'Returns empty when no names are requested' {
+            $yaml = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 's' -Slug 'slug'))
+            (Get-StimulusBacklinkForName -Yaml $yaml -Name @()).Count | Should -Be 0
+        }
+    }
+}
+
+Describe 'Get-ChangedSpecStimulusArtifact (git integration)' -Tag 'Integration' {
+    BeforeEach {
+        $script:Repo = Join-Path $TestDrive ('repo-' + [Guid]::NewGuid())
+        New-Item -ItemType Directory -Path $script:Repo -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:Repo 'evals/behavior-conformance') -Force | Out-Null
+
+        Push-Location $script:Repo
+        git init --quiet 2>&1 | Out-Null
+        git config user.email 'test@example.com' 2>&1 | Out-Null
+        git config user.name 'Test' 2>&1 | Out-Null
+        git config commit.gpgsign false 2>&1 | Out-Null
+        Pop-Location
+    }
+
+    AfterEach {
+        if (Test-Path -LiteralPath $script:Repo) {
+            Remove-Item -LiteralPath $script:Repo -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Emits a synthetic artifact for a newly added stimulus' {
+        $specRel = 'evals/behavior-conformance/prompts.eval.yaml'
+        $specAbs = Join-Path $script:Repo $specRel
+
+        $base = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 'prompt-existing-conformance' -Slug 'existing'))
+        Set-Content -LiteralPath $specAbs -Value $base -Encoding utf8
+
+        Push-Location $script:Repo
+        try {
+            git add -A 2>&1 | Out-Null
+            git commit -m 'base' --quiet 2>&1 | Out-Null
+            $baseSha = (git rev-parse HEAD).Trim()
+
+            # Head: add a new stimulus and commit it (PR head is always committed).
+            $head = New-StimulusSpec -Stimuli @(
+                (New-PromptStimulus -Name 'prompt-existing-conformance' -Slug 'existing'),
+                (New-PromptStimulus -Name 'prompt-vex-scan-conformance' -Slug 'vex-scan')
+            )
+            Set-Content -LiteralPath $specAbs -Value $head -Encoding utf8
+            git add -A 2>&1 | Out-Null
+            git commit -m 'add stimulus' --quiet 2>&1 | Out-Null
+
+            $artifacts = Get-ChangedSpecStimulusArtifact -BaseRef $baseSha -HeadRef 'HEAD' -RepoRoot $script:Repo -EvalRoot 'evals'
+        }
+        finally {
+            Pop-Location
+        }
+
+        @($artifacts).Count | Should -Be 1
+        $artifacts[0].kind | Should -Be 'prompt'
+        $artifacts[0].artifactId | Should -Be 'vex-scan'
+        $artifacts[0].source | Should -Be 'changed-spec'
+        $artifacts[0].path | Should -Be $specRel
+    }
+
+    It 'Does not emit an artifact when only non-stimulus content changes' {
+        $specRel = 'evals/behavior-conformance/prompts.eval.yaml'
+        $specAbs = Join-Path $script:Repo $specRel
+
+        $base = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 'prompt-existing-conformance' -Slug 'existing'))
+        Set-Content -LiteralPath $specAbs -Value $base -Encoding utf8
+
+        Push-Location $script:Repo
+        try {
+            git add -A 2>&1 | Out-Null
+            git commit -m 'base' --quiet 2>&1 | Out-Null
+            $baseSha = (git rev-parse HEAD).Trim()
+
+            # Head: change only the top-level description, not any stimulus.
+            $head = $base -replace 'type: capability', "type: capability`ndescription: tweaked"
+            Set-Content -LiteralPath $specAbs -Value $head -Encoding utf8
+            git add -A 2>&1 | Out-Null
+            git commit -m 'tweak description' --quiet 2>&1 | Out-Null
+
+            $artifacts = Get-ChangedSpecStimulusArtifact -BaseRef $baseSha -HeadRef 'HEAD' -RepoRoot $script:Repo -EvalRoot 'evals'
+        }
+        finally {
+            Pop-Location
+        }
+
+        @($artifacts).Count | Should -Be 0
+    }
+}
+
+Describe 'Invoke-VallyEvals changed-spec union (integration)' -Tag 'Integration' {
+    BeforeEach {
+        Remove-Item Env:\STUB_VALLY_MODE -ErrorAction SilentlyContinue
+        $script:Root = Join-Path $TestDrive ('union-' + [Guid]::NewGuid())
+        $script:EvalRoot = Join-Path $script:Root 'evals'
+        $script:LogsDir = Join-Path $script:Root 'logs'
+        New-Item -ItemType Directory -Path $script:EvalRoot -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:LogsDir -Force | Out-Null
+
+        $spec = New-StimulusSpec -Stimuli @((New-PromptStimulus -Name 'prompt-vex-scan-conformance' -Slug 'vex-scan'))
+        Set-Content -LiteralPath (Join-Path $script:EvalRoot 'prompts.eval.yaml') -Value $spec -Encoding utf8
+
+        # Empty changed-artifact manifest: the underlying prompt did not change.
+        $script:ArtifactManifest = Join-Path $script:Root 'manifest.json'
+        @{ artifacts = @() } | ConvertTo-Json | Set-Content -LiteralPath $script:ArtifactManifest -Encoding utf8
+
+        $script:SummaryPath = Join-Path $script:LogsDir 'eval-summary.json'
+    }
+
+    AfterEach {
+        Remove-Item Env:\STUB_VALLY_MODE -ErrorAction SilentlyContinue
+    }
+
+    It 'Executes a changed-spec stimulus even when the artifact manifest is empty' {
+        $changedSpecManifest = Join-Path $script:Root 'changed-spec-stimuli.json'
+        @{
+            artifacts = @(
+                @{ kind = 'prompt'; artifactId = 'vex-scan'; path = 'evals/prompts.eval.yaml'; status = 'M'; source = 'changed-spec' }
+            )
+        } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $changedSpecManifest -Encoding utf8
+
+        $env:STUB_VALLY_MODE = 'pass'
+        try {
+            & pwsh -NoProfile -File $script:ExecutorPath `
+                -ManifestPath $script:ArtifactManifest `
+                -ChangedSpecManifestPath $changedSpecManifest `
+                -EvalRoot $script:EvalRoot `
+                -LogsDir $script:LogsDir `
+                -RepoRoot $script:Root `
+                -VallyCommand $script:StubPath `
+                -SkipInputModeration -SkipOutputModeration *> $null
+        }
+        finally {
+            Remove-Item Env:\STUB_VALLY_MODE -ErrorAction SilentlyContinue
+        }
+        $LASTEXITCODE | Should -Be 0
+
+        $summary = Get-Content -LiteralPath $script:SummaryPath -Raw | ConvertFrom-Json
+        $summary.totals.artifacts | Should -Be 1
+        $summary.totals.specs | Should -Be 1
+        $summary.perArtifact[0].kind | Should -Be 'prompt'
+        $summary.perArtifact[0].artifactId | Should -Be 'vex-scan'
+    }
+
+    It 'Writes an empty summary when neither the artifact nor the changed-spec manifest has entries' {
+        $changedSpecManifest = Join-Path $script:Root 'changed-spec-stimuli.json'
+        @{ artifacts = @() } | ConvertTo-Json | Set-Content -LiteralPath $changedSpecManifest -Encoding utf8
+
+        & pwsh -NoProfile -File $script:ExecutorPath `
+            -ManifestPath $script:ArtifactManifest `
+            -ChangedSpecManifestPath $changedSpecManifest `
+            -EvalRoot $script:EvalRoot `
+            -LogsDir $script:LogsDir `
+            -RepoRoot $script:Root `
+            -VallyCommand $script:StubPath *> $null
+        $LASTEXITCODE | Should -Be 0
+
+        $summary = Get-Content -LiteralPath $script:SummaryPath -Raw | ConvertFrom-Json
+        $summary.totals.artifacts | Should -Be 0
+    }
+
+    It 'Does not double-run when a changed-spec artifact is already in the artifact manifest' {
+        @{
+            artifacts = @(
+                @{ kind = 'prompt'; artifactId = 'vex-scan'; path = '.github/prompts/security/vex-scan.prompt.md'; status = 'M' }
+            )
+        } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $script:ArtifactManifest -Encoding utf8
+
+        $changedSpecManifest = Join-Path $script:Root 'changed-spec-stimuli.json'
+        @{
+            artifacts = @(
+                @{ kind = 'prompt'; artifactId = 'vex-scan'; path = 'evals/prompts.eval.yaml'; status = 'M'; source = 'changed-spec' }
+            )
+        } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $changedSpecManifest -Encoding utf8
+
+        $env:STUB_VALLY_MODE = 'pass'
+        try {
+            & pwsh -NoProfile -File $script:ExecutorPath `
+                -ManifestPath $script:ArtifactManifest `
+                -ChangedSpecManifestPath $changedSpecManifest `
+                -EvalRoot $script:EvalRoot `
+                -LogsDir $script:LogsDir `
+                -RepoRoot $script:Root `
+                -VallyCommand $script:StubPath `
+                -SkipInputModeration -SkipOutputModeration *> $null
+        }
+        finally {
+            Remove-Item Env:\STUB_VALLY_MODE -ErrorAction SilentlyContinue
+        }
+        $LASTEXITCODE | Should -Be 0
+
+        $summary = Get-Content -LiteralPath $script:SummaryPath -Raw | ConvertFrom-Json
+        $summary.totals.artifacts | Should -Be 1
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Eval execution selected which stimuli to run from the changed-AI-artifact manifest only, so a stimulus added or modified in an otherwise-unchanged eval spec was linted and coverage-checked but never executed against the model. A test you authored would only run the first time a PR happened to touch the underlying artifact.

This change closes that gap. A stimulus declares its artifact backlink via `tags.<kind>: <slug>`, and the executor already maps an artifact to its covering spec and scopes the run with `--tag kind=slug`. So rather than adding a parallel execution path, this PR derives synthetic artifact descriptors from the stimuli added or modified in changed eval specs and unions them into the executor's existing run plan. The result is diff-scoped execution — only the changed stimuli run — reusing the established tag-filtering machinery.

Concretely:

* A new `ChangedSpecStimulus` module diffs `evals/` between the base and head refs, compares per-stimulus canonical signatures to find added or modified stimuli, resolves each one's backlink, and emits a synthetic `{ kind, artifactId, path, status, source }` descriptor (deduplicated by `kind:artifactId`).
* A new `Get-ChangedSpecStimulus.ps1` wrapper writes that set to `logs/changed-spec-stimuli.json`, mirroring the existing changed-artifact manifest shape.
* `Invoke-VallyEvals.ps1` gains an optional `-ChangedSpecManifestPath` and unions those entries into its execution set, deduped against the changed-artifact manifest so a stimulus whose artifact also changed runs only once.
* The `eval-validation` workflow generates the changed-spec manifest and passes it to the execute step.

Stimuli without a backlink tag are intentionally skipped (there is no `kind=slug` to scope a run on), which keeps execution bounded and avoids re-running an entire aggregated spec. Advisory-tier semantics are unchanged.

## Related Issue(s)

Closes #2297

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Automated validation run locally:

* `npm run test:ps -- -TestPath scripts/tests/evals/ChangedSpecStimulus.Tests.ps1 -ExcludeTag Slow` — **18/18 pass** (unit signature/backlink logic, a real-git resolver integration test, and executor-union integration tests including the dedupe and empty-manifest cases). The key regression — executing a changed-spec stimulus when the changed-artifact manifest is empty — is covered directly.
* `npm run test:ps -- -TestPath scripts/tests/evals/Invoke-VallyEvals.Tests.ps1 -ExcludeTag Slow` — **61/61 pass** (no regression from the new `-ChangedSpecManifestPath` parameter and union).
* `npm run lint:ps` — **PASS** (PSScriptAnalyzer clean on new and modified scripts).
* `npm run lint:yaml` — **PASS** (actionlint on the modified workflow).
* `npm run lint:permissions` — **PASS** (100%).
* `npm run validate:copyright` — **PASS** (new files carry headers).

Manual testing was not performed; behavior is validated by the suites above. Live model execution of the new path runs in CI under the `Eval Execute` jobs.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — no documentation changes)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `/prompt-analyze` to review contribution (N/A — no AI artifact changes)
* [ ] Addressed all feedback from `prompt-builder` review (N/A — no AI artifact changes)
* [ ] Verified contribution follows common standards and type-specific requirements (N/A — no AI artifact changes)

### Required Automated Checks

The following validation commands must pass before merging:

* [ ] Markdown linting: `npm run lint:md` (N/A — no markdown changes)
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter` (N/A — no frontmatter files changed)
* [ ] Skill structure validation: `npm run validate:skills` (N/A — no skill changes)
* [ ] Link validation: `npm run lint:md-links` (N/A — no markdown changes)
* [x] PowerShell analysis: `npm run lint:ps`
* [ ] Eval spec schema and coverage (if AI artifacts changed): `npm run eval:lint:schema` (N/A — no AI artifacts or eval specs changed)
* [ ] Plugin freshness: `npm run plugin:generate` (N/A — no collection or plugin changes)
* [ ] Docusaurus tests: `npm run docs:test` (N/A — no docs changes)

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

* Files changed: `scripts/evals/Modules/ChangedSpecStimulus.psm1` (new), `scripts/evals/Get-ChangedSpecStimulus.ps1` (new), `scripts/evals/Invoke-VallyEvals.ps1` (new optional parameter + union), `.github/workflows/eval-validation.yml` (manifest generation + pass-through), and `scripts/tests/evals/ChangedSpecStimulus.Tests.ps1` (new).
* Design notes: change detection uses the three-dot `base...HEAD` diff (matching `Get-ChangedAIArtifact.ps1`); signatures are key-order-independent so cosmetic reordering does not force a re-run; the executor change is purely additive (an unused parameter leaves prior behavior unchanged).
* Follow-up from #2293 / #2294 (the VEX eval coverage fix that surfaced this gap).
