### PR TITLE
docs: sync release pipeline docs with current provenance workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 title: GitHub Actions Workflows
 description: Modular CI/CD workflow architecture for validation, security scanning, and automated maintenance
 author: HVE Core Team
-ms.date: 2026-06-27
+ms.date: 2026-07-08
 ms.topic: reference
 keywords:
   - github actions
@@ -50,13 +50,13 @@ Compose multiple reusable workflows for comprehensive validation and security sc
 | Workflow                          | Triggers                                | Jobs                                                                                                                                 | Mode                       | Purpose                              |
 |-----------------------------------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------------------|--------------------------------------|
 | `pr-validation.yml`               | PR to main/develop (open, push, reopen) | 31 jobs (29 validation jobs + `pr-validation-success` gate + `gate-completeness-check`); `pr-validation-success` is the merge signal | Strict validation          | Pre-merge quality gate with security |
-| `release-stable.yml`              | Push to main                            | 5 jobs (5 reusable workflows)                                                                                                        | Strict mode, SARIF uploads | Post-merge validation                |
+| `release-stable.yml`              | Push to main                            | 23 jobs                                                                                                                              | Strict mode, SARIF uploads | Post-merge validation                |
 | `weekly-security-maintenance.yml` | Schedule (Sun 2AM UTC)                  | 4 (validate-pinning, check-staleness, codeql-analysis, summary)                                                                      | Soft-fail warnings         | Weekly security posture              |
 | `scorecard.yml`                   | Push to main, Schedule (Sun 3AM UTC)    | 1 (scorecard)                                                                                                                        | SARIF upload               | OpenSSF Scorecard security posture   |
 
 pr-validation.yml jobs: 29 validation jobs feed a single `pr-validation-success` aggregator gate, which is the only required status check that gates merge; a `gate-completeness-check` job verifies every validation job is wired into that gate's `needs:` list.
 
-release-stable.yml jobs: spell-check, markdown-lint, table-format, codeql-analysis, dependency-pinning-scan
+release-stable.yml jobs: spell-check, markdown-lint, table-format, dependency-pinning-scan, action-version-consistency-scan, gitleaks-scan, pester-tests, docusaurus-tests, discover-python-projects, python-lint, pytest, release-please, close-milestone, reset-prerelease, generate-dependency-sbom, plugin-package-release, extension-provenance, upload-plugin-packages, vex-attest, sbom-diff, verify-provenance, append-verification-notes, publish-release
 
 ## Reusable Workflows
 
@@ -233,11 +233,12 @@ Outputs: SARIF results uploaded to GitHub Security tab, job summary with badge l
 
 **Previous Behavior:** CodeQL previously ran as both a standalone workflow (on PR/push events) AND within orchestrator workflows, causing duplicate analyses on the same commits and wasting GitHub Actions minutes.
 
-**Current Architecture:** CodeQL now runs exclusively through orchestrator workflows to prevent duplicate runs and ensure consistent security scanning:
+**Current Architecture:** CodeQL now runs through dedicated entrypoint workflows to prevent duplicate runs and ensure consistent security scanning:
 
 * CodeQL PR validation: Runs via `pr-validation.yml` on all PR activity (open, push, reopen)
-* Main branch: Runs via `release-stable.yml` on every push to main
+* Main branch: Runs via `security-scan.yml` on pushes to `main` and `develop`, which calls the reusable workflow `codeql-analysis.yml`
 * Weekly scan: Standalone scheduled run every Sunday at 4 AM UTC for continuous security monitoring
+* `release-stable.yml` does not run CodeQL
 
 This architecture ensures:
 
@@ -248,13 +249,13 @@ This architecture ensures:
 
 Workflow Execution Matrix:
 
