### PR TITLE
fix(workflows): grant reusable-workflow caller jobs required permissions

### DIFF
--- a/.github/workflows/release-marketplace-prerelease.yml
+++ b/.github/workflows/release-marketplace-prerelease.yml
@@ -109,5 +109,6 @@ jobs:
       pre-release: true
     permissions:
       contents: read
+      attestations: read
       id-token: write
     secrets: inherit

--- a/.github/workflows/release-marketplace-stable.yml
+++ b/.github/workflows/release-marketplace-stable.yml
@@ -151,5 +151,6 @@ jobs:
       verify-attestation: true
     permissions:
       contents: read
+      attestations: read
       id-token: write
     secrets: inherit

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -381,7 +381,10 @@ jobs:
       channel: Stable
       release-tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
 
   plugin-package-release:
     name: Package Plugins (Release)

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -539,7 +539,10 @@ jobs:
       version: ${{ needs.release-please.outputs.tag_name }}
       sbom-artifact: sbom-dependencies
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
 
   verify-provenance:
     name: Verify Provenance

--- a/.github/workflows/weekly-gh-code-scanning.yml
+++ b/.github/workflows/weekly-gh-code-scanning.yml
@@ -30,4 +30,5 @@ jobs:
     uses: ./.github/workflows/create-gh-code-scanning-issues.yml
     permissions:
       issues: write
+      actions: read
       security-events: read


### PR DESCRIPTION
# Pull Request

## Description

Fixes the **Stable Release Pipeline** failing at startup with an **Invalid workflow file**
error. Reusable-workflow caller jobs must grant at least the permissions their nested jobs
request; several callers granted less, so GitHub rejected the workflow before any job ran.

Changes:

* `release-stable.yml`: the `extension-provenance` and `vex-attest` caller jobs now grant
  `contents: write`, `id-token: write`, `attestations: write`, and `artifact-metadata: write`,
  matching their reusable workflows' nested attest jobs.
* `release-marketplace-stable.yml` and `release-marketplace-prerelease.yml`: the `publish`
  caller job adds `attestations: read` required by `extension-marketplace-publish.yml`.
* `weekly-gh-code-scanning.yml`: the `create-gh-code-scanning-issues` caller job adds
  `actions: read` required by `create-gh-code-scanning-issues.yml`.

The top-level workflow `permissions` were already correct; the gaps were all at the caller
**job** level. An audit of every reusable-workflow caller across `.github/workflows/` confirms
no remaining mismatches.

## Related Issue(s)

closes #2423 

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

* Dispatched `release-stable.yml` on the fix branch via [`workflow_dispatch`](https://github.com/microsoft/hve-core/actions/runs/28917197827). Before the fix,
  runs ended in `startup_failure` with 0 jobs; after the fix, the run validated and scheduled
  35 jobs (release-gated jobs remain skipped without an actual release).
* `npm run lint:permissions` passes at 100% (63/63).
* Repo-wide audit comparing each reusable-workflow caller's granted permissions against its
  nested-job requirements reports no mismatches.
* Both edited files parse as valid YAML.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [x] Spell checking: `npm run spell-check`
* [x] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [ ] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

Least-privilege note: each caller job is granted only the permissions its reusable workflow's
nested jobs actually request (write for attestation/provenance jobs, read where sufficient),
with no broadening of the top-level workflow permissions.

## Additional Notes

The permission gaps were latent until the VEX/provenance reusable workflows were wired into the
release pipelines. Consider adding the reusable-caller permission audit to `lint:all` to catch
this class of mismatch before it reaches CI.