### PR TITLE
fix(scripts): wrap generated overview descriptions to satisfy MD013

### DIFF
--- a/scripts/docs/Modules/DocsHelpers.psm1
+++ b/scripts/docs/Modules/DocsHelpers.psm1
@@ -839,9 +839,10 @@ function New-AssetOverviewBody {
         Renders the overview ("What it does") region body for an asset.
 
     .DESCRIPTION
-        Returns the asset description collapsed to a single line, or a stable
-        fallback sentence when the asset declares no description. Shared by the
-        generator and the validator so the sync check renders identically.
+        Returns the normalized asset description wrapped at 500 characters on
+        word boundaries, or a stable fallback sentence when the asset declares
+        no description. Shared by the generator and the validator so the sync
+        check renders identically.
 
     .PARAMETER Model
         Page model from New-AssetPageModel.
@@ -858,7 +859,33 @@ function New-AssetOverviewBody {
     if ([string]::IsNullOrWhiteSpace($Model.Description)) {
         return 'This asset does not declare a description.'
     }
-    return ($Model.Description -replace '\r?\n', ' ').Trim()
+
+    $description = ($Model.Description -replace '\r?\n', ' ').Trim()
+    if ($description.Length -le 500) {
+        return $description
+    }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $remaining = $description
+    while ($remaining.Length -gt 500) {
+        $breakIndex = -1
+        for ($index = 500; $index -ge 0; $index--) {
+            if ([char]::IsWhiteSpace($remaining[$index])) {
+                $breakIndex = $index
+                break
+            }
+        }
+
+        if ($breakIndex -lt 1) {
+            break
+        }
+
+        $lines.Add($remaining.Substring(0, $breakIndex).TrimEnd())
+        $remaining = $remaining.Substring($breakIndex).TrimStart()
+    }
+
+    $lines.Add($remaining)
+    return $lines -join "`n"
 }
 
 Export-ModuleMember -Function @(

--- a/scripts/tests/docs/DocsHelpers.Tests.ps1
+++ b/scripts/tests/docs/DocsHelpers.Tests.ps1
@@ -557,6 +557,23 @@ Describe 'New-AssetOverviewBody' -Tag 'Unit' {
         New-AssetOverviewBody -Model $model | Should -Be 'First line Second line'
     }
 
+    It 'Preserves a description at the line length limit' {
+        $description = 'x' * 500
+        $model = [PSCustomObject]@{ Description = $description }
+        New-AssetOverviewBody -Model $model | Should -Be $description
+    }
+
+    It 'Wraps long prose on word boundaries within the line length limit' {
+        $description = (@('word') * 101) -join ' '
+        $model = [PSCustomObject]@{ Description = $description }
+
+        $lines = (New-AssetOverviewBody -Model $model) -split "`n"
+
+        $lines | Should -HaveCount 2
+        $lines | Where-Object { $_.Length -gt 500 } | Should -BeNullOrEmpty
+        $lines -join ' ' | Should -Be $description
+    }
+
     It 'Trims surrounding whitespace' {
         $model = [PSCustomObject]@{ Description = '  padded description  ' }
         New-AssetOverviewBody -Model $model | Should -Be 'padded description'


### PR DESCRIPTION
# fix(scripts): wrap generated overview descriptions to satisfy MD013

## Description

`New-AssetOverviewBody` in `scripts/docs/Modules/DocsHelpers.psm1` previously
collapsed the asset description to a single physical line. Skills with
descriptions longer than 500 characters caused `MD013/line-length` failures
in CI (first observed in PR #2420 with the `performance-slo-planner` skill).

This fix adds a word-boundary wrap loop that emits lines of at most 500
characters. Descriptions at or below the limit are returned unchanged. The
validator calls the same function, so the `[Sync]` check in `lint:asset-docs`
remains consistent with generated output.

## Related Issue(s)

Fixes #2536

## Type of Change

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)

**Infrastructure & Configuration:**

* [x] Script/automation (`.ps1`)

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

**Other:**

* [ ] Other (please describe):

## Testing

The fix was validated against the `rekhako:feat/performance-slo-planner` branch
(PR #2420), which introduced the first skill description long enough to trigger
the issue.

**Validation steps performed:**

1. Merged `rekhako-performance-slo-planner` into `fix/2536-asset-doc-gen-word-wrap` with `--no-commit --no-ff`.
2. Ran `npm run docs:generate` — generator reported 1 updated file (`performance-slo-planner.md`).
3. `npx markdownlint-cli2 docs/reference/skills/project-planning/performance-slo-planner.md` → **0 errors**.
4. `npm run lint:asset-docs` → **0 errors** for that file (sync check passes with new wrapped output).
5. `npm run test:ps -- -TestPath scripts/tests/docs/DocsHelpers.Tests.ps1` → **74 passed, 0 failed**, including the two new regression tests:
   - Boundary test: 500-character description is returned unchanged.
   - Wrap test: 505-character description is split to exactly 2 lines, each ≤ 500 characters, and text round-trips correctly.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`