-| Event                                | Workflows That Run                                       | CodeQL Included     |
-|--------------------------------------|----------------------------------------------------------|---------------------|
-| Open PR to main/develop              | `pr-validation.yml` (31 jobs)                            | ✅  Yes              |
-| Push to PR branch                    | `pr-validation.yml` (31 jobs)                            | ✅  Yes              |
-| Merge to main                        | `release-stable.yml` (5 jobs)                            | ✅  Yes              |
-| Sunday 4AM UTC                       | `codeql-analysis.yml`, `weekly-security-maintenance.yml` | ✅  Yes (standalone) |
-| Feature branch push (no open PR)[^1] | None                                                     | ❌  No               |
+| Event                                | Workflows That Run                                          | CodeQL Included                                          |
+|--------------------------------------|-------------------------------------------------------------|----------------------------------------------------------|
+| Open PR to main/develop              | `pr-validation.yml` (31 jobs)                               | ✅ Yes                                                    |
+| Push to PR branch                    | `pr-validation.yml` (31 jobs)                               | ✅ Yes                                                    |
+| Merge to main                        | `release-stable.yml` (23 jobs), `security-scan.yml` (1 job) | ✅ Yes (via `security-scan.yml` -> `codeql-analysis.yml`) |
+| Sunday 4AM UTC                       | `codeql-analysis.yml`, `weekly-security-maintenance.yml`    | ✅ Yes (standalone)                                       |
+| Feature branch push (no open PR)[^1] | None                                                        | ❌ No                                                     |
 
 [^1]: Feature branches without an open PR are not validated. Open a PR to main or develop to trigger validation workflows.
 

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -3,7 +3,7 @@ title: Build Workflows
 description: GitHub Actions CI/CD pipeline architecture for validation, security, and release automation
 sidebar_position: 3
 author: WilliamBerryiii
-ms.date: 2026-06-30
+ms.date: 2026-07-08
 ms.topic: overview
 ---
 
@@ -189,23 +189,31 @@ flowchart LR
     V2[markdown-lint] --> RP
     V3[table-format] --> RP
     V4[dependency-pinning-scan] --> RP
-    V5[gitleaks-scan] --> RP
-    V6[pester-tests] --> RP
+    V5[action-version-consistency-scan] --> RP
+    V6[gitleaks-scan] --> RP
+    V7[pester-tests] --> RP
+    V8[docusaurus-tests] --> RP
+    V9[python-lint] --> RP
+    V10[pytest] --> RP
+    RP --> CM[close-milestone]
     RP --> RST[reset-prerelease]
-    RP -->|release_created| EPR[extension-package-release]
-    RP -->|release_created| PPR[plugin-package-release]
     RP -->|release_created| SBOM[generate-dependency-sbom]
-    EPR --> ATT[attest-and-upload]
-    SBOM --> ATT
+    RP -->|release_created| PPR[plugin-package-release]
+    SBOM --> EP[extension-provenance]
+    SBOM --> VX[vex-attest]
+    SBOM --> SD[sbom-diff]
     PPR --> UPP[upload-plugin-packages]
     SBOM --> UPP
-    SBOM --> AUV[attest-and-upload-vex]
-    SBOM --> SD[sbom-diff]
-    ATT --> AVN[append-verification-notes]
+    EP --> VP[verify-provenance]
+    UPP --> VP
+    VX --> VP
+    VP --> AVN[append-verification-notes]
+    EP --> AVN
     UPP --> AVN
-    ATT --> PUB[publish-release]
+    EP --> PUB[publish-release]
     UPP --> PUB
-    AUV --> PUB
+    VX --> PUB
+    VP --> PUB
     SD --> PUB
     AVN --> PUB
     style RP fill:#f9f,stroke:#333
@@ -215,29 +223,35 @@ Release-please v4 handles `chore`-type commits natively. They are not releasable
 
 ### Main Branch Jobs
 
