### PR TITLE
fix(ci): grant extension-provenance caller required write permissions

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -381,7 +381,10 @@ jobs:
       channel: Stable
       release-tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
 
   plugin-package-release:
     name: Package Plugins (Release)


### PR DESCRIPTION
## Description

The `Stable Release Pipeline` (`.github/workflows/release-stable.yml`) failed at startup with an invalid-workflow error, blocking all stable releases before any job could run.

The `extension-provenance` caller job granted only `contents: read`, but the reusable workflow it calls (`.github/workflows/extension-provenance.yml`) contains a nested `build-attest` job that requires `contents: write`, `id-token: write`, `attestations: write`, and `artifact-metadata: write`. GitHub Actions caps a reusable workflow's effective permissions at whatever the caller grants, so the nested job requested more than it was allowed and the workflow was rejected as invalid.

This change updates the caller job's `permissions` block to grant exactly the four permissions the reusable workflow needs. The prerelease pipeline already uses this same permission set on its equivalent attest job, so this brings the stable pipeline into alignment. Other reusable-workflow callers in the file that genuinely only need `contents: read` are unchanged.

## Related Issue(s)

Closes #2407

## Type of Change

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

* `npm run lint:permissions` — passed (100% compliance, 63/63 workflows, 0 violations).
* Verified the caller job's granted permissions now match the reusable `build-attest` job's required permissions (`contents: write`, `id-token: write`, `attestations: write`, `artifact-metadata: write`).
* Confirmed the other reusable-workflow callers in `release-stable.yml` (`plugin-package`, `spell-check`, `markdown-lint`, `table-format`) only require `contents: read` and were left unchanged.
* Manual pipeline execution was not performed; validation was limited to workflow-permissions linting and diff review.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

The permissions granted to the caller job are the minimum required by the reusable `build-attest` job; no broader scope was added. This aligns the stable pipeline with the existing prerelease pipeline's attest job, which already declares the same permission set.