-| Job                       | Purpose                                   | Dependencies                                                                                                           |
-|---------------------------|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| spell-check               | Post-merge spelling validation            | None                                                                                                                   |
-| markdown-lint             | Post-merge markdown validation            | None                                                                                                                   |
-| table-format              | Post-merge table validation               | None                                                                                                                   |
-| dependency-pinning-scan   | Security pinning check                    | None                                                                                                                   |
-| gitleaks-scan             | Secret detection scanning                 | None                                                                                                                   |
-| pester-tests              | PowerShell unit tests                     | None                                                                                                                   |
-| release-please            | Automated release management              | All validation jobs                                                                                                    |
-| reset-prerelease          | Reset pre-release tracking                | release-please                                                                                                         |
-| extension-package-release | Build release VSIX                        | release-please (conditional)                                                                                           |
-| plugin-package-release    | Build release plugin packages             | release-please (conditional)                                                                                           |
-| generate-dependency-sbom  | Generate dependency SBOM                  | release-please (conditional)                                                                                           |
-| attest-and-upload         | Sign and upload VSIX                      | release-please, extension-package-release, generate-dependency-sbom                                                    |
-| upload-plugin-packages    | Upload plugin packages                    | release-please, plugin-package-release, generate-dependency-sbom                                                       |
-| attest-and-upload-vex     | Attest and upload VEX document            | release-please, generate-dependency-sbom                                                                               |
-| sbom-diff                 | Compare SBOM changes                      | release-please, generate-dependency-sbom                                                                               |
-| append-verification-notes | Append artifact verification instructions | release-please, attest-and-upload, upload-plugin-packages                                                              |
-| publish-release           | Finalize GitHub Release                   | release-please, attest-and-upload, upload-plugin-packages, attest-and-upload-vex, sbom-diff, append-verification-notes |
+| Job                             | Purpose                                        | Dependencies                                                                                                                      |
+|---------------------------------|------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| spell-check                     | Post-merge spelling validation                 | None                                                                                                                              |
+| markdown-lint                   | Post-merge markdown validation                 | None                                                                                                                              |
+| table-format                    | Post-merge table validation                    | None                                                                                                                              |
+| dependency-pinning-scan         | Dependency pinning security check              | None                                                                                                                              |
+| action-version-consistency-scan | Action version consistency check               | None                                                                                                                              |
+| gitleaks-scan                   | Secret detection scanning                      | None                                                                                                                              |
+| pester-tests                    | PowerShell unit tests                          | None                                                                                                                              |
+| docusaurus-tests                | Docs site build and tests                      | None                                                                                                                              |
+| discover-python-projects        | Enumerate Python projects                      | None                                                                                                                              |
+| python-lint                     | Python lint (ruff)                             | discover-python-projects                                                                                                          |
+| pytest                          | Python unit tests                              | discover-python-projects                                                                                                          |
+| release-please                  | Automated release management                   | All validation jobs                                                                                                               |
+| close-milestone                 | Close the released milestone                   | release-please                                                                                                                    |
+| reset-prerelease                | Reset pre-release tracking                     | release-please                                                                                                                    |
+| generate-dependency-sbom        | Generate dependency SBOM                       | release-please                                                                                                                    |
+| plugin-package-release          | Build release plugin packages                  | release-please                                                                                                                    |
+| extension-provenance            | Build, sign, and attest release VSIX (SLSA L3) | release-please, generate-dependency-sbom                                                                                          |
+| upload-plugin-packages          | Upload plugin packages                         | release-please, plugin-package-release, generate-dependency-sbom                                                                  |
+| vex-attest                      | Attest and upload VEX document                 | release-please, generate-dependency-sbom                                                                                          |
+| sbom-diff                       | Compare SBOM changes                           | release-please, generate-dependency-sbom                                                                                          |
+| verify-provenance               | Verify extension, plugin, and VEX attestations | release-please, extension-provenance, upload-plugin-packages, vex-attest                                                          |
+| append-verification-notes       | Append artifact verification instructions      | release-please, extension-provenance, upload-plugin-packages, verify-provenance                                                   |
+| publish-release                 | Finalize GitHub Release                        | release-please, extension-provenance, upload-plugin-packages, vex-attest, verify-provenance, sbom-diff, append-verification-notes |
 
-When release-please creates a release, parallel jobs build the extension VSIX (`extension-package-release`), package plugin collections (`plugin-package-release`), and generate an SBOM (`generate-dependency-sbom`). The `attest-and-upload` job signs the VSIX with Sigstore attestation, `upload-plugin-packages` uploads collection artifacts, and `sbom-diff` compares dependency changes. The `publish-release` job finalizes the GitHub Release after all artifacts are ready.
+When release-please creates a release, parallel jobs generate an SBOM (`generate-dependency-sbom`) and package plugin collections (`plugin-package-release`). The `extension-provenance` reusable workflow then builds, signs, and attests the extension VSIX for SLSA Build Level 3, `upload-plugin-packages` uploads collection artifacts, and `sbom-diff` compares dependency changes. The `verify-provenance` job verifies the extension, plugin, and VEX attestations before the release is finalized.
 
-The `attest-and-upload-vex` job attests the VEX document (`security/vex/hve-core.openvex.json`) twice: a build-provenance attestation of the document, plus an in-toto attestation that binds the VEX statements as a predicate over the dependency SBOM. The `append-verification-notes` job adds artifact verification instructions to the release notes before `publish-release` finalizes the release.
+The `vex-attest` job attests the VEX document (`security/vex/hve-core.openvex.json`) twice: a build-provenance attestation of the document, plus an in-toto attestation that binds the VEX statements as a predicate over the dependency SBOM. The `append-verification-notes` job adds artifact verification instructions to the release notes before `publish-release` finalizes the release.
 
 ## Security Workflows
 

--- a/scripts/extension/README.md
+++ b/scripts/extension/README.md
@@ -2,7 +2,7 @@
 title: Extension Scripts
 description: PowerShell scripts for VS Code extension preparation, packaging, and collection discovery
 author: HVE Core Team
-ms.date: 2026-03-17
+ms.date: 2026-07-08
 ms.topic: reference
 keywords:
   - powershell
@@ -127,6 +127,66 @@ maturity rules.
 
 # Discover all collections for pre-release
 ./scripts/extension/Find-CollectionManifests.ps1 -Channel PreRelease
+```
+
+### `Resolve-VsixFile.ps1`
+
+Resolves the single `.vsix` file within a directory.
+
+Purpose: Return the one VSIX path in a directory, failing when zero or multiple
+`.vsix` files are present. Used by the `extension-provenance.yml` reusable
+workflow to locate the built VSIX before signing and attestation.
+
+#### Parameters
+
+* `-DirectoryPath` - Directory to search for a `.vsix` file (defaults to `$env:VSIX_DIRECTORY`)
+
+#### Usage
+
+```powershell
+# Resolve the VSIX in a directory
+./scripts/extension/Resolve-VsixFile.ps1 -DirectoryPath ./extension
+```
+
+### `Select-CollectionVsix.ps1`
+
+Selects the collection-specific VSIX from a set of candidate assets.
+
+Purpose: Pick the `.vsix` matching a collection ID from a directory of release
+assets. Used by the `extension-marketplace-publish.yml` reusable workflow to
+choose the correct collection artifact before publishing.
+
+#### Parameters
+
+* `-AssetDirectory` - Directory containing candidate assets (defaults to `$env:ASSET_DIRECTORY`)
+* `-CollectionId` - Collection ID to match (defaults to `$env:COLLECTION_ID`)
+
+#### Usage
+
+```powershell
+# Select the VSIX for a collection
+./scripts/extension/Select-CollectionVsix.ps1 -AssetDirectory ./dist -CollectionId hve-core
+```
+
+### `Export-AttestationBundle.ps1`
+
+Exports attestation files from an attestation bundle.
+
+Purpose: Extract the Sigstore and in-toto attestation files from a bundle to
+local paths. Used in the provenance flow to materialize attestation artifacts
+for verification and release upload.
+
+#### Parameters
+
+* `-BundlePath` - Path to the attestation bundle (defaults to `$env:BUNDLE_PATH`)
+* `-SigstorePath` - Output path for the Sigstore attestation (defaults to `$env:SIGSTORE_PATH`)
+* `-IntotoPath` - Output path for the in-toto attestation (defaults to `$env:INTOTO_PATH`)
+
+#### Usage
+
+```powershell
+# Export attestation files from a bundle
+./scripts/extension/Export-AttestationBundle.ps1 -BundlePath ./bundle.json -SigstorePath ./out.sigstore.json -IntotoPath ./out.intoto.jsonl
 ```
 
 ## npm Scripts

--- a/scripts/linting/README.md
+++ b/scripts/linting/README.md
@@ -2,7 +2,7 @@
 title: Linting Scripts
 description: PowerShell scripts for code quality validation and documentation checks
 author: HVE Core Team
-ms.date: 2026-06-30
+ms.date: 2026-07-08
 ms.topic: reference
 keywords:
   - powershell
@@ -521,14 +521,21 @@ Purpose: Execute Python test suites for all Python skills that include a `tests/
 
 The linting directory also contains these scripts that are not yet covered in the earlier sections:
 
-| Script                          | Purpose                                                                       |
-|---------------------------------|-------------------------------------------------------------------------------|
-| `Invoke-JsonLint.ps1`           | Validate strict JSON syntax using System.Text.Json                            |
-| `Validate-HookManifests.ps1`    | Validate collection-scoped hook manifests under `.github/hooks/`              |
-| `Validate-PlannerArtifacts.ps1` | Validate AI artifact footer and disclaimer presence in instruction templates  |
-| `Test-ModelReferences.ps1`      | Validate model references in agent and prompt files against the model catalog |
-| `Update-ModelCatalog.ps1`       | Refresh the model catalog from GitHub docs data                               |
-| `Format-MarkdownTables.ps1`     | Normalize markdown tables to the repository formatting convention             |
+| Script                             | Purpose                                                                                              |
+|------------------------------------|------------------------------------------------------------------------------------------------------|
+| `Invoke-JsonLint.ps1`              | Validate strict JSON syntax using System.Text.Json                                                   |
+| `Validate-HookManifests.ps1`       | Validate collection-scoped hook manifests under `.github/hooks/`                                     |
+| `Validate-PlannerArtifacts.ps1`    | Validate AI artifact footer and disclaimer presence in instruction templates                         |
+| `Test-ModelReferences.ps1`         | Validate model references in agent and prompt files against the model catalog                        |
+| `Test-ExtensionArtifactNaming.ps1` | Validate extension-vsix artifact producer and consumer naming across the extension release workflows |
+| `Update-ModelCatalog.ps1`          | Refresh the model catalog from GitHub docs data                                                      |
+| `Format-MarkdownTables.ps1`        | Normalize markdown tables to the repository formatting convention                                    |
+
+## npm Scripts
+
+| npm Script                       | Description                                                                                                            |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `lint:extension-artifact-naming` | Run `pwsh -NoProfile -File scripts/linting/Test-ExtensionArtifactNaming.ps1` to validate extension VSIX artifact names |
 
 ## Shared Module
 


### PR DESCRIPTION
# Pull Request

## Description

Sync four documentation surfaces with the current `release-stable.yml` release pipeline after PR #2388 / #2231 rewired VSIX and VEX attestation into isolated SLSA Build Level 3 reusable workflows. The docs still described the pre-rewrite job names, counts, and script inventory.

Changes:

* docs/architecture/workflows.md — Replaced the release Mermaid flowchart, the "Main Branch Jobs" table, and two prose paragraphs with the current 23-job pipeline. Removed `extension-package-release`, `attest-and-upload`, and `attest-and-upload-vex`; added `extension-provenance`, `vex-attest`, and `verify-provenance`.
* .github/workflows/README.md — Corrected the orchestrator row and job list from "5 jobs" to 23 jobs, updated the Workflow Execution Matrix "Merge to main" row, and fixed the CodeQL Execution Strategy to attribute main-branch CodeQL to `security-scan.yml` → `codeql-analysis.yml` (not `release-stable.yml`).
* scripts/extension/README.md — Documented the three new VSIX provenance scripts: `Resolve-VsixFile.ps1`, `Select-CollectionVsix.ps1`, `Export-AttestationBundle.ps1`.
* scripts/linting/README.md — Documented `Test-ExtensionArtifactNaming.ps1` and the `lint:extension-artifact-naming` npm script.

## Related Issue(s)

Closes #2252
Closes #2396
Closes #2397
Closes #2398

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `prompt-builder` agent and addressed all feedback
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Documentation-only change. Validated locally against the four edited files:

* `npm run lint:md` — 0 errors on all four files.
* `npm run format:tables` — normalized (no residual changes needed).
* Residual-reference check — 0 references to removed job names (`extension-package-release`, `attest-and-upload`, `attest-and-upload-vex`) remain in the edited files.
* Cross-checked every job name and dependency against the current `.github/workflows/release-stable.yml` (23 top-level jobs) and confirmed the three new extension scripts and the linting script exist on disk.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `/prompt-analyze` to review contribution
* [ ] Addressed all feedback from `prompt-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Automated Checks

The following validation commands must pass before merging:

* [x] Markdown linting: `npm run lint:md`
* [ ] Spell checking: `npm run spell-check`
* [ ] Frontmatter validation: `npm run lint:frontmatter`
* [ ] Skill structure validation: `npm run validate:skills`
* [x] Link validation: `npm run lint:md-links`
* [ ] PowerShell analysis: `npm run lint:ps`
* [ ] Eval spec schema and coverage (if AI artifacts changed): `npm run eval:lint:schema`
* [ ] Plugin freshness: `npm run plugin:generate`
* [ ] Docusaurus tests: `npm run docs:test`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

* Out-of-scope follow-up (not in this PR): `docs/security/security-model.md` (~L1406) still references a removed release job name; tracked separately.
