### PR TITLE
fix(hooks): correct telemetry payload handling and cross-platform entry points

### DIFF
--- a/.github/hooks/shared/telemetry.json
+++ b/.github/hooks/shared/telemetry.json
@@ -6,7 +6,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -14,7 +14,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -22,7 +22,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -30,7 +30,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -38,7 +38,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -46,7 +46,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -54,7 +54,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -62,7 +62,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -70,7 +70,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -78,7 +78,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ]

--- a/.github/hooks/shared/telemetry.json
+++ b/.github/hooks/shared/telemetry.json
@@ -6,7 +6,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -14,7 +14,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -22,7 +22,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -30,7 +30,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -38,7 +38,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -46,7 +46,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -54,7 +54,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -62,7 +62,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -70,7 +70,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ],
@@ -78,7 +78,7 @@
       {
         "type": "command",
         "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
-        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "powershell": "pwsh -NoProfile -File .github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
         "timeoutSec": 10
       }
     ]

--- a/.github/hooks/shared/telemetry.json
+++ b/.github/hooks/shared/telemetry.json
@@ -74,6 +74,14 @@
         "timeoutSec": 10
       }
     ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": ".github/hooks/shared/telemetry/telemetry-collector.sh",
+        "powershell": ".github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "timeoutSec": 10
+      }
+    ],
     "preCompact": [
       {
         "type": "command",

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryClean.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryClean.ps1
@@ -39,12 +39,19 @@ $ErrorActionPreference = 'Stop'
 #region Resolve repo root
 # Match the collector and anchor on the caller's workspace: the script itself
 # may live outside the repo it cleans, so its location says nothing.
-$RepoRoot = $env:HVE_REPO_ROOT
-if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
-    try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
-}
-if (-not $RepoRoot) {
-    $RepoRoot = (Get-Location).Path
+# Only needed to build the default telemetry path; an explicit -Path makes the
+# whole lookup unnecessary, including the git subprocess.
+if (-not $Path) {
+    $RepoRoot = $env:HVE_REPO_ROOT
+    if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
+        try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
+    }
+    if (-not $RepoRoot) {
+        # ProviderPath, not .Path: the latter is PowerShell-qualified ('Work:\',
+        # 'HKLM:\SOFTWARE'). A non-filesystem provider survives this as a path with
+        # no drive qualifier, which the guard below rejects.
+        $RepoRoot = $PWD.ProviderPath
+    }
 }
 #endregion Resolve repo root
 
@@ -66,6 +73,21 @@ if (-not (Test-Path $CorePy)) {
 }
 
 $TelemetryDir = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking' 'telemetry' }
+
+# Hand Python a native absolute path. -Path may be relative or on a PSDrive, and
+# PowerShell does not sync [Environment]::CurrentDirectory with Set-Location, so
+# the child process would resolve a relative path against a different directory
+# than the one shown in the confirmation prompt below. Guarding the resolved path
+# covers both branches: a non-filesystem location leaves a drive-less path
+# ('HKEY_LOCAL_MACHINE\SOFTWARE\...') that Python would silently take as relative
+# to its own working directory and delete from there.
+$Provider = $null
+$TelemetryDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+    $TelemetryDir, [ref]$Provider, [ref]$null)
+if ($Provider.Name -ne 'FileSystem') {
+    Write-Error "Telemetry path resolved to '$TelemetryDir' on the $($Provider.Name) provider from location '$($PWD.Path)'; re-run from a filesystem directory, pass an absolute -Path, or set HVE_REPO_ROOT."
+    exit 1
+}
 
 # An explicit -Path narrows the scope. The generated launcher always passes
 # -AllDirs, so announce the override rather than silently widening or dropping
@@ -94,5 +116,14 @@ $CliArgs = @('clean')
 if ($UseAllDirs) { $CliArgs += '--all-dirs' }
 if ($DryRun) { $CliArgs += '--dry-run' }
 
+# Scope the variable to this call, as the bash wrapper's prefix assignment does:
+# leaking it would silently redirect the collector and report scripts for the
+# rest of the session.
+$PreviousTelemetryDir = $env:HVE_TELEMETRY_DIR
 $env:HVE_TELEMETRY_DIR = $TelemetryDir
-& $Python.Source $CorePy @CliArgs
+try {
+    & $Python.Source $CorePy @CliArgs
+}
+finally {
+    $env:HVE_TELEMETRY_DIR = $PreviousTelemetryDir
+}

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryClean.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryClean.ps1
@@ -17,7 +17,8 @@
     registry, plus the generated launchers, report, and registry in the HVE home
     directory.
 .PARAMETER Path
-    Telemetry directory. Default: <repo>/.copilot-tracking/telemetry
+    Telemetry directory. Scopes the cleanup to this directory alone, overriding
+    -AllDirs. Default: <repo>/.copilot-tracking/telemetry
 .PARAMETER DryRun
     List what would be removed without deleting anything.
 .PARAMETER Force
@@ -36,12 +37,14 @@ param(
 $ErrorActionPreference = 'Stop'
 
 #region Resolve repo root
+# Match the collector and anchor on the caller's workspace: the script itself
+# may live outside the repo it cleans, so its location says nothing.
 $RepoRoot = $env:HVE_REPO_ROOT
 if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
-    try { $RepoRoot = & git -C $PSScriptRoot rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
+    try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
 }
 if (-not $RepoRoot) {
-    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    $RepoRoot = (Get-Location).Path
 }
 #endregion Resolve repo root
 
@@ -62,12 +65,20 @@ if (-not (Test-Path $CorePy)) {
     exit 1
 }
 
-$TelemetryDir = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking/telemetry' }
+$TelemetryDir = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking' 'telemetry' }
+
+# An explicit -Path narrows the scope. The generated launcher always passes
+# -AllDirs, so announce the override rather than silently widening or dropping
+# a destructive scope flag.
+$UseAllDirs = [bool]$AllDirs -and -not $Path
+if ($AllDirs -and $Path) {
+    Write-Warning "Ignoring -AllDirs because -Path was given; scope is '$TelemetryDir'."
+}
 
 # Prompt before destructive deletion. Skipped on -DryRun (non-destructive) and
 # bypassed with -Force (required for non-interactive use).
 if (-not $DryRun -and -not $Force) {
-    $scope = if ($AllDirs) {
+    $scope = if ($UseAllDirs) {
         'ALL registered telemetry stores plus the user-level HVE home directory'
     } else {
         $TelemetryDir
@@ -80,7 +91,7 @@ if (-not $DryRun -and -not $Force) {
 
 # Build the clean-mode argument list mirroring the bash wrapper's flags.
 $CliArgs = @('clean')
-if ($AllDirs) { $CliArgs += '--all-dirs' }
+if ($UseAllDirs) { $CliArgs += '--all-dirs' }
 if ($DryRun) { $CliArgs += '--dry-run' }
 
 $env:HVE_TELEMETRY_DIR = $TelemetryDir

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
@@ -15,7 +15,11 @@
     Runs via: Copilot agent hook (stdin JSON, stdout JSON)
 #>
 [CmdletBinding()]
-param()
+param(
+    [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+    [AllowEmptyString()]
+    [string]$HookInput
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -67,7 +71,7 @@ if (-not (Test-Path $TelemetryDir)) {
 }
 
 # Delegate all JSON processing to the shared Python telemetry engine
-$RawInput = $input | Out-String
+$RawInput = if ($PSBoundParameters.ContainsKey('HookInput')) { $HookInput } else { $input | Out-String }
 
 # Dump raw input for diagnostics (first 5 events only). This records hook
 # payloads verbatim, including the full prompt text and tool inputs such as

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
@@ -18,85 +18,124 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
-#region Resolve repo root
-$RepoRoot = $env:HVE_REPO_ROOT
-if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
-    try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
-}
-if (-not $RepoRoot) {
-    $RepoRoot = '.'
-}
-#endregion Resolve repo root
-
-#region Opt-in gate
-$Enabled = $env:HVE_TELEMETRY -eq '1'
-if (-not $Enabled) {
-    $MarkerPath = Join-Path $RepoRoot '.hve-telemetry'
-    $Enabled = Test-Path $MarkerPath
-}
-if (-not $Enabled) {
-    '{"continue":true}'
-    return
-}
-#endregion Opt-in gate
-
-# Require Python3 for JSON processing
-$Python = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $Python) {
-    $Python = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $Python) {
-    Write-Warning 'HVE telemetry enabled but python3 not found; events will not be recorded'
-    '{"continue":true}'
-    return
-}
-
-# Resolve the shared telemetry engine from the skill directory
-$CorePy = Join-Path $PSScriptRoot '_telemetry_core.py'
-
-if (-not (Test-Path $CorePy)) {
-    Write-Warning "Telemetry engine not found at $CorePy; events will not be recorded"
-    '{"continue":true}'
-    return
-}
-
-# Nested 2-arg Join-Path: the 3-arg form needs PS 6+, and this hook can be
-# launched by a host that picks Windows PowerShell 5.1.
-$TelemetryDir = if ($env:HVE_TELEMETRY_DIR) { $env:HVE_TELEMETRY_DIR } else { Join-Path (Join-Path $RepoRoot '.copilot-tracking') 'telemetry' }
-if (-not (Test-Path $TelemetryDir)) {
-    New-Item -ItemType Directory -Path $TelemetryDir -Force | Out-Null
-}
-
-# Delegate all JSON processing to the shared Python telemetry engine.
-# The hook contract is raw process stdin, not a PowerShell object pipeline:
-# [CmdletBinding()] makes this an advanced script, which rejects pipeline input
-# it cannot bind to a parameter, leaving $input empty.
-$RawInput = if ([Console]::IsInputRedirected) { [Console]::In.ReadToEnd() } else { '' }
-
-# Dump raw input for diagnostics (first 5 events only). This records hook
-# payloads verbatim, including the full prompt text and tool inputs such as
-# file contents and shell command strings, which can contain secrets. The
-# processed sessions-*.jsonl stream already provides the diagnostic signal,
-# so the verbatim dump is a separate explicit opt-in (off by default) layered
-# on top of the telemetry gate. See docs/customization/local-telemetry.md.
-if ($env:HVE_TELEMETRY_RAW -eq '1') {
-    $RawLog = Join-Path $TelemetryDir 'raw-input.jsonl'
-    $RawCount = 0
-    if (Test-Path $RawLog) {
-        $RawCount = (Get-Content -LiteralPath $RawLog).Count
-    }
-    if ($RawCount -lt 5) {
-        Add-Content -LiteralPath $RawLog -Value $RawInput
-    }
-}
-
+# The hook contract is that this script always answers with a continue signal:
+# a silent hook stalls the agent turn. The answer is emitted from finally so
+# every path below, including an early return, still produces it.
 try {
+    #region Resolve repo root
+    $RepoRoot = $env:HVE_REPO_ROOT
+    if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
+        try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
+    }
+    if (-not $RepoRoot) {
+        $RepoRoot = '.'
+    }
+    #endregion Resolve repo root
+
+    #region Opt-in gate
+    # Test-Path takes -LiteralPath throughout: these paths come from the
+    # environment and from the repository, so a bracket in a directory name must
+    # not be read as a wildcard and quietly report the path as missing.
+    $Enabled = $env:HVE_TELEMETRY -eq '1'
+    if (-not $Enabled) {
+        $MarkerPath = Join-Path $RepoRoot '.hve-telemetry'
+        $Enabled = Test-Path -LiteralPath $MarkerPath
+    }
+    if (-not $Enabled) {
+        return
+    }
+    #endregion Opt-in gate
+
+    # Require Python3 for JSON processing
+    $Python = Get-Command python3 -ErrorAction SilentlyContinue
+    if (-not $Python) {
+        $Python = Get-Command python -ErrorAction SilentlyContinue
+    }
+    if (-not $Python) {
+        Write-Warning 'HVE telemetry enabled but no python3 or python found; events will not be recorded'
+        return
+    }
+
+    # Resolve the shared telemetry engine from the skill directory
+    $CorePy = Join-Path $PSScriptRoot '_telemetry_core.py'
+
+    if (-not (Test-Path -LiteralPath $CorePy)) {
+        Write-Warning "Telemetry engine not found at $CorePy; events will not be recorded"
+        return
+    }
+
+    # Nested 2-arg Join-Path: the 3-arg form needs PS 6+, and this hook can be
+    # launched by a host that picks Windows PowerShell 5.1.
+    $TelemetryDir = if ($env:HVE_TELEMETRY_DIR) { $env:HVE_TELEMETRY_DIR } else { Join-Path (Join-Path $RepoRoot '.copilot-tracking') 'telemetry' }
+    $StackDir = Join-Path $TelemetryDir '.stacks'
+    try {
+        if (-not (Test-Path -LiteralPath $TelemetryDir)) {
+            New-Item -ItemType Directory -Path $TelemetryDir -Force | Out-Null
+        }
+        if (-not (Test-Path -LiteralPath $StackDir)) {
+            New-Item -ItemType Directory -Path $StackDir -Force | Out-Null
+        }
+    }
+    catch {
+        # An unwritable store is a telemetry failure, not a turn failure. The
+        # engine below skips its own writes for the same reason.
+        Write-Verbose "Telemetry directory unavailable: $_"
+    }
+
+    # Delegate all JSON processing to the shared Python telemetry engine.
+    # The hook contract is raw process stdin, not a PowerShell object pipeline:
+    # [CmdletBinding()] makes this an advanced script, which rejects pipeline input
+    # it cannot bind to a parameter, leaving $input empty.
+    # Decode explicitly as UTF-8: [Console]::In would use the OEM console codepage
+    # under Windows PowerShell 5.1 and corrupt non-ASCII payload bytes.
+    $RawInput = ''
+    if ([Console]::IsInputRedirected) {
+        $Reader = [IO.StreamReader]::new([Console]::OpenStandardInput(), [Text.UTF8Encoding]::new($false))
+        try { $RawInput = $Reader.ReadToEnd() }
+        finally { $Reader.Dispose() }
+    }
+
+    # Dump raw input for diagnostics (first 5 events only). This records hook
+    # payloads verbatim, including the full prompt text and tool inputs such as
+    # file contents and shell command strings, which can contain secrets. The
+    # processed sessions-*.jsonl stream already provides the diagnostic signal,
+    # so the verbatim dump is a separate explicit opt-in (off by default)
+    # layered on top of the telemetry gate. See docs/customization/local-telemetry.md.
+    if ($env:HVE_TELEMETRY_RAW -eq '1') {
+        try {
+            $RawLog = Join-Path $TelemetryDir 'raw-input.jsonl'
+            $RawCount = 0
+            if (Test-Path -LiteralPath $RawLog) {
+                # Array subexpression: Get-Content returns a bare string for a
+                # single-line file, whose .Count is 1 only by PS 3+ unified property.
+                $RawCount = @(Get-Content -LiteralPath $RawLog).Count
+            }
+            if ($RawCount -lt 5) {
+                # Not Add-Content -Encoding UTF8: that emits a BOM under Windows
+                # PowerShell 5.1, which makes the first JSONL line unparseable.
+                # Trim the inbound line ending and write LF so one event is one JSONL
+                # record, as on bash; CRLF here would leave a blank line between records.
+                [IO.File]::AppendAllText($RawLog, $RawInput.TrimEnd("`r", "`n") + "`n", [Text.UTF8Encoding]::new($false))
+            }
+        }
+        catch {
+            Write-Verbose "Raw telemetry capture failed: $_"
+        }
+    }
+
     $env:HVE_REPO_ROOT = $RepoRoot
     $env:HVE_TELEMETRY_DIR = $TelemetryDir
-    $RawInput | & $Python.Source $CorePy collect 2>$null
+    # Windows PowerShell 5.1 defaults $OutputEncoding to ASCII, which flattens
+    # every non-ASCII character to '?' when piping into a native process.
+    $OutputEncoding = [Text.UTF8Encoding]::new($false)
+    # Engine stderr is left unredirected so it reaches the host log, matching the
+    # bash wrapper. Whether a non-zero exit throws depends on the host version,
+    # and either way the finally below still returns continue.
+    $RawInput | & $Python.Source $CorePy collect
 }
 catch {
     Write-Verbose "Telemetry collection error: $_"
 }
-
-'{"continue":true}'
+finally {
+    '{"continue":true}'
+}

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1
@@ -1,7 +1,6 @@
 ﻿#!/usr/bin/env pwsh
 # Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
-#Requires -Version 7.4
 
 <#
 .SYNOPSIS
@@ -15,11 +14,7 @@
     Runs via: Copilot agent hook (stdin JSON, stdout JSON)
 #>
 [CmdletBinding()]
-param(
-    [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
-    [AllowEmptyString()]
-    [string]$HookInput
-)
+param()
 
 $ErrorActionPreference = 'Stop'
 
@@ -51,7 +46,7 @@ if (-not $Python) {
     $Python = Get-Command python -ErrorAction SilentlyContinue
 }
 if (-not $Python) {
-    Write-Warning 'HVE telemetry enabled but python3 not found — events will not be recorded'
+    Write-Warning 'HVE telemetry enabled but python3 not found; events will not be recorded'
     '{"continue":true}'
     return
 }
@@ -60,18 +55,23 @@ if (-not $Python) {
 $CorePy = Join-Path $PSScriptRoot '_telemetry_core.py'
 
 if (-not (Test-Path $CorePy)) {
-    Write-Warning "Telemetry engine not found at $CorePy — events will not be recorded"
+    Write-Warning "Telemetry engine not found at $CorePy; events will not be recorded"
     '{"continue":true}'
     return
 }
 
-$TelemetryDir = if ($env:HVE_TELEMETRY_DIR) { $env:HVE_TELEMETRY_DIR } else { Join-Path $RepoRoot '.copilot-tracking/telemetry' }
+# Nested 2-arg Join-Path: the 3-arg form needs PS 6+, and this hook can be
+# launched by a host that picks Windows PowerShell 5.1.
+$TelemetryDir = if ($env:HVE_TELEMETRY_DIR) { $env:HVE_TELEMETRY_DIR } else { Join-Path (Join-Path $RepoRoot '.copilot-tracking') 'telemetry' }
 if (-not (Test-Path $TelemetryDir)) {
     New-Item -ItemType Directory -Path $TelemetryDir -Force | Out-Null
 }
 
-# Delegate all JSON processing to the shared Python telemetry engine
-$RawInput = if ($PSBoundParameters.ContainsKey('HookInput')) { $HookInput } else { $input | Out-String }
+# Delegate all JSON processing to the shared Python telemetry engine.
+# The hook contract is raw process stdin, not a PowerShell object pipeline:
+# [CmdletBinding()] makes this an advanced script, which rejects pipeline input
+# it cannot bind to a parameter, leaving $input empty.
+$RawInput = if ([Console]::IsInputRedirected) { [Console]::In.ReadToEnd() } else { '' }
 
 # Dump raw input for diagnostics (first 5 events only). This records hook
 # payloads verbatim, including the full prompt text and tool inputs such as

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryReport.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryReport.ps1
@@ -23,7 +23,7 @@
     sessions-*.jsonl file.
 .PARAMETER AllDirs
     Scan every per-project telemetry directory recorded in the user-level
-    registry (~/.hve/telemetry-dirs.txt) for a combined cross-project report.
+    registry (~/.hve/telemetry-dirs) for a combined cross-project report.
     Ignored when -Path is given.
 .PARAMETER Path
     Telemetry directory. Scopes the report to this directory alone, overriding
@@ -62,12 +62,18 @@ $CorePy = Join-Path $PSScriptRoot '_telemetry_core.py'
 #region Resolve repo root
 # Match the collector and anchor on the caller's workspace: the script itself
 # may live outside the repo it reports on, so its location says nothing.
-$RepoRoot = $env:HVE_REPO_ROOT
-if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
-    try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
-}
-if (-not $RepoRoot) {
-    $RepoRoot = (Get-Location).Path
+# Only needed to build the default telemetry path; an explicit -Path makes the
+# whole lookup unnecessary, including the git subprocess.
+if (-not $Path) {
+    $RepoRoot = $env:HVE_REPO_ROOT
+    if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
+        try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
+    }
+    if (-not $RepoRoot) {
+        # ProviderPath, not .Path: the latter is PowerShell-qualified ('Work:\',
+        # 'HKLM:\SOFTWARE') and is not a path Python can open.
+        $RepoRoot = $PWD.ProviderPath
+    }
 }
 #endregion Resolve repo root
 
@@ -81,13 +87,20 @@ if (-not $Python) {
 # per line). Used by -AllDirs for cross-project reports. Empty without Python.
 function Get-RegistryDir {
     if (-not $Python) { return @() }
+    # Windows PowerShell 5.1 decodes native stdout with the OEM codepage, which
+    # corrupts registry paths holding non-ASCII characters and silently drops
+    # those stores from cross-project reports.
+    $PrevEncoding = [Console]::OutputEncoding
     try {
+        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
         $lines = & $Python.Source $CorePy list-dirs 2>$null
         if ($LASTEXITCODE -eq 0 -and $lines) {
             return @($lines | Where-Object { $_ -and $_.Trim() })
         }
     } catch {
         Write-Verbose "Registry lookup failed; continuing without cross-project dirs: $_"
+    } finally {
+        [Console]::OutputEncoding = $PrevEncoding
     }
     return @()
 }
@@ -118,6 +131,9 @@ if (-not (Test-Path -LiteralPath $TemplatePath)) {
 
 $TargetDate = if ($Date) { $Date } else { (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd') }
 $TelemetryPath = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking' 'telemetry' }
+# PowerShell does not sync [Environment]::CurrentDirectory with Set-Location, so
+# a relative or PSDrive path would resolve elsewhere in the Python child process.
+$TelemetryPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($TelemetryPath)
 $OutputPath = if ($Output) { $Output } else { Join-Path $TelemetryPath 'report.generated.html' }
 
 # Determine which telemetry directories to scan. With -AllDirs, prepend every
@@ -134,26 +150,31 @@ if ($AllDirs -and -not $Path) {
 $SearchDirs.Add($TelemetryPath)
 
 # Collect session files for the target date across the chosen directories,
-# de-duplicating directories that appear more than once.
-$Pattern = if ($TargetDate -eq 'all') { 'sessions-*.jsonl' } else { "sessions-$TargetDate.jsonl" }
+# de-duplicating directories that appear more than once. The trailing '*' also
+# picks up any shard a collector wrote when it could not lock the shared log;
+# report.html orders every record it loads by ts.
+$Pattern = if ($TargetDate -eq 'all') { 'sessions-*.jsonl' } else { "sessions-$TargetDate*.jsonl" }
 $Files = [System.Collections.Generic.List[string]]::new()
 $SeenDirs = [System.Collections.Generic.HashSet[string]]::new()
-foreach ($dir in $SearchDirs) {
-    if (-not $dir) { continue }
-    # Registry entries and the default path can spell one directory differently
-    # (separator style on Windows), so key de-duplication on the canonical form.
-    $DirKey = $dir
-    try { $DirKey = [System.IO.Path]::GetFullPath($dir) } catch { Write-Verbose "Unnormalizable telemetry dir '$dir': $_" }
-    if (-not $SeenDirs.Add($DirKey)) { continue }
-    if (-not (Test-Path -LiteralPath $dir -PathType Container)) { continue }
-    Get-ChildItem -LiteralPath $dir -Filter $Pattern -File -ErrorAction SilentlyContinue |
-        Sort-Object Name |
-        ForEach-Object { $Files.Add($_.FullName) }
-}
 
-# Temp files for enrichment payloads; cleaned up on exit.
-$TmpDir = $null
+# The temp directory is created inside the try whose finally removes it, so a
+# failure between the two can never leave it behind.
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
 try {
+    New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+    foreach ($dir in $SearchDirs) {
+        if (-not $dir) { continue }
+        # Registry entries and the default path can spell one directory differently
+        # (separator style on Windows), so key de-duplication on the canonical form.
+        $DirKey = $dir
+        try { $DirKey = [System.IO.Path]::GetFullPath($dir) } catch { Write-Verbose "Unnormalizable telemetry dir '$dir': $_" }
+        if (-not $SeenDirs.Add($DirKey)) { continue }
+        if (-not (Test-Path -LiteralPath $dir -PathType Container)) { continue }
+        Get-ChildItem -LiteralPath $dir -Filter $Pattern -File -ErrorAction SilentlyContinue |
+            Sort-Object Name |
+            ForEach-Object { $Files.Add($_.FullName) }
+    }
+
     if ($DebugLog) {
         if (-not (Test-Path -LiteralPath $DebugLog)) {
             Write-Error "Debug log not found: $DebugLog"
@@ -163,9 +184,6 @@ try {
     } elseif ($Files.Count -gt 0) {
         # Auto-enrich with precise model + token data from VS Code debug logs and
         # CLI session state, scoped to the sessions already collected.
-        $TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
-        New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
-
         $DebugAgg = Join-Path $TmpDir 'debug-llm-requests.jsonl'
         if (Invoke-AggregateDebug -OutFile $DebugAgg -HookFile $Files.ToArray()) {
             $Files.Add($DebugAgg)
@@ -182,17 +200,17 @@ try {
         exit 0
     }
 
-    # Build a JSON array of {name, content} objects. ConvertTo-Json escapes '<'
-    # to \u003c, so no literal </script> survives in the embedded text; the
-    # explicit </ neutralization is a defense-in-depth backstop. The HTML loader
-    # decodes both forms via JSON.parse.
+    # Build a JSON array of {name, content} objects. Session content quoting
+    # markup can steer the HTML tokenizer out of the host <script> element, so
+    # '<' is escaped twice over: ConvertTo-Json escapes only control characters
+    # by default on PS 6.2+, and the replace backstops the switch.
     $Objects = foreach ($f in $Files) {
         $content = Get-Content -LiteralPath $f -Raw
         if ($null -eq $content) { $content = '' }
         [PSCustomObject]@{ name = (Split-Path -Leaf $f); content = $content }
     }
-    $Json = @($Objects) | ConvertTo-Json -Depth 10 -Compress -AsArray
-    $Data = $Json -replace '</', '<\/'
+    $Json = @($Objects) | ConvertTo-Json -Depth 10 -Compress -AsArray -EscapeHandling EscapeHtml
+    $Data = $Json -replace '<', '\u003c'
 
     # Inject the data into the single-line embeddedData script element. The whole
     # matching line is replaced, mirroring the bash awk substitution.

--- a/.github/hooks/shared/telemetry/Invoke-TelemetryReport.ps1
+++ b/.github/hooks/shared/telemetry/Invoke-TelemetryReport.ps1
@@ -23,9 +23,11 @@
     sessions-*.jsonl file.
 .PARAMETER AllDirs
     Scan every per-project telemetry directory recorded in the user-level
-    registry (~/.copilot/telemetry-dirs.txt) for a combined cross-project report.
+    registry (~/.hve/telemetry-dirs.txt) for a combined cross-project report.
+    Ignored when -Path is given.
 .PARAMETER Path
-    Telemetry directory. Default: <repo>/.copilot-tracking/telemetry
+    Telemetry directory. Scopes the report to this directory alone, overriding
+    -AllDirs. Default: <repo>/.copilot-tracking/telemetry
 .PARAMETER DebugLog
     Optional debug log JSONL (e.g. main.jsonl) for token data. When omitted, VS
     Code debug logs are auto-discovered and the precise model version plus token
@@ -58,12 +60,14 @@ $TemplatePath = Join-Path $PSScriptRoot 'report.html'
 $CorePy = Join-Path $PSScriptRoot '_telemetry_core.py'
 
 #region Resolve repo root
+# Match the collector and anchor on the caller's workspace: the script itself
+# may live outside the repo it reports on, so its location says nothing.
 $RepoRoot = $env:HVE_REPO_ROOT
 if (-not $RepoRoot -and (Get-Command git -ErrorAction SilentlyContinue)) {
-    try { $RepoRoot = & git -C $PSScriptRoot rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
+    try { $RepoRoot = & git rev-parse --show-toplevel 2>$null } catch { $RepoRoot = $null }
 }
 if (-not $RepoRoot) {
-    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    $RepoRoot = (Get-Location).Path
 }
 #endregion Resolve repo root
 
@@ -113,13 +117,18 @@ if (-not (Test-Path -LiteralPath $TemplatePath)) {
 }
 
 $TargetDate = if ($Date) { $Date } else { (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd') }
-$TelemetryPath = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking/telemetry' }
+$TelemetryPath = if ($Path) { $Path } else { Join-Path $RepoRoot '.copilot-tracking' 'telemetry' }
 $OutputPath = if ($Output) { $Output } else { Join-Path $TelemetryPath 'report.generated.html' }
 
 # Determine which telemetry directories to scan. With -AllDirs, prepend every
-# directory recorded in the user-level registry (cross-project view).
+# directory recorded in the user-level registry (cross-project view). An
+# explicit -Path wins so the generated cross-project launcher, which always
+# passes -AllDirs, can still be scoped to one store.
+if ($AllDirs -and $Path) {
+    Write-Warning "Ignoring -AllDirs because -Path was given; scanning '$TelemetryPath' only."
+}
 $SearchDirs = [System.Collections.Generic.List[string]]::new()
-if ($AllDirs) {
+if ($AllDirs -and -not $Path) {
     foreach ($d in (Get-RegistryDir)) { $SearchDirs.Add($d) }
 }
 $SearchDirs.Add($TelemetryPath)
@@ -130,7 +139,12 @@ $Pattern = if ($TargetDate -eq 'all') { 'sessions-*.jsonl' } else { "sessions-$T
 $Files = [System.Collections.Generic.List[string]]::new()
 $SeenDirs = [System.Collections.Generic.HashSet[string]]::new()
 foreach ($dir in $SearchDirs) {
-    if (-not $dir -or -not $SeenDirs.Add($dir)) { continue }
+    if (-not $dir) { continue }
+    # Registry entries and the default path can spell one directory differently
+    # (separator style on Windows), so key de-duplication on the canonical form.
+    $DirKey = $dir
+    try { $DirKey = [System.IO.Path]::GetFullPath($dir) } catch { Write-Verbose "Unnormalizable telemetry dir '$dir': $_" }
+    if (-not $SeenDirs.Add($DirKey)) { continue }
     if (-not (Test-Path -LiteralPath $dir -PathType Container)) { continue }
     Get-ChildItem -LiteralPath $dir -Filter $Pattern -File -ErrorAction SilentlyContinue |
         Sort-Object Name |

--- a/.github/hooks/shared/telemetry/_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/_telemetry_core.py
@@ -28,6 +28,7 @@ import shutil
 import sys
 from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import Any
 
 
 def _detect_client() -> str:
@@ -55,6 +56,48 @@ EVENT_ALIASES = {
 # Shape inference matches only these so an unrelated ``reason`` key on some
 # other or future event is not mistaken for a session end.
 SESSION_END_REASONS = frozenset({"complete", "error", "abort", "timeout", "user_exit"})
+
+# Canonical field -> the payload keys that carry it, in priority order. Three
+# documented payload formats reach this collector: VS Code (snake_case), the
+# Copilot CLI camelCase format, and the CLI "VS Code compatible" format it sends
+# when events are configured in PascalCase. They disagree on both casing and
+# naming (tool output is ``tool_response`` in VS Code, ``tool_result`` in the
+# CLI compatible format, ``toolResult`` in CLI camelCase). This table is the
+# only place surface-specific key names appear, so shape inference and entry
+# building cannot drift apart when a surface adds or renames a key. Add keys
+# only when a surface documents them.
+PAYLOAD_ALIASES: dict[str, tuple[str, ...]] = {
+    "event_name": ("hook_event_name", "hookEventName", "event"),
+    "session_id": ("session_id", "sessionId"),
+    "cwd": ("cwd",),
+    "timestamp": ("timestamp",),
+    "tool_name": ("tool_name", "toolName"),
+    "tool_input": ("tool_input", "toolArgs"),
+    "tool_result": ("tool_response", "tool_result", "toolResult"),
+    "tool_result_text": ("text_result_for_llm", "textResultForLlm"),
+    # VS Code names the subagent only as ``agent_type``; the CLI sends a name.
+    "agent_name": ("agent_name", "agentName", "agent_type", "agentType"),
+    "agent_display_name": ("agent_display_name", "agentDisplayName"),
+    "prompt": ("prompt",),
+    "source": ("source",),
+    "trigger": ("trigger",),
+    "stop_reason": ("stop_reason", "stopReason"),
+    "reason": ("reason",),
+}
+
+
+def _payload_get(data: dict, field: str, default: Any = "") -> Any:
+    """Return the first non-empty alias value for a canonical payload field."""
+    for key in PAYLOAD_ALIASES[field]:
+        value = data.get(key)
+        if value:
+            return value
+    return default
+
+
+def _payload_has(data: dict, field: str) -> bool:
+    """Return True when a payload carries any alias of a canonical field."""
+    return any(key in data for key in PAYLOAD_ALIASES[field])
 
 
 def iter_jsonl(path: str | os.PathLike[str]) -> Iterator[dict]:
@@ -685,49 +728,50 @@ def _infer_event_from_shape(data: dict) -> str:
     The Copilot CLI does not send an event-name field in the hook payload
     (no ``hook_event_name``/``hookEventName``/``event``), unlike VS Code. It
     also fires one shared command for every manifest event, so the event must
-    be inferred from which keys are present. Checks are ordered so that events
-    sharing keys are disambiguated by their distinguishing field:
+    be inferred from which fields are present. Fields are resolved through
+    ``PAYLOAD_ALIASES``, so inference is surface-agnostic. Checks are ordered
+    so that events sharing fields are disambiguated by their distinguishing
+    field:
 
-    * ``toolResult`` present -> PostToolUse (also carries ``toolName``)
-    * ``toolName`` present -> PreToolUse
-    * ``prompt`` present -> UserPromptSubmit
-    * ``agentName`` present -> SubagentStop when ``stopReason`` is set (a
+    * tool result present -> PostToolUse (also carries a tool name)
+    * tool name present -> PreToolUse
+    * prompt present -> UserPromptSubmit
+    * agent name present -> SubagentStop when a stop reason is set (a
       Subagent stop), otherwise SubagentStart
-    * ``trigger`` present -> PreCompact
-    * ``stopReason`` present without ``agentName`` -> Stop (an agent turn end)
-    * ``source`` present -> SessionStart
+    * trigger present -> PreCompact
+    * stop reason present without an agent name -> Stop (an agent turn end)
+    * source present -> SessionStart
     * ``reason`` holding a documented session-end value (``complete``,
       ``error``, ``abort``, ``timeout``, ``user_exit``) -> SessionEnd (the
-      session terminates; unlike an agent Stop, no ``stopReason``)
+      session terminates; unlike an agent Stop, no stop reason)
     """
-    if "toolResult" in data:
+    if _payload_has(data, "tool_result"):
         return "PostToolUse"
-    if "toolName" in data:
+    if _payload_has(data, "tool_name"):
         return "PreToolUse"
-    if "prompt" in data:
+    if _payload_has(data, "prompt"):
         return "UserPromptSubmit"
-    if "agentName" in data:
-        return "SubagentStop" if "stopReason" in data else "SubagentStart"
-    if "trigger" in data:
+    if _payload_has(data, "agent_name"):
+        return "SubagentStop" if _payload_has(data, "stop_reason") else "SubagentStart"
+    if _payload_has(data, "trigger"):
         return "PreCompact"
-    if "stopReason" in data:
+    if _payload_has(data, "stop_reason"):
         return "Stop"
-    if "source" in data:
+    if _payload_has(data, "source"):
         return "SessionStart"
-    if data.get("reason") in SESSION_END_REASONS:
+    if _payload_get(data, "reason") in SESSION_END_REASONS:
         return "SessionEnd"
     return "unknown"
 
 
 def _normalize_event(data: dict) -> str:
     """Resolve the canonical PascalCase event name from a hook payload."""
-    event = data.get("hook_event_name", "unknown")
-    if event == "unknown":
-        for key in ("hookEventName", "event"):
-            value = data.get(key)
-            if value and value != "unknown":
-                event = value
-                break
+    event = "unknown"
+    for key in PAYLOAD_ALIASES["event_name"]:
+        value = data.get(key)
+        if value and value != "unknown":
+            event = value
+            break
     if event == "unknown":
         # The Copilot CLI omits the event name entirely; recover it from the
         # payload shape so CLI sessions record telemetry like VS Code sessions.
@@ -814,12 +858,12 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
 
     Returns ``None`` for unrecognized events, which the caller drops.
     """
-    sid = data.get("session_id") or data.get("sessionId", "")
-    cwd = data.get("cwd", os.getcwd())
-    ts = _normalize_timestamp(data.get("timestamp", ""))
-    tool_name = data.get("tool_name") or data.get("toolName", "")
-    tool_input = data.get("tool_input") or data.get("toolArgs", {})
-    tool_result = data.get("tool_result") or data.get("toolResult", "")
+    sid = _payload_get(data, "session_id")
+    cwd = _payload_get(data, "cwd", os.getcwd())
+    ts = _normalize_timestamp(_payload_get(data, "timestamp"))
+    tool_name = _payload_get(data, "tool_name")
+    tool_input = _payload_get(data, "tool_input", {})
+    tool_result = _payload_get(data, "tool_result")
 
     # The Copilot CLI serializes tool arguments as a JSON string rather than an
     # object; decode it so key extraction and file-path detection below work.
@@ -835,10 +879,10 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
     entry: dict = {"ts": ts, "sid": sid, "event": event, "cwd": cwd}
 
     if event == "SessionStart":
-        entry["source"] = data.get("source", "")
+        entry["source"] = _payload_get(data, "source")
         entry["client"] = _detect_client()
     elif event == "UserPromptSubmit":
-        entry["prompt"] = (data.get("prompt", "") or "")[:200]
+        entry["prompt"] = _payload_get(data, "prompt")[:200]
     elif event == "PreToolUse":
         entry["tool"] = tool_name
         entry["tool_input_keys"] = list(tool_input.keys()) if isinstance(tool_input, dict) else []
@@ -869,7 +913,7 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
     elif event == "PostToolUse":
         entry["tool"] = tool_name
         if isinstance(tool_result, dict):
-            text = tool_result.get("text_result_for_llm") or tool_result.get("textResultForLlm", "")
+            text = _payload_get(tool_result, "tool_result_text")
             entry["tool_response_len"] = len(text if isinstance(text, str) else str(text))
         elif isinstance(tool_result, str):
             entry["tool_response_len"] = len(tool_result)
@@ -877,27 +921,23 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
             entry["tool_response_len"] = len(json.dumps(tool_result))
         entry["agent"] = stack.current()
     elif event == "SubagentStart":
-        agent_name = data.get("agent_name") or data.get("agentName", "")
+        agent_name = _payload_get(data, "agent_name")
         entry["agent_name"] = agent_name
-        entry["agent_display_name"] = data.get("agent_display_name") or data.get(
-            "agentDisplayName", ""
-        )
+        entry["agent_display_name"] = _payload_get(data, "agent_display_name")
         stack.push(agent_name)
     elif event == "SubagentStop":
-        agent_name = data.get("agent_name") or data.get("agentName", "")
+        agent_name = _payload_get(data, "agent_name")
         entry["agent_name"] = agent_name
         stack.pop()
     elif event == "PreCompact":
-        entry["trigger"] = data.get("trigger", "")
+        entry["trigger"] = _payload_get(data, "trigger")
     elif event == "Stop":
         # Fall back to ``reason`` for surfaces that name the event Stop but
-        # supply a session-end style payload without ``stopReason``.
-        entry["stop_reason"] = (
-            data.get("stop_reason") or data.get("stopReason") or data.get("reason", "")
-        )
+        # supply a session-end style payload without a stop reason.
+        entry["stop_reason"] = _payload_get(data, "stop_reason") or _payload_get(data, "reason")
         stack.clear()
     elif event == "SessionEnd":
-        entry["reason"] = data.get("reason", "")
+        entry["reason"] = _payload_get(data, "reason")
         stack.clear()
 
     return entry
@@ -912,7 +952,7 @@ def _mode_collect() -> int:
     if not isinstance(data, dict):
         return 0
 
-    sid = data.get("session_id") or data.get("sessionId", "")
+    sid = _payload_get(data, "session_id")
     # Reject session IDs containing path separators or traversal sequences
     # to prevent writes outside the telemetry directory.
     if sid and not _is_safe_sid(sid):
@@ -929,11 +969,13 @@ def _mode_collect() -> int:
     if entry is None:
         return 0
 
+    # Register before the first write of the day so a store whose SessionStart
+    # was never delivered (telemetry enabled mid-session, or a surface that
+    # omits the event) still reaches cross-project reports. Bounded to one
+    # registry read per store per day plus each session start.
+    first_write = not log_file.exists()
     tel_dir.mkdir(parents=True, exist_ok=True)
-    # Record this project's telemetry dir once per session so cross-project
-    # reports can discover every store, and refresh the user-level launcher.
-    # SessionStart keeps these writes infrequent.
-    if event == "SessionStart":
+    if event == "SessionStart" or first_write:
         register_telemetry_dir(tel_dir)
         write_report_launchers()
     with open(log_file, "a", encoding="utf-8") as handle:
@@ -966,6 +1008,27 @@ def _mode_collect() -> int:
                     handle.write(json.dumps(summary) + "\n")
     return 0
 
+def _workspace_storage_dirs() -> list[Path]:
+    """Return candidate VS Code workspaceStorage roots for this host.
+
+    Covers remote/server installs (``~/.vscode-server*/data``) and local
+    installs, whose user-data dir is platform specific.
+    """
+    home = Path.home()
+    roots = [home / d / "data" for d in (".vscode-server-insiders", ".vscode-server", ".vscode")]
+
+    if _is_windows():
+        appdata = os.environ.get("APPDATA")
+        local_base = Path(appdata) if appdata else home / "AppData/Roaming"
+    elif sys.platform == "darwin":
+        local_base = home / "Library/Application Support"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        local_base = Path(xdg) if xdg else home / ".config"
+
+    roots += [local_base / d for d in ("Code - Insiders", "Code", "VSCodium")]
+    return [r / "User/workspaceStorage" for r in roots]
+
 
 def _mode_aggregate_debug(out: str, hook_files: list[str]) -> int:
     """Emit llm_request events from VS Code debug logs for collected sids."""
@@ -973,10 +1036,8 @@ def _mode_aggregate_debug(out: str, hook_files: list[str]) -> int:
     if not sids:
         return 1
 
-    home = Path.home()
     patterns = [
-        str(home / d / "data/User/workspaceStorage/**/debug-logs/**/*.jsonl")
-        for d in (".vscode-server-insiders", ".vscode-server", ".vscode")
+        str(base / "**/debug-logs/**/*.jsonl") for base in _workspace_storage_dirs()
     ]
     count = 0
     with open(out, "w", encoding="utf-8") as writer:

--- a/.github/hooks/shared/telemetry/_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/_telemetry_core.py
@@ -1008,6 +1008,7 @@ def _mode_collect() -> int:
                     handle.write(json.dumps(summary) + "\n")
     return 0
 
+
 def _workspace_storage_dirs() -> list[Path]:
     """Return candidate VS Code workspaceStorage roots for this host.
 
@@ -1036,9 +1037,7 @@ def _mode_aggregate_debug(out: str, hook_files: list[str]) -> int:
     if not sids:
         return 1
 
-    patterns = [
-        str(base / "**/debug-logs/**/*.jsonl") for base in _workspace_storage_dirs()
-    ]
+    patterns = [str(base / "**/debug-logs/**/*.jsonl") for base in _workspace_storage_dirs()]
     count = 0
     with open(out, "w", encoding="utf-8") as writer:
         for pattern in patterns:

--- a/.github/hooks/shared/telemetry/_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/_telemetry_core.py
@@ -145,6 +145,12 @@ def _fallback_stem() -> str:
 # O_BINARY keeps Windows from expanding "\n" and desynchronizing the byte count.
 _APPEND_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_BINARY", 0)
 
+# Telemetry records carry prompt previews and working-directory paths, and the
+# registry carries every store location, so nothing here is readable by group or
+# other. umask can only clear further bits, never restore them.
+_OWNER_ONLY_FILE = 0o600
+_OWNER_ONLY_EXEC = 0o700
+
 
 def _write_all(fd: int, payload: bytes) -> None:
     """Write every byte; a signal or a full disk can cut one write short."""
@@ -195,6 +201,9 @@ if os.name == "nt":
         try:
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
         except OSError:
+            # The lock is released by the close in _append_shared's finally, and
+            # by the OS if this process dies, so a failed explicit unlock leaves
+            # nothing to repair and must not mask the record that was written.
             pass
 
 else:
@@ -241,7 +250,7 @@ def append_line(target: Path, line: str) -> None:
 
 def _append_shared(target: Path, payload: bytes) -> bool:
     """Append under the platform's append guarantee. False if unavailable."""
-    fd = os.open(target, _APPEND_FLAGS, 0o644)
+    fd = os.open(target, _APPEND_FLAGS, _OWNER_ONLY_FILE)
     try:
         if not _lock_append(fd):
             return False
@@ -256,7 +265,7 @@ def _append_shared(target: Path, payload: bytes) -> bool:
 
 def _append_private(target: Path, payload: bytes) -> None:
     """Append to a file only this process writes, so no lock is required."""
-    fd = os.open(target, _APPEND_FLAGS, 0o644)
+    fd = os.open(target, _APPEND_FLAGS, _OWNER_ONLY_FILE)
     try:
         _write_all(fd, payload)
     finally:
@@ -273,7 +282,7 @@ def append_jsonl(target: Path, entry: dict) -> None:
     append_line(target, json.dumps(entry) + "\n")
 
 
-def _write_text_atomic(path: Path, text: str, mode: int = 0o644) -> None:
+def _write_text_atomic(path: Path, text: str, mode: int = _OWNER_ONLY_FILE) -> None:
     """Replace ``path`` in one step so a reader never observes a partial file.
 
     Plain truncate-then-write leaves a window in which the file is empty or
@@ -556,8 +565,8 @@ def write_report_launchers(script_dir: Path | None = None) -> None:
             bash_clean_text = _BASH_CLEAN_LAUNCHER.replace(
                 "__CLEAN_SCRIPT__", shlex.quote(clean_script)
             )
-            _write_text_atomic(home / "generate-report.sh", bash_text, mode=0o755)
-            _write_text_atomic(home / "clean-telemetry.sh", bash_clean_text, mode=0o755)
+            _write_text_atomic(home / "generate-report.sh", bash_text, mode=_OWNER_ONLY_EXEC)
+            _write_text_atomic(home / "clean-telemetry.sh", bash_clean_text, mode=_OWNER_ONLY_EXEC)
     except OSError:
         # Cannot write launchers (e.g., permission denied); skip generation.
         return

--- a/.github/hooks/shared/telemetry/_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/_telemetry_core.py
@@ -21,14 +21,20 @@ from __future__ import annotations
 
 import datetime
 import glob
+import hashlib
 import json
 import os
+import secrets
 import shlex
 import shutil
 import sys
+import time
 from collections.abc import Iterable, Iterator
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
+
+if os.name == "nt":
+    import msvcrt
 
 
 def _detect_client() -> str:
@@ -73,10 +79,14 @@ PAYLOAD_ALIASES: dict[str, tuple[str, ...]] = {
     "timestamp": ("timestamp",),
     "tool_name": ("tool_name", "toolName"),
     "tool_input": ("tool_input", "toolArgs"),
+    "tool_use_id": ("tool_use_id", "toolUseId"),
     "tool_result": ("tool_response", "tool_result", "toolResult"),
     "tool_result_text": ("text_result_for_llm", "textResultForLlm"),
     # VS Code names the subagent only as ``agent_type``; the CLI sends a name.
     "agent_name": ("agent_name", "agentName", "agent_type", "agentType"),
+    # Unique per subagent invocation on VS Code; absent on surfaces that send
+    # only a name, which then has to serve as the identity.
+    "agent_id": ("agent_id", "agentId"),
     "agent_display_name": ("agent_display_name", "agentDisplayName"),
     "prompt": ("prompt",),
     "source": ("source",),
@@ -119,13 +129,202 @@ def iter_jsonl(path: str | os.PathLike[str]) -> Iterator[dict]:
         return
 
 
+def _fallback_stem() -> str:
+    """Return a filename stem no other live collector process will produce.
+
+    The UTC time orders fallback files beside their day log, the pid separates
+    concurrent writers, and the random suffix keeps a recycled pid from
+    reopening a departed process's file. The suffix carries the uniqueness on
+    Windows, whose clock resolution is coarse enough to collapse the timestamp
+    for writers started in the same tick.
+    """
+    stamp = datetime.datetime.now(datetime.UTC).strftime("%H%M%S%f")
+    return f"{stamp}-{os.getpid()}-{secrets.token_hex(8)}"
+
+
+# O_BINARY keeps Windows from expanding "\n" and desynchronizing the byte count.
+_APPEND_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_BINARY", 0)
+
+
+def _write_all(fd: int, payload: bytes) -> None:
+    """Write every byte; a signal or a full disk can cut one write short."""
+    view = memoryview(payload)
+    while view:
+        written = os.write(fd, view)
+        if not written:
+            # Retrying a write that consumed nothing spins forever inside a
+            # synchronous hook, so surface it to the caller's fallback instead.
+            raise OSError("write made no progress")
+        view = view[written:]
+
+
+# Copilot runs hooks concurrently: parallel tool calls and subagents each spawn
+# their own collector process, and they share one log per day. POSIX resolves
+# O_APPEND under the inode lock, so nothing further is needed there. The Windows
+# CRT emulates O_APPEND as seek-to-end plus write in user space, so racing
+# collectors resolve the same offset and the second overwrites the first; a
+# byte-range lock closes that window. A writer that cannot take the lock falls
+# back to a private shard, which readers merge alongside the log.
+if os.name == "nt":
+    # A record is a few hundred bytes, so a collision clears in microseconds.
+    # LK_LOCK would sleep a full second per retry for up to ten seconds, which
+    # is charged to the agent turn; poll instead, at the timescale of the write.
+    _LOCK_ATTEMPTS = 2000
+    _LOCK_BACKOFF_SECONDS = 0.001
+
+    def _lock_append(fd: int) -> bool:
+        """Take the byte-0 mutex and seek to end. False if the lock is refused.
+
+        Byte 0 is never read as data; it is only somewhere to anchor the lock.
+        Windows drops the lock when the handle closes, including on a crash, so
+        a dead collector cannot wedge the log.
+        """
+        os.lseek(fd, 0, os.SEEK_SET)
+        for _ in range(_LOCK_ATTEMPTS):
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            except OSError:
+                time.sleep(_LOCK_BACKOFF_SECONDS)
+                continue
+            os.lseek(fd, 0, os.SEEK_END)
+            return True
+        return False
+
+    def _unlock_append(fd: int) -> None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+
+else:
+
+    def _lock_append(fd: int) -> bool:
+        """POSIX appends atomically under O_APPEND; there is no lock to take."""
+        return True
+
+    def _unlock_append(fd: int) -> None:
+        return
+
+
+def append_line(target: Path, line: str) -> None:
+    """Append one newline-terminated line to the shared log for its day.
+
+    Best-effort: a store that cannot be written is a telemetry failure, not a
+    turn failure, so every path returns rather than raising into the hook.
+
+    Args:
+        target: The shared log path. Its parent is created when missing, and a
+            sibling shard is used when the log cannot be locked or written.
+        line: The record text, already newline-terminated by the caller.
+    """
+    payload = line.encode("utf-8")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if _append_shared(target, payload):
+            return
+    except OSError:
+        # A refused lock returns False; an unwritable or torn log raises. Both
+        # reach the shard below, which is the only way the record still lands.
+        pass
+    # A filesystem that refuses locks would let writers interleave, so this
+    # process takes a file of its own. Readers match the shard alongside the
+    # log, so the record still lands.
+    try:
+        _append_private(
+            target.with_name(f"{target.stem}.{_fallback_stem()}{target.suffix}"), payload
+        )
+    except OSError:
+        # Nothing in this store is writable; drop the record.
+        return
+
+
+def _append_shared(target: Path, payload: bytes) -> bool:
+    """Append under the platform's append guarantee. False if unavailable."""
+    fd = os.open(target, _APPEND_FLAGS, 0o644)
+    try:
+        if not _lock_append(fd):
+            return False
+        try:
+            _write_all(fd, payload)
+        finally:
+            _unlock_append(fd)
+    finally:
+        os.close(fd)
+    return True
+
+
+def _append_private(target: Path, payload: bytes) -> None:
+    """Append to a file only this process writes, so no lock is required."""
+    fd = os.open(target, _APPEND_FLAGS, 0o644)
+    try:
+        _write_all(fd, payload)
+    finally:
+        os.close(fd)
+
+
+def append_jsonl(target: Path, entry: dict) -> None:
+    """Append one JSON object as a JSONL record.
+
+    Args:
+        target: The shared log path, as for :func:`append_line`.
+        entry: The record, serialized on one line.
+    """
+    append_line(target, json.dumps(entry) + "\n")
+
+
+def _write_text_atomic(path: Path, text: str, mode: int = 0o644) -> None:
+    """Replace ``path`` in one step so a reader never observes a partial file.
+
+    Plain truncate-then-write leaves a window in which the file is empty or
+    half written, and every collector racing on ``first_write`` rewrites these
+    files at once. The temp name carries the pid so concurrent writers do not
+    collide on the staging file itself.
+
+    Args:
+        path: The destination, replaced by an atomic rename.
+        text: The full file contents, written as UTF-8.
+        mode: Permission bits the staging file is created with, so the content
+            is never briefly readable more widely than the destination.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+        try:
+            _write_all(fd, text.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 def _is_safe_sid(sid: str) -> bool:
     """Return True when a session id is safe to embed in a filesystem path.
 
     Rejects empty ids and any value containing a path separator or ``..``
-    traversal sequence so callers never build paths outside their store.
+    traversal sequence so callers never build paths outside their store. A bare
+    drive or UNC specifier such as ``C:`` holds no separator yet still re-anchors
+    the path when joined, discarding the store prefix, so reject anchors too.
     """
-    return bool(sid) and not (os.sep in sid or "/" in sid or "\\" in sid or ".." in sid)
+    if not sid or ".." in sid:
+        return False
+    if os.sep in sid or "/" in sid or "\\" in sid:
+        return False
+    return not PureWindowsPath(sid).anchor
+
+
+def _is_contained(child: Path, parent: Path) -> bool:
+    """Return True when ``child`` resolves inside ``parent``.
+
+    Checked immediately before a destructive operation so a path that escaped
+    its store cannot be removed, whatever produced it.
+    """
+    try:
+        return child.resolve().is_relative_to(parent.resolve())
+    except OSError:
+        return False
 
 
 def collect_sids(hook_files: Iterable[str]) -> set[str]:
@@ -152,48 +351,91 @@ def hve_home() -> Path:
 
 
 def telemetry_registry() -> Path:
-    """Return the user-level registry that lists per-project telemetry dirs."""
-    return hve_home() / "telemetry-dirs.txt"
+    """Return the user-level registry of per-project telemetry dirs.
+
+    A directory holding one marker per store rather than a shared list file:
+    every writer targets a distinct path and rewriting it is a no-op, so
+    collectors racing on the first write of the day need no coordination.
+    """
+    return hve_home() / "telemetry-dirs"
+
+
+def _registry_marker(registry: Path, resolved: str) -> Path:
+    """Return the marker path for one store, named by a digest of its path."""
+    return registry / f"{hashlib.sha256(resolved.encode('utf-8')).hexdigest()[:32]}.path"
+
+
+# Registry file used before the marker directory: one absolute path per line.
+_LEGACY_REGISTRY_NAME = "telemetry-dirs.txt"
+
+
+def _migrate_legacy_registry(registry: Path) -> None:
+    """Import the pre-directory registry file once, then retire it.
+
+    Without this an upgraded install silently drops every store it had already
+    registered. Active projects re-register on their next event, but a retired
+    one never does, and that is exactly the set ``clean --all-dirs`` exists to
+    reclaim. Renaming rather than deleting keeps the original recoverable.
+    """
+    legacy = registry.parent / _LEGACY_REGISTRY_NAME
+    try:
+        if not legacy.is_file():
+            return
+        lines = legacy.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    for line in lines:
+        entry = line.strip()
+        if entry:
+            register_telemetry_dir(Path(entry), registry)
+    try:
+        legacy.rename(legacy.with_name(_LEGACY_REGISTRY_NAME + ".migrated"))
+    except OSError:
+        # Left in place; re-importing is idempotent, so the next call retries.
+        return
 
 
 def read_registry_dirs(registry: Path | None = None) -> list[str]:
-    """Return registered telemetry directories in order, de-duplicated."""
+    """Return registered telemetry directories, sorted and de-duplicated."""
     registry = registry if registry is not None else telemetry_registry()
+    _migrate_legacy_registry(registry)
     try:
-        text = registry.read_text(encoding="utf-8")
+        markers = sorted(registry.glob("*.path"))
     except OSError:
-        # Registry file is missing or unreadable; treat as no registered dirs.
+        # Registry dir is missing or unreadable; treat as no registered dirs.
         return []
-    dirs: list[str] = []
-    seen: set[str] = set()
-    for line in text.splitlines():
-        entry = line.strip()
-        if entry and entry not in seen:
-            seen.add(entry)
-            dirs.append(entry)
-    return dirs
+    dirs: set[str] = set()
+    for marker in markers:
+        try:
+            entry = marker.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if entry:
+            dirs.add(entry)
+    return sorted(dirs)
 
 
 def register_telemetry_dir(tel_dir: Path, registry: Path | None = None) -> None:
     """Record an absolute telemetry directory in the user-level registry.
 
     Lets the report tooling discover every per-project telemetry store without
-    relying on environment propagation. Resolves to an absolute path and skips
-    the append when already present so the registry stays de-duplicated.
+    relying on environment propagation. Resolves to an absolute path and writes
+    the marker whole, so repeated and concurrent registrations converge on the
+    same content instead of appending duplicates.
     """
     registry = registry if registry is not None else telemetry_registry()
     try:
         resolved = str(tel_dir.resolve())
     except OSError:
         resolved = os.path.abspath(str(tel_dir))
-    if resolved in read_registry_dirs(registry):
+    marker = _registry_marker(registry, resolved)
+    if marker.exists():
         return
     try:
-        registry.parent.mkdir(parents=True, exist_ok=True)
-        with open(registry, "a", encoding="utf-8") as handle:
-            handle.write(resolved + "\n")
+        registry.mkdir(parents=True, exist_ok=True)
+        _write_text_atomic(marker, resolved + "\n")
     except OSError:
-        # Cannot create or append to the registry; skip recording this dir.
+        # Cannot create the registry entry; skip recording this dir.
         return
 
 
@@ -303,8 +545,8 @@ def write_report_launchers(script_dir: Path | None = None) -> None:
             pwsh_clean_text = _PWSH_CLEAN_LAUNCHER.replace(
                 "__CLEAN_PS1__", clean_ps1.replace("'", "''")
             )
-            (home / "generate-report.ps1").write_text(pwsh_text, encoding="utf-8")
-            (home / "clean-telemetry.ps1").write_text(pwsh_clean_text, encoding="utf-8")
+            _write_text_atomic(home / "generate-report.ps1", pwsh_text)
+            _write_text_atomic(home / "clean-telemetry.ps1", pwsh_clean_text)
         else:
             # Shell-quote so unusual install paths (spaces, quotes, ``$``)
             # cannot break or inject into the generated launchers.
@@ -314,12 +556,8 @@ def write_report_launchers(script_dir: Path | None = None) -> None:
             bash_clean_text = _BASH_CLEAN_LAUNCHER.replace(
                 "__CLEAN_SCRIPT__", shlex.quote(clean_script)
             )
-            sh_path = home / "generate-report.sh"
-            sh_path.write_text(bash_text, encoding="utf-8")
-            sh_path.chmod(0o755)
-            clean_sh_path = home / "clean-telemetry.sh"
-            clean_sh_path.write_text(bash_clean_text, encoding="utf-8")
-            clean_sh_path.chmod(0o755)
+            _write_text_atomic(home / "generate-report.sh", bash_text, mode=0o755)
+            _write_text_atomic(home / "clean-telemetry.sh", bash_clean_text, mode=0o755)
     except OSError:
         # Cannot write launchers (e.g., permission denied); skip generation.
         return
@@ -802,55 +1040,125 @@ def _token_estimate(path: str) -> int:
 
 
 class _AgentStack:
-    """Per-session agent stack persisted as a JSON array on disk.
+    """Per-session record of active agents, kept as an append-only op log.
 
-    Tracks the active agent (root vs subagent) so telemetry entries can
-    attribute tool calls to the correct agent context.
+    Tracks which subagents have started but not stopped so telemetry entries can
+    attribute tool calls to the correct agent context. Subagents start and stop
+    in their own collector processes, so the state is appended and replayed on
+    read rather than read-modify-written, which would lose all but one of a
+    simultaneous batch. Appends go through :func:`append_line`, so the replay
+    also picks up any shard a writer left behind when it could not take the lock.
+
+    Records are keyed by the surface's unique invocation id rather than the
+    agent's name: concurrent subagents of the same type share a name, so
+    name-keyed removal evicts an arbitrary one.
     """
 
     def __init__(self, stack_dir: Path, sid: str) -> None:
         self.stack_dir = stack_dir
-        self.stack_file = stack_dir / f"{sid}.json" if _is_safe_sid(sid) else None
+        self.session_dir = stack_dir / sid if _is_safe_sid(sid) else None
+        self.stack_file = self.session_dir / "ops.log" if self.session_dir else None
 
-    def _read(self) -> list[str]:
-        if self.stack_file and self.stack_file.exists():
-            try:
-                with open(self.stack_file, encoding="utf-8") as handle:
-                    data = json.load(handle)
-                if isinstance(data, list):
-                    return data
-            except (OSError, ValueError):
-                # Stack file is unreadable or malformed; treat as empty stack.
-                return []
-        return []
+    def _replay(self) -> list[tuple[str, str]]:
+        """Rebuild the (key, name) pairs of started-but-not-stopped agents."""
+        active: list[tuple[str, str]] = []
+        if not self.session_dir:
+            return active
+        ops: list[dict] = []
+        for shard in self.session_dir.glob("*.log"):
+            ops.extend(iter_jsonl(shard))
+        # Shards interleave, so recover a single order from the recorded time.
+        # A push must settle before a pop stamped in the same tick, or the pop
+        # matches nothing and its agent stays active forever.
+        ops.sort(key=lambda op: (str(op.get("ts", "")), 0 if op.get("op") == "push" else 1))
+        for op in ops:
+            name = op.get("agent", "")
+            key = op.get("id") or name
+            if op.get("op") == "push":
+                active.append((key, name))
+                continue
+            for i in reversed(range(len(active))):
+                if active[i][0] == key:
+                    del active[i]
+                    break
+            # An unmatched pop means its push was lost; keeping the other
+            # records reports the caller as unknown instead of evicting a
+            # live agent and misattributing every tool call after it.
+        return active
 
-    def current(self) -> str:
-        stack = self._read()
-        return stack[-1] if stack else "root"
+    def active(self) -> list[str]:
+        """Return the names of every started-but-not-stopped agent."""
+        return [name for _, name in self._replay()]
 
-    def push(self, name: str) -> None:
+    def push(self, agent_id: str, name: str = "") -> None:
+        """Record that an agent started.
+
+        Args:
+            agent_id: The surface's unique invocation id, used as the record
+                key. Falls back to ``name`` when the payload omits it, which
+                makes concurrent same-named agents indistinguishable.
+            name: The agent's display name, reported by :meth:`active`.
+        """
         if not self.stack_file:
             return
-        self.stack_dir.mkdir(parents=True, exist_ok=True)
-        stack = self._read()
-        stack.append(name)
-        with open(self.stack_file, "w", encoding="utf-8") as handle:
-            json.dump(stack, handle)
+        append_jsonl(
+            self.stack_file,
+            {
+                "ts": datetime.datetime.now(datetime.UTC).isoformat(),
+                "op": "push",
+                "id": agent_id or name,
+                "agent": name,
+            },
+        )
 
-    def pop(self) -> None:
-        """Remove the topmost agent. Deletes the file when the stack empties."""
-        if not self.stack_file or not self.stack_file.exists():
+    def pop(self, agent_id: str, name: str = "") -> None:
+        """Record that an agent stopped. The log is discarded by :meth:`clear`.
+
+        Args:
+            agent_id: The invocation id passed to :meth:`push`; ``name`` is the
+                fallback key, matching push so the pair cancels.
+            name: The agent's display name, used only as that fallback.
+        """
+        if not self.session_dir or not self.session_dir.exists():
             return
-        stack = self._read()
-        if len(stack) > 1:
-            with open(self.stack_file, "w", encoding="utf-8") as handle:
-                json.dump(stack[:-1], handle)
-        else:
-            self.stack_file.unlink(missing_ok=True)
+        append_jsonl(
+            self.stack_file,
+            {
+                "ts": datetime.datetime.now(datetime.UTC).isoformat(),
+                "op": "pop",
+                "id": agent_id or name,
+            },
+        )
 
     def clear(self) -> None:
-        if self.stack_file and self.stack_file.exists():
-            self.stack_file.unlink(missing_ok=True)
+        """Discard this session's op log directory."""
+        if not self.session_dir or not self.session_dir.is_dir():
+            return
+        # Re-check containment at the point of deletion: _is_safe_sid gates the
+        # id, but a recursive remove should not rest on that alone.
+        if not _is_contained(self.session_dir, self.stack_dir):
+            return
+        shutil.rmtree(self.session_dir, ignore_errors=True)
+
+
+def _attribute_agent(entry: dict, active: list[str]) -> None:
+    """Credit a tool call to the agent that made it, when that is knowable.
+
+    A tool payload names no caller and a turn's tool calls run in parallel, so
+    an active subagent is not evidence that it issued this one. Only an empty
+    active set is conclusive; otherwise every candidate is recorded and the
+    choice is left to offline analysis.
+
+    Args:
+        entry: The telemetry record, mutated in place. Gains ``agents`` (a
+            candidate list) when subagents are active, or ``agent`` (a single
+            name) when none are. The two shapes are mutually exclusive.
+        active: Names of every started-but-not-stopped agent.
+    """
+    if active:
+        entry["agents"] = ["root", *active]
+    else:
+        entry["agent"] = "root"
 
 
 def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
@@ -878,6 +1186,12 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
 
     entry: dict = {"ts": ts, "sid": sid, "event": event, "cwd": cwd}
 
+    # Pairs a Pre with its Post, which is the only handle offline analysis has
+    # on when a call was in flight.
+    tool_use_id = _payload_get(data, "tool_use_id")
+    if tool_use_id and event in ("PreToolUse", "PostToolUse"):
+        entry["tool_use_id"] = tool_use_id
+
     if event == "SessionStart":
         entry["source"] = _payload_get(data, "source")
         entry["client"] = _detect_client()
@@ -886,7 +1200,7 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
     elif event == "PreToolUse":
         entry["tool"] = tool_name
         entry["tool_input_keys"] = list(tool_input.keys()) if isinstance(tool_input, dict) else []
-        entry["agent"] = stack.current()
+        _attribute_agent(entry, stack.active())
         # Detect instructions and skills by file path convention to track
         # which artifacts the agent loaded during the session. Normalize
         # Windows backslash separators so splitting works cross-platform.
@@ -897,11 +1211,9 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
                 entry["instruction"] = norm.split("/")[-1]
                 entry["tokens"] = _token_estimate(fpath)
             elif norm.endswith("SKILL.md"):
+                # SKILL.md sits at the skill root in every layout, collection or flat.
                 parts = norm.rstrip("/").split("/")
-                idx = next((i for i, p in enumerate(parts) if p == "skills"), -1)
-                if idx >= 0 and idx + 2 < len(parts):
-                    entry["skill"] = parts[idx + 2]
-                elif len(parts) >= 2:
+                if len(parts) >= 2:
                     entry["skill"] = parts[-2]
                 entry["tokens"] = _token_estimate(fpath)
         if isinstance(tool_input, dict) and tool_name in ("runSubagent", "task"):
@@ -919,16 +1231,22 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
             entry["tool_response_len"] = len(tool_result)
         else:
             entry["tool_response_len"] = len(json.dumps(tool_result))
-        entry["agent"] = stack.current()
+        _attribute_agent(entry, stack.active())
     elif event == "SubagentStart":
         agent_name = _payload_get(data, "agent_name")
+        agent_id = _payload_get(data, "agent_id")
         entry["agent_name"] = agent_name
         entry["agent_display_name"] = _payload_get(data, "agent_display_name")
-        stack.push(agent_name)
+        if agent_id:
+            entry["agent_id"] = agent_id
+        stack.push(agent_id, agent_name)
     elif event == "SubagentStop":
         agent_name = _payload_get(data, "agent_name")
+        agent_id = _payload_get(data, "agent_id")
         entry["agent_name"] = agent_name
-        stack.pop()
+        if agent_id:
+            entry["agent_id"] = agent_id
+        stack.pop(agent_id, agent_name)
     elif event == "PreCompact":
         entry["trigger"] = _payload_get(data, "trigger")
     elif event == "Stop":
@@ -943,10 +1261,24 @@ def build_entry(data: dict, event: str, stack: _AgentStack) -> dict | None:
     return entry
 
 
+def _read_stdin_text() -> str:
+    """Read the hook payload as UTF-8 regardless of the host locale.
+
+    Windows decodes ``sys.stdin`` with the ANSI codepage and a POSIX/C locale
+    decodes it as ASCII, either of which mangles or rejects UTF-8 payload
+    bytes. ``UnicodeDecodeError`` subclasses ``ValueError``, so a rejected
+    payload would otherwise be dropped as if it were malformed JSON.
+    """
+    buffer = getattr(sys.stdin, "buffer", None)
+    if buffer is None:
+        return sys.stdin.read()
+    return buffer.read().decode("utf-8", errors="replace")
+
+
 def _mode_collect() -> int:
     """Process a single hook event from stdin; returns a process exit code."""
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(_read_stdin_text())
     except ValueError:
         return 0
     if not isinstance(data, dict):
@@ -974,12 +1306,16 @@ def _mode_collect() -> int:
     # omits the event) still reaches cross-project reports. Bounded to one
     # registry read per store per day plus each session start.
     first_write = not log_file.exists()
-    tel_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        tel_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # An unwritable store is a telemetry failure, not a turn failure. The
+        # writes below are best-effort and skip themselves for the same reason.
+        return 0
     if event == "SessionStart" or first_write:
         register_telemetry_dir(tel_dir)
         write_report_launchers()
-    with open(log_file, "a", encoding="utf-8") as handle:
-        handle.write(json.dumps(entry) + "\n")
+    append_jsonl(log_file, entry)
 
     # Enrich the log with a SessionSummary of token totals and model usage.
     # Emitted at SessionEnd (the authoritative final snapshot), at Stop (each
@@ -1004,8 +1340,7 @@ def _mode_collect() -> int:
                 client=_detect_client(),
             )
             if summary is not None:
-                with open(log_file, "a", encoding="utf-8") as handle:
-                    handle.write(json.dumps(summary) + "\n")
+                append_jsonl(log_file, summary)
     return 0
 
 
@@ -1075,13 +1410,19 @@ def _mode_aggregate_session(out: str, hook_files: list[str]) -> int:
 # these known names so a directory a user pointed ``HVE_TELEMETRY_DIR`` at is
 # never removed wholesale.
 _TELEMETRY_FILE_ARTIFACTS = ("raw-input.jsonl", "report.generated.html")
-_TELEMETRY_GLOB_ARTIFACTS = ("sessions-*.jsonl",)
+# One session log per UTC day, plus any fallback shard a collector wrote when it
+# could not lock that log (sessions-<date>.<HHMMSSffffff>-<pid>-<hex>.jsonl).
+_TELEMETRY_GLOB_ARTIFACTS = ("sessions-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*.jsonl",)
 _TELEMETRY_DIR_ARTIFACTS = (".stacks",)
 
 # Artifacts written into the HVE home directory (registry plus generated
-# cross-project launchers and report).
+# cross-project launchers and report). ``telemetry-dirs.txt`` and its lock are
+# the pre-directory registry, listed so an upgraded install is tidied up too.
 _HVE_HOME_ARTIFACTS = (
+    "telemetry-dirs",
     "telemetry-dirs.txt",
+    "telemetry-dirs.txt.lock",
+    "telemetry-dirs.txt.migrated",
     "report.generated.html",
     "generate-report.sh",
     "generate-report.ps1",
@@ -1166,22 +1507,19 @@ def _mode_clean(all_dirs: bool, dry_run: bool) -> int:
 def _mode_list_dirs() -> int:
     """Print registered telemetry dirs that still exist; prune dead entries.
 
-    Pruning rewrites the registry only when stale paths are dropped, keeping
-    the cross-project report scan fast as repositories come and go.
+    Pruning unlinks the marker for a store that has been deleted, keeping the
+    cross-project report scan fast as repositories come and go.
     """
     registry = telemetry_registry()
-    dirs = read_registry_dirs(registry)
-    live = [d for d in dirs if Path(d).is_dir()]
-    if live != dirs:
+    for directory in read_registry_dirs(registry):
+        if Path(directory).is_dir():
+            sys.stdout.write(directory + "\n")
+            continue
         try:
-            registry.parent.mkdir(parents=True, exist_ok=True)
-            with open(registry, "w", encoding="utf-8") as handle:
-                handle.write("".join(d + "\n" for d in live))
+            _registry_marker(registry, directory).unlink(missing_ok=True)
         except OSError:
-            # Cannot rewrite the registry; keep stale entries rather than fail.
-            pass
-    for directory in live:
-        sys.stdout.write(directory + "\n")
+            # Cannot prune this marker; leave it rather than fail the listing.
+            continue
     return 0
 
 

--- a/.github/hooks/shared/telemetry/clean-telemetry.sh
+++ b/.github/hooks/shared/telemetry/clean-telemetry.sh
@@ -13,9 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 readonly CORE_PY="${SCRIPT_DIR}/_telemetry_core.py"
 
-# Repo root anchors the default telemetry path so the script works from any cwd.
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || true)"
-[[ -n "${REPO_ROOT}" ]] || REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# Match the collector and anchor on the caller's workspace: the script itself
+# may live outside the repo it cleans, so its location says nothing.
+REPO_ROOT="${HVE_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[[ -n "${REPO_ROOT}" ]] || REPO_ROOT="${PWD}"
 readonly REPO_ROOT
 
 usage() {
@@ -28,8 +29,11 @@ report.generated.html) from a telemetry store. Unrelated files are preserved.
 Options:
   -a, --all-dirs    Also clean every per-project telemetry directory recorded
                     in the user-level registry, plus the generated launchers,
-                    report, and registry in the HVE home directory.
-  -p, --path DIR    Telemetry directory. Default: <repo>/.copilot-tracking/telemetry
+                    report, and registry in the HVE home directory. Ignored
+                    when --path is given.
+  -p, --path DIR    Telemetry directory. Scopes the cleanup to this directory
+                    alone, overriding --all-dirs.
+                    Default: <repo>/.copilot-tracking/telemetry
   -n, --dry-run     List what would be removed without deleting anything.
   -y, --yes         Skip the confirmation prompt (required for non-interactive
                     use).
@@ -62,11 +66,12 @@ main() {
   local all_dirs=0
   local dry_run=0
   local assume_yes=0
+  local path_explicit=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -a|--all-dirs) all_dirs=1; shift ;;
-      -p|--path) telemetry_path="$2"; shift 2 ;;
+      -p|--path) telemetry_path="$2"; path_explicit=1; shift 2 ;;
       -n|--dry-run) dry_run=1; shift ;;
       -y|--yes) assume_yes=1; shift ;;
       -h|--help) usage; exit 0 ;;
@@ -76,6 +81,15 @@ main() {
 
   command -v python3 &>/dev/null || err "'python3' is required but not installed"
   [[ -f "${CORE_PY}" ]] || err "Telemetry engine not found: ${CORE_PY}"
+
+  # An explicit --path narrows the scope. The generated launcher always passes
+  # --all-dirs, so announce the override rather than silently widening or
+  # dropping a destructive scope flag.
+  if (( all_dirs && path_explicit )); then
+    all_dirs=0
+    printf "Ignoring --all-dirs because --path was given; scope is '%s'.\n" \
+      "${telemetry_path}" >&2
+  fi
 
   if (( ! dry_run && ! assume_yes )); then
     local scope_desc="${telemetry_path}"

--- a/.github/hooks/shared/telemetry/generate-telemetry-report.sh
+++ b/.github/hooks/shared/telemetry/generate-telemetry-report.sh
@@ -119,11 +119,11 @@ main() {
   local pattern="sessions-${target_date}.jsonl"
   [[ "${target_date}" == "all" ]] && pattern="sessions-*.jsonl"
   declare -a files=()
-  declare -A seen_dirs=()
+  local seen_dirs=""
   local dir
   for dir in "${search_dirs[@]}"; do
-    [[ -n "$dir" && -z "${seen_dirs[$dir]:-}" ]] || continue
-    seen_dirs["$dir"]=1
+    [[ -n "$dir" && "$seen_dirs" != *"|${dir}|"* ]] || continue
+    seen_dirs+="|${dir}|"
     [[ -d "$dir" ]] || continue
     while IFS= read -r -d '' f; do
       files+=("$f")

--- a/.github/hooks/shared/telemetry/generate-telemetry-report.sh
+++ b/.github/hooks/shared/telemetry/generate-telemetry-report.sh
@@ -27,7 +27,7 @@ Options:
   -d, --date DATE       Target date (yyyy-MM-dd). Default: today (UTC).
                         Use 'all' to include every sessions-*.jsonl file.
   -a, --all-dirs        Scan every per-project telemetry directory recorded in
-                        the user-level registry (~/.hve/telemetry-dirs.txt) for
+                        the user-level registry (~/.hve/telemetry-dirs) for
                         a combined cross-project report. Ignored when --path is
                         given.
   -p, --path DIR        Telemetry directory. Scopes the report to this directory
@@ -86,9 +86,11 @@ main() {
   local path_explicit=0
 
   # Temp files/dirs cleaned up on return (single trap to avoid overrides).
+  # EXIT is listed too: several paths below exit outright, and RETURN alone
+  # would leave the enrichment temp directory behind in /tmp on each of them.
   local -a tmp_files=()
   # shellcheck disable=SC2154  # 't' is the loop variable, assigned within the trap body.
-  trap 'for t in "${tmp_files[@]:-}"; do [[ -n "$t" ]] && rm -rf "$t"; done' RETURN
+  trap 'for t in "${tmp_files[@]:-}"; do [[ -n "$t" ]] && rm -rf "$t"; done' RETURN EXIT
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -126,19 +128,25 @@ main() {
   search_dirs+=("${telemetry_path}")
 
   # Collect session files for the target date across the chosen directories,
-  # de-duplicating directories that appear more than once.
-  local pattern="sessions-${target_date}.jsonl"
-  [[ "${target_date}" == "all" ]] && pattern="sessions-*.jsonl"
+  # de-duplicating directories that appear more than once. The trailing '*'
+  # also picks up any shard a collector wrote when it could not lock the shared
+  # log; report.html orders every record it loads by ts.
+  local prefix="sessions-${target_date}"
+  [[ "${target_date}" == "all" ]] && prefix="sessions-"
   declare -a files=()
   local seen_dirs=""
-  local dir
+  local dir f
   for dir in "${search_dirs[@]}"; do
     [[ -n "$dir" && "$seen_dirs" != *"|${dir}|"* ]] || continue
     seen_dirs+="|${dir}|"
     [[ -d "$dir" ]] || continue
-    while IFS= read -r -d '' f; do
-      files+=("$f")
-    done < <(find "$dir" -maxdepth 1 -name "${pattern}" -print0 | sort -z)
+    # A glob rather than find | sort -z: pathname expansion is already sorted
+    # and needs no GNU-only flags, so this runs on macOS's BSD userland. Only
+    # the '*' is unquoted, so a date holding a space cannot split into two
+    # patterns; an unmatched glob expands to itself and the -f test discards it.
+    for f in "$dir"/"$prefix"*.jsonl; do
+      [[ -f "$f" ]] && files+=("$f")
+    done
   done
 
   if [[ -n "${debug_log}" ]]; then
@@ -168,9 +176,12 @@ main() {
     exit 0
   fi
 
-  # Build a compact JSON array of {name, content} objects with jq, then
-  # neutralize any literal </script> so the embedded JSON cannot break out
-  # of its host <script> element. The HTML loader decodes the <\/ escape.
+  # Build a compact JSON array of {name, content} objects with jq, then escape
+  # every '<' as \u003c. Session content routinely quotes markup, and inside a
+  # <script> element the HTML tokenizer treats not only </script> but also an
+  # unbalanced <!-- followed by <script as a state change, which swallows the
+  # closing tag and corrupts the payload. Escaping '<' removes all three cases;
+  # JSON.parse decodes \u003c back to '<'.
   declare -a obj_json=()
   local f
   for f in "${files[@]}"; do
@@ -181,7 +192,7 @@ main() {
   done
 
   local data
-  data="$(printf '%s\n' "${obj_json[@]}" | jq -s -c '.' | sed 's#</#<\\/#g')"
+  data="$(printf '%s\n' "${obj_json[@]}" | jq -s -c '.' | sed 's#<#\\u003c#g')"
 
   # Inject the data into the embeddedData script element. The payload is
   # streamed from a temp file via getline rather than passed through argv or

--- a/.github/hooks/shared/telemetry/generate-telemetry-report.sh
+++ b/.github/hooks/shared/telemetry/generate-telemetry-report.sh
@@ -13,9 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 readonly TEMPLATE_PATH="${SCRIPT_DIR}/report.html"
 
-# Repo root anchors the default telemetry path so the script works from any cwd.
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || true)"
-[[ -n "${REPO_ROOT}" ]] || REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# Match the collector and anchor on the caller's workspace: the script itself
+# may live outside the repo it reports on, so its location says nothing.
+REPO_ROOT="${HVE_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[[ -n "${REPO_ROOT}" ]] || REPO_ROOT="${PWD}"
 readonly REPO_ROOT
 
 usage() {
@@ -26,9 +27,12 @@ Options:
   -d, --date DATE       Target date (yyyy-MM-dd). Default: today (UTC).
                         Use 'all' to include every sessions-*.jsonl file.
   -a, --all-dirs        Scan every per-project telemetry directory recorded in
-                        the user-level registry (~/.copilot/telemetry-dirs.txt)
-                        for a combined cross-project report.
-  -p, --path DIR        Telemetry directory. Default: <repo>/.copilot-tracking/telemetry
+                        the user-level registry (~/.hve/telemetry-dirs.txt) for
+                        a combined cross-project report. Ignored when --path is
+                        given.
+  -p, --path DIR        Telemetry directory. Scopes the report to this directory
+                        alone, overriding --all-dirs.
+                        Default: <repo>/.copilot-tracking/telemetry
   -l, --debug-log FILE  Optional debug log JSONL (e.g. main.jsonl) for tokens.
                         When omitted, VS Code debug logs are auto-discovered and
                         the precise model version (e.g. claude-opus-4.6) plus
@@ -79,6 +83,7 @@ main() {
   local output_path=""
   local open_report=0
   local all_dirs=0
+  local path_explicit=0
 
   # Temp files/dirs cleaned up on return (single trap to avoid overrides).
   local -a tmp_files=()
@@ -89,7 +94,7 @@ main() {
     case "$1" in
       -d|--date) target_date="$2"; shift 2 ;;
       -a|--all-dirs) all_dirs=1; shift ;;
-      -p|--path) telemetry_path="$2"; shift 2 ;;
+      -p|--path) telemetry_path="$2"; path_explicit=1; shift 2 ;;
       -l|--debug-log) debug_log="$2"; shift 2 ;;
       -o|--output) output_path="$2"; shift 2 ;;
       --open) open_report=1; shift ;;
@@ -106,8 +111,14 @@ main() {
 
   # Determine which telemetry directories to scan. With --all-dirs, prepend
   # every directory recorded in the user-level registry (cross-project view).
+  # An explicit --path wins so the generated cross-project launcher, which
+  # always passes --all-dirs, can still be scoped to one store.
+  if (( all_dirs && path_explicit )); then
+    printf "Ignoring --all-dirs because --path was given; scanning '%s' only.\n" \
+      "${telemetry_path}" >&2
+  fi
   declare -a search_dirs=()
-  if (( all_dirs )); then
+  if (( all_dirs && ! path_explicit )); then
     while IFS= read -r d; do
       [[ -n "$d" ]] && search_dirs+=("$d")
     done < <(registry_dirs)

--- a/.github/hooks/shared/telemetry/pyproject.toml
+++ b/.github/hooks/shared/telemetry/pyproject.toml
@@ -19,6 +19,9 @@ fuzz = [
 testpaths = ["tests"]
 pythonpath = ["."]
 python_files = ["test_*.py", "fuzz_harness.py"]
+markers = [
+    "slow: spawns collector subprocesses; deselect with -m 'not slow'",
+]
 
 [tool.ruff]
 line-length = 100

--- a/.github/hooks/shared/telemetry/report.html
+++ b/.github/hooks/shared/telemetry/report.html
@@ -62,6 +62,7 @@
   .tag-tool { background: rgba(206,145,120,0.15); color: var(--orange); }
   .tag-client { background: rgba(86,156,214,0.15); color: var(--accent); font-weight: 600; }
   .tag-approx { background: rgba(255,255,255,0.06); color: var(--text-dim); font-style: italic; cursor: help; }
+  .tag-share { background: rgba(255,255,255,0.08); color: var(--text-dim); cursor: help; }
 
   .agent-usage-breakdown { margin-top: 4px; border-top: 1px solid var(--border); padding-top: 4px; }
   .agent-usage-row { display: flex; align-items: center; gap: 6px; margin: 2px 0; }
@@ -217,11 +218,15 @@
 
   /** Build per-session profile from hook events */
   function buildSessions() {
+    // Records arrive per file: a day's log, any shard a collector wrote when it
+    // could not lock that log, and whatever a user drags in. Latency pairs
+    // Pre/Post by position, so order by ts before reading them.
+    hookEvents.sort((a, b) => (a.ts || '') < (b.ts || '') ? -1 : (a.ts || '') > (b.ts || '') ? 1 : 0);
     const sessions = {};
     for (const e of hookEvents) {
       if (!sessions[e.sid]) {
         sessions[e.sid] = {
-          sid: e.sid, cwd: '', model: new Set(), modelHint: new Set(), agents: new Set(),
+          sid: e.sid, cwd: '', model: new Set(), modelHint: new Set(),
           instructions: new Set(), skills: new Set(), subagents: new Set(),
           instrTokens: {}, skillTokens: {},
           tools: {}, toolCount: 0, firstTs: e.ts, lastTs: e.ts,
@@ -295,6 +300,7 @@
         // Per-subagent token attribution from process log partitioning
         if (e.agent_usage) {
           s.agentUsage = e.agent_usage;
+          s.agentUsageExact = true;
         }
       }
 
@@ -320,9 +326,6 @@
       // Subagent invocations
       if (e.event === 'SubagentStart') s.subagents.add(e.agent_name || e.agent_display_name || '');
       if (e.subagent) s.subagents.add(e.subagent);
-
-      // Agent context (who called the tool)
-      if (e.agent && e.agent !== 'root') s.agents.add(e.agent);
 
       // Tool usage and latency (sequential correlation by tool name)
       if (e.event === 'PreToolUse' && e.tool) {
@@ -422,19 +425,43 @@
       }
       // Synthesize per-agent usage from child session data when the backend
       // did not emit agent_usage (e.g. process log was unavailable).
-      if (!parent.agentUsage && cu.requests) {
-        if (!parent.agentUsage) parent.agentUsage = {};
-        parent.agentUsage[agentLabel] = {
-          output_tokens: cu.output, input_tokens: cu.input,
-          cache_read_tokens: cu.cached, total_nano_aiu: cu.aiu,
-          requests: cu.requests,
-        };
+      if (!parent.agentUsageExact && cu.requests) {
+        if (!parent.agentUsageSynth) parent.agentUsageSynth = {};
+        const b = parent.agentUsageSynth[agentLabel] || (parent.agentUsageSynth[agentLabel] = {
+          output_tokens: 0, input_tokens: 0, cache_read_tokens: 0, total_nano_aiu: 0, requests: 0,
+        });
+        b.output_tokens += cu.output; b.input_tokens += cu.input;
+        b.cache_read_tokens += cu.cached; b.total_nano_aiu += cu.aiu;
+        b.requests += cu.requests;
       }
       // Extend parent time range
       if (child.firstTs < parent.firstTs) parent.firstTs = child.firstTs;
       if (child.lastTs > parent.lastTs) parent.lastTs = child.lastTs;
       // Remove the child session
       delete sessions[childSid];
+    }
+
+    // Close a synthesized split with the root remainder, so its lines reconcile
+    // with the session total the way an exact process-log split does.
+    for (const s of Object.values(sessions)) {
+      if (s.agentUsageExact || !s.agentUsageSynth) continue;
+      const subs = Object.values(s.agentUsageSynth);
+      const sum = (k) => subs.reduce((t, b) => t + (b[k] || 0), 0);
+      s.agentUsage = Object.assign({}, s.agentUsageSynth);
+      const rem = {
+        output_tokens: s.usage.output - sum('output_tokens'),
+        input_tokens: s.usage.input - sum('input_tokens'),
+        cache_read_tokens: s.usage.cached - sum('cache_read_tokens'),
+        total_nano_aiu: s.usage.aiu - sum('total_nano_aiu'),
+        requests: s.usage.requests - sum('requests'),
+      };
+      // Only claim a root line when the parent's own usage was measured. Where
+      // it was not, a clamped remainder would render as a measured zero.
+      if (rem.requests > 0 || rem.output_tokens > 0 || rem.total_nano_aiu > 0) {
+        for (const k of Object.keys(rem)) rem[k] = Math.max(0, rem[k]);
+        s.agentUsage.root = rem;
+      }
+      s.agentUsageApprox = true;
     }
 
     return Object.values(sessions);
@@ -512,6 +539,27 @@
         { label: 'Output Tokens', value: fmtTokens(totalOut) }
       );
     }
+    // How much of the spend happened inside subagents rather than the root agent.
+    // The basis must be common to every session: preferring AIU while some
+    // sessions report none would drop their subagent spend from the total.
+    const withUsage = sessions.filter(s => Object.keys(s.agentUsage || {}).length);
+    const useAiu = withUsage.length > 0 && withUsage.every(s =>
+      Object.values(s.agentUsage).some(au => (au.total_nano_aiu || 0) > 0));
+    const weigh = au => useAiu ? (au.total_nano_aiu || 0) : (au.output_tokens || 0);
+    let shareNum = 0, shareDen = 0;
+    withUsage.forEach(s => {
+      for (const [n, au] of Object.entries(s.agentUsage)) {
+        shareDen += weigh(au);
+        if (n !== 'root') shareNum += weigh(au);
+      }
+    });
+    if (shareNum > 0 && shareDen > 0) {
+      cards.push({
+        label: 'Subagent Share',
+        value: Math.round(shareNum / shareDen * 100) + '%',
+        title: `Portion of ${useAiu ? 'AIU' : 'output tokens'} spent inside subagents rather than the root agent`
+      });
+    }
     grid.innerHTML = cards.map(c => `<div class="card"${c.title ? ` title="${esc(c.title)}"` : ''}><div class="label">${esc(c.label)}</div><div class="value">${esc(c.value)}</div></div>`).join('');
   }
 
@@ -540,20 +588,37 @@
           (u.aiu ? `<span class="tag tag-model">${fmtAiu(u.aiu)} AIU</span>` : '') +
           `<span class="meta">${u.requests} request${u.requests === 1 ? '' : 's'}</span>`
         : dim('no debug-log usage');
-      // Per-subagent token breakdown
+      // Per-agent token split. A process-log split is exact: each request
+      // carries its own agent_id. A synthesized split is reconstructed from
+      // merged child sessions and is marked approximate.
       if (s.agentUsage) {
-        const agentLines = Object.entries(s.agentUsage)
-          .filter(([name]) => name !== 'root')
-          .sort((a, b) => (b[1].output_tokens || 0) - (a[1].output_tokens || 0))
+        const entries = Object.entries(s.agentUsage);
+        const aiuTotal = entries.reduce((t, [, au]) => t + (au.total_nano_aiu || 0), 0);
+        const outTotal = entries.reduce((t, [, au]) => t + (au.output_tokens || 0), 0);
+        // Share is measured in AIU where the host reports it, since that is the
+        // billed unit; output tokens are the fallback basis.
+        const basis = aiuTotal > 0 ? 'AIU' : 'output tokens';
+        const denom = aiuTotal > 0 ? aiuTotal : outTotal;
+        const weight = au => aiuTotal > 0 ? (au.total_nano_aiu || 0) : (au.output_tokens || 0);
+        const agentLines = entries
+          .sort((a, b) => weight(b[1]) - weight(a[1]))
           .map(([name, au]) => {
-            const freshIn = Math.max(0, (au.input_tokens || 0) - (au.cache_read_tokens || 0));
+            const freshIn = typeof au.input_tokens_uncached === 'number'
+              ? Math.max(0, au.input_tokens_uncached)
+              : Math.max(0, (au.input_tokens || 0) - (au.cache_read_tokens || 0));
+            const pct = denom > 0 ? Math.round(weight(au) / denom * 100) : 0;
             return `<div class="agent-usage-row"><span class="tag tag-agent">${esc(name)}</span>` +
+              `<span class="tag tag-share" title="Share of session ${basis}">${pct}%</span>` +
               `<span class="meta">${fmtTokens(freshIn)} in · ${fmtTokens(au.output_tokens || 0)} out` +
               (au.total_nano_aiu ? ` · ${fmtAiu(au.total_nano_aiu)} AIU` : '') +
               ` · ${au.requests || 0} req</span></div>`;
           });
-        if (agentLines.length) {
-          tokens += `<div class="agent-usage-breakdown">${agentLines.join('')}</div>`;
+        // A lone root line just restates the totals; only a real split is useful.
+        if (agentLines.length > 1) {
+          const approx = s.agentUsageApprox
+            ? `<span class="tag tag-approx" title="Reconstructed from merged subagent sessions rather than a per-request process log">approx</span>`
+            : '';
+          tokens += `<div class="agent-usage-breakdown">${approx}${agentLines.join('')}</div>`;
         }
       }
 
@@ -655,7 +720,7 @@
 
   function fmtDuration(ms) {
     const s = ms / 1000;
-    if (s < 1) return ms + 'ms';
+    if (s < 1) return Math.round(ms) + 'ms';
     if (s < 60) return s.toFixed(1) + 's';
     if (s < 3600) return Math.floor(s / 60) + 'm ' + Math.floor(s % 60) + 's';
     return Math.floor(s / 3600) + 'h ' + Math.floor((s % 3600) / 60) + 'm';

--- a/.github/hooks/shared/telemetry/telemetry-collector.sh
+++ b/.github/hooks/shared/telemetry/telemetry-collector.sh
@@ -18,7 +18,7 @@ main() {
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
   [[ -z "$repo_root" ]] && repo_root="${HVE_REPO_ROOT:-.}"
 
-  # Opt-in gate — exit immediately if telemetry is not enabled
+  # Opt-in gate: exit immediately if telemetry is not enabled
   if [[ "${HVE_TELEMETRY:-}" != "1" ]]; then
     if [[ ! -f "$repo_root/.hve-telemetry" ]]; then
       echo '{"continue":true}'
@@ -28,7 +28,7 @@ main() {
 
   # Require Python3 for JSON processing
   if ! command -v python3 &>/dev/null; then
-    echo "WARNING: HVE telemetry enabled but python3 not found — events will not be recorded" >&2
+    echo "WARNING: HVE telemetry enabled but python3 not found, events will not be recorded" >&2
     echo '{"continue":true}'
     return 0
   fi

--- a/.github/hooks/shared/telemetry/telemetry-collector.sh
+++ b/.github/hooks/shared/telemetry/telemetry-collector.sh
@@ -13,10 +13,13 @@ main() {
   input=$(cat)
 
   # Resolve repository root for reliable path anchoring across all surfaces
-  # (CLI, VS Code, cloud agent). Falls back to HVE_REPO_ROOT or cwd.
-  local repo_root
-  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-  [[ -z "$repo_root" ]] && repo_root="${HVE_REPO_ROOT:-.}"
+  # (CLI, VS Code, cloud agent). The explicit override wins over git discovery
+  # so a host can anchor the store outside the current checkout.
+  local repo_root="${HVE_REPO_ROOT:-}"
+  if [[ -z "$repo_root" ]] && command -v git &>/dev/null; then
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  [[ -z "$repo_root" ]] && repo_root="."
 
   # Opt-in gate: exit immediately if telemetry is not enabled
   if [[ "${HVE_TELEMETRY:-}" != "1" ]]; then
@@ -26,9 +29,19 @@ main() {
     fi
   fi
 
-  # Require Python3 for JSON processing
-  if ! command -v python3 &>/dev/null; then
-    echo "WARNING: HVE telemetry enabled but python3 not found, events will not be recorded" >&2
+  # Require Python for JSON processing. The engine needs 3.11 (datetime.UTC),
+  # and on some systems `python` is still a 2.x or an older 3.x, so probe the
+  # version rather than trusting the name.
+  local python_bin="" candidate
+  for candidate in python3 python; do
+    if command -v "$candidate" &>/dev/null &&
+      "$candidate" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' &>/dev/null; then
+      python_bin="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$python_bin" ]]; then
+    echo "WARNING: HVE telemetry enabled but no Python 3.11+ found, events will not be recorded" >&2
     echo '{"continue":true}'
     return 0
   fi
@@ -38,8 +51,19 @@ main() {
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   core_py="${script_dir}/_telemetry_core.py"
 
+  if [[ ! -f "$core_py" ]]; then
+    echo "WARNING: Telemetry engine not found at $core_py, events will not be recorded" >&2
+    echo '{"continue":true}'
+    return 0
+  fi
+
   local telemetry_dir="${HVE_TELEMETRY_DIR:-$repo_root/.copilot-tracking/telemetry}"
-  mkdir -p "$telemetry_dir" "$telemetry_dir/.stacks"
+  # An unwritable store is a telemetry failure, not a turn failure: under set -e
+  # an unguarded mkdir would exit before the continue signal and stall the turn.
+  if ! mkdir -p "$telemetry_dir" "$telemetry_dir/.stacks" 2>/dev/null; then
+    echo '{"continue":true}'
+    return 0
+  fi
 
   # Dump raw input for diagnostics (first 5 events only). This records hook
   # payloads verbatim, including the full prompt text and tool inputs such as
@@ -63,7 +87,7 @@ main() {
   # session with token/cost data.
   export HVE_REPO_ROOT="$repo_root"
   export HVE_TELEMETRY_DIR="$telemetry_dir"
-  echo "$input" | python3 "$core_py" collect || true
+  echo "$input" | "$python_bin" "$core_py" collect || true
 
   echo '{"continue":true}'
 }

--- a/.github/hooks/shared/telemetry/tests/fuzz_harness.py
+++ b/.github/hooks/shared/telemetry/tests/fuzz_harness.py
@@ -70,17 +70,15 @@ def fuzz_build_entry(data: bytes) -> None:
         "tool_name": provider.ConsumeUnicodeNoSurrogates(15),
         "prompt": provider.ConsumeUnicodeNoSurrogates(50),
     }
+    import shutil
     import tempfile
-    from pathlib import Path
 
     stack_dir = Path(tempfile.mkdtemp())
     stack = core._AgentStack(stack_dir, payload["session_id"])
     with suppress(Exception):
         core.build_entry(payload, event, stack)
-    # Cleanup
-    for f in stack_dir.iterdir():
-        f.unlink(missing_ok=True)
-    stack_dir.rmdir()
+    # rmtree, not unlink: a session's op log lives in a subdirectory.
+    shutil.rmtree(stack_dir, ignore_errors=True)
 
 
 FUZZ_TARGETS = [

--- a/.github/hooks/shared/telemetry/tests/test_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/tests/test_telemetry_core.py
@@ -17,6 +17,12 @@ def _write_jsonl(path, rows):
     path.write_text("".join(json.dumps(r) + "\n" for r in rows))
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hve_home(tmp_path, monkeypatch):
+    """Keep registry and launcher writes out of the real user home."""
+    monkeypatch.setenv("HVE_HOME", str(tmp_path / "hve-home"))
+
+
 def test_given_blank_and_malformed_lines_when_iter_jsonl_then_skips_them(tmp_path):
     f = tmp_path / "events.jsonl"
     f.write_text('{"a": 1}\n\n  \nnot-json\n{"b": 2}\n')
@@ -399,6 +405,38 @@ def test_given_cli_posttooluse_payload_when_normalize_event_then_infers_posttool
     assert core._normalize_event(data) == "PostToolUse"
 
 
+def test_given_snake_case_tool_response_when_normalize_event_then_infers_posttooluse():
+    # VS Code names the tool output tool_response; without alias-aware
+    # inference this payload is mistaken for a PreToolUse.
+    data = {"session_id": "s", "tool_name": "read", "tool_response": {}}
+    assert core._normalize_event(data) == "PostToolUse"
+
+
+def test_given_snake_case_stop_reason_when_normalize_event_then_infers_subagent_stop():
+    data = {"session_id": "s", "agent_name": "explore", "stop_reason": "end_turn"}
+    assert core._normalize_event(data) == "SubagentStop"
+
+
+def test_given_tool_response_payload_when_build_entry_then_measures_length(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    data = {
+        "session_id": "sid1",
+        "tool_name": "read",
+        "tool_response": {"text_result_for_llm": "abcde"},
+    }
+    entry = core.build_entry(data, "PostToolUse", stack)
+    assert entry["tool_response_len"] == 5
+
+
+def test_given_vscode_subagent_payload_when_build_entry_then_names_agent(tmp_path):
+    # VS Code identifies the subagent only by agent_type.
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    data = {"session_id": "sid1", "agent_id": "sub-1", "agent_type": "Plan"}
+    entry = core.build_entry(data, "SubagentStart", stack)
+    assert entry["agent_name"] == "Plan"
+    assert stack.current() == "Plan"
+
+
 def test_given_cli_prompt_payload_when_normalize_event_then_infers_userpromptsubmit():
     assert core._normalize_event({"sessionId": "s", "prompt": "hi"}) == "UserPromptSubmit"
 
@@ -632,6 +670,18 @@ def test_given_session_start_when_mode_collect_then_registers_dir(tmp_path, monk
     else:
         assert (hve / "generate-report.sh").is_file()
         assert (hve / "clean-telemetry.sh").is_file()
+
+
+def test_given_no_session_start_when_mode_collect_then_still_registers_dir(tmp_path, monkeypatch):
+    tel_dir = tmp_path / "tel"
+    hve = tmp_path / "hve"
+    monkeypatch.setenv("HVE_TELEMETRY_DIR", str(tel_dir))
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HVE_HOME", str(hve))
+    payload = {"hook_event_name": "UserPromptSubmit", "session_id": "sid1", "prompt": "hi"}
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    assert core._mode_collect() == 0
+    assert core.read_registry_dirs(hve / "telemetry-dirs.txt") == [str(tel_dir.resolve())]
 
 
 def test_given_stale_entries_when_mode_list_dirs_then_prunes_and_prints(

--- a/.github/hooks/shared/telemetry/tests/test_telemetry_core.py
+++ b/.github/hooks/shared/telemetry/tests/test_telemetry_core.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import re
+import subprocess
+import sys
 
 import pytest
 
@@ -357,13 +361,83 @@ def test_given_shutdown_missing_metrics_when_summary_then_output_from_messages(t
     assert summary["input_tokens_uncached"] == 4
 
 
-def test_given_single_element_stack_when_current_then_returns_full_name(tmp_path):
+def _session_records(tel_dir):
+    """Read every record the store holds, in file order."""
+    records = []
+    for path in _session_files(tel_dir):
+        text = path.read_text(encoding="utf-8")
+        records.extend(json.loads(line) for line in text.splitlines() if line.strip())
+    return records
+
+
+def _session_files(tel_dir):
+    """Return every session log and shard the store holds, in name order."""
+    return sorted(tel_dir.glob("sessions-*.jsonl"))
+
+
+def test_given_one_active_agent_when_replayed_then_reports_full_name(tmp_path):
     stack = core._AgentStack(tmp_path / ".stacks", "sid1")
-    stack.push("Researcher")
-    assert stack.current() == "Researcher"
+    stack.push("sub-1", "Researcher")
+    assert stack.active() == ["Researcher"]
 
 
-def test_given_subagent_pushed_when_build_entry_pretooluse_then_reports_agent(tmp_path):
+def test_given_overlapping_subagents_when_one_stops_then_removes_it_by_id(tmp_path):
+    """Subagents can overlap, so a stop must not simply drop the newest entry."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("sub-1", "Alpha")
+    stack.push("sub-2", "Beta")
+    stack.pop("sub-1", "Alpha")
+    assert stack.active() == ["Beta"]
+    stack.pop("sub-2", "Beta")
+    assert stack.active() == []
+
+
+def test_given_same_named_subagents_when_one_stops_then_keeps_the_other(tmp_path):
+    """Concurrent subagents share a type name; only the invocation id separates them."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("sub-1", "Explore")
+    stack.push("sub-2", "Explore")
+    stack.pop("sub-1", "Explore")
+    assert stack.active() == ["Explore"]
+
+
+def test_given_unmatched_pop_when_replaying_then_keeps_live_agents(tmp_path):
+    """A lost push must not let the stop evict an unrelated running agent."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("sub-1", "Alpha")
+    stack.pop("sub-9", "Ghost")
+    assert stack.active() == ["Alpha"]
+
+
+def test_given_same_timestamp_push_and_pop_when_replaying_then_cancels(tmp_path):
+    """A short subagent stamps both ops in one tick on a coarse clock.
+
+    Sorting the pop first would leave it unmatched and the agent active forever.
+    """
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    same_ts = "2026-01-01T00:00:00+00:00"
+    for op in ("pop", "push"):
+        core.append_jsonl(stack.stack_file, {"ts": same_ts, "op": op, "id": "sub-1", "agent": "A"})
+    assert stack.active() == []
+
+
+def test_given_name_only_surface_when_pushed_then_name_serves_as_identity(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("", "Alpha")
+    stack.pop("", "Alpha")
+    assert stack.active() == []
+
+
+def test_given_active_agents_when_cleared_then_returns_to_root(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("sub-1", "Alpha")
+    stack.push("sub-2", "Beta")
+    stack.clear()
+    assert stack.active() == []
+
+
+def test_given_subagent_pushed_when_build_entry_pretooluse_then_lists_candidates(tmp_path):
+    """Tool calls run in parallel, so an active subagent is only a candidate."""
     stack = core._AgentStack(tmp_path / ".stacks", "sid1")
     core.build_entry(
         {"hook_event_name": "SubagentStart", "agent_name": "Coder"}, "SubagentStart", stack
@@ -371,7 +445,66 @@ def test_given_subagent_pushed_when_build_entry_pretooluse_then_reports_agent(tm
     entry = core.build_entry(
         {"hook_event_name": "PreToolUse", "tool_name": "read"}, "PreToolUse", stack
     )
-    assert entry["agent"] == "Coder"
+    assert "agent" not in entry
+    assert entry["agents"] == ["root", "Coder"]
+
+
+def test_given_no_subagent_when_build_entry_pretooluse_then_credits_root(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    entry = core.build_entry(
+        {"hook_event_name": "PreToolUse", "tool_name": "read"}, "PreToolUse", stack
+    )
+    assert entry["agent"] == "root"
+    assert "agents" not in entry
+
+
+def test_given_overlapping_subagents_when_build_entry_then_declines_to_guess(tmp_path):
+    """No tool payload names its caller, so overlap must not credit one agent."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    stack.push("sub-1", "Alpha")
+    stack.push("sub-2", "Beta")
+    entry = core.build_entry(
+        {"hook_event_name": "PostToolUse", "tool_name": "read", "tool_response": ""},
+        "PostToolUse",
+        stack,
+    )
+    assert "agent" not in entry
+    assert entry["agents"] == ["root", "Alpha", "Beta"]
+
+
+def test_given_tool_use_id_when_build_entry_then_records_it(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    entry = core.build_entry(
+        {"hook_event_name": "PreToolUse", "tool_name": "read", "tool_use_id": "call-7"},
+        "PreToolUse",
+        stack,
+    )
+    assert entry["tool_use_id"] == "call-7"
+
+
+def test_given_no_tool_use_id_when_build_entry_then_omits_it(tmp_path):
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    entry = core.build_entry(
+        {"hook_event_name": "PreToolUse", "tool_name": "read"}, "PreToolUse", stack
+    )
+    assert "tool_use_id" not in entry
+
+
+def test_given_vscode_subagent_lifecycle_when_build_entry_then_stops_by_id(tmp_path):
+    """VS Code identifies a subagent by agent_id; agent_type is only its label."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    for aid in ("sub-1", "sub-2"):
+        core.build_entry(
+            {"session_id": "sid1", "agent_id": aid, "agent_type": "Explore"},
+            "SubagentStart",
+            stack,
+        )
+    core.build_entry(
+        {"session_id": "sid1", "agent_id": "sub-1", "agent_type": "Explore"},
+        "SubagentStop",
+        stack,
+    )
+    assert stack.active() == ["Explore"]
 
 
 def test_given_unknown_event_when_build_entry_then_returns_none(tmp_path):
@@ -390,6 +523,18 @@ def test_given_skill_path_when_build_entry_then_detects_skill(tmp_path):
     }
     entry = core.build_entry(data, "PreToolUse", stack)
     assert entry["skill"] == "my-skill"
+
+
+def test_given_flat_skill_path_when_build_entry_then_detects_skill(tmp_path):
+    """VS Code ships skills as ``skills/<name>/SKILL.md``, with no collection dir."""
+    stack = core._AgentStack(tmp_path / ".stacks", "sid1")
+    data = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "read_file",
+        "tool_input": {"filePath": r"/repo/.github/skills/chronicle/SKILL.md"},
+    }
+    entry = core.build_entry(data, "PreToolUse", stack)
+    assert entry["skill"] == "chronicle"
 
 
 def test_given_cli_pretooluse_payload_when_normalize_event_then_infers_pretooluse():
@@ -429,12 +574,13 @@ def test_given_tool_response_payload_when_build_entry_then_measures_length(tmp_p
 
 
 def test_given_vscode_subagent_payload_when_build_entry_then_names_agent(tmp_path):
-    # VS Code identifies the subagent only by agent_type.
+    # VS Code labels the subagent with agent_type and identifies it by agent_id.
     stack = core._AgentStack(tmp_path / ".stacks", "sid1")
     data = {"session_id": "sid1", "agent_id": "sub-1", "agent_type": "Plan"}
     entry = core.build_entry(data, "SubagentStart", stack)
     assert entry["agent_name"] == "Plan"
-    assert stack.current() == "Plan"
+    assert entry["agent_id"] == "sub-1"
+    assert stack.active() == ["Plan"]
 
 
 def test_given_cli_prompt_payload_when_normalize_event_then_infers_userpromptsubmit():
@@ -546,9 +692,7 @@ def test_given_session_end_event_when_mode_collect_then_writes_entry_and_summary
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
 
-    logs = list(tel_dir.glob("sessions-*.jsonl"))
-    assert len(logs) == 1
-    events = [json.loads(line) for line in logs[0].read_text().splitlines()]
+    events = _session_records(tel_dir)
     assert events[0]["event"] == "SessionEnd"
     assert events[0]["reason"] == "complete"
     assert any(e["event"] == "SessionSummary" for e in events)
@@ -579,9 +723,7 @@ def test_given_stop_event_when_mode_collect_then_writes_entry_and_summary(tmp_pa
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
 
-    logs = list(tel_dir.glob("sessions-*.jsonl"))
-    assert len(logs) == 1
-    events = [json.loads(line) for line in logs[0].read_text().splitlines()]
+    events = _session_records(tel_dir)
     assert events[0]["event"] == "Stop"
     assert any(e["event"] == "SessionSummary" for e in events)
 
@@ -611,12 +753,40 @@ def test_given_precompact_event_when_mode_collect_then_writes_summary(tmp_path, 
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
 
-    logs = list(tel_dir.glob("sessions-*.jsonl"))
-    assert len(logs) == 1
-    events = [json.loads(line) for line in logs[0].read_text().splitlines()]
+    events = _session_records(tel_dir)
     assert events[0]["event"] == "PreCompact"
     # PreCompact captures a summary before process logs rotate.
     assert any(e["event"] == "SessionSummary" for e in events)
+
+
+def test_given_tool_pair_when_mode_collect_then_carries_tool_use_id(tmp_path, monkeypatch):
+    """The id survives to disk on both halves so offline analysis can pair them.
+
+    The bundled report correlates by tool name, which cannot separate two
+    concurrent calls to the same tool; the recorded id can.
+    """
+    tel_dir = tmp_path / "tel"
+    monkeypatch.setenv("HVE_TELEMETRY_DIR", str(tel_dir))
+    for payload in (
+        {
+            "hook_event_name": "PreToolUse",
+            "session_id": "sid1",
+            "tool_name": "read_file",
+            "toolUseId": "call-42",
+        },
+        {
+            "hook_event_name": "PostToolUse",
+            "session_id": "sid1",
+            "tool_name": "read_file",
+            "tool_use_id": "call-42",
+        },
+    ):
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+        assert core._mode_collect() == 0
+
+    events = _session_records(tel_dir)
+    pairs = [(e["event"], e.get("tool_use_id")) for e in events if e["event"].endswith("ToolUse")]
+    assert pairs == [("PreToolUse", "call-42"), ("PostToolUse", "call-42")]
 
 
 def test_given_traversal_sid_when_mode_collect_then_rejects(tmp_path, monkeypatch):
@@ -626,11 +796,322 @@ def test_given_traversal_sid_when_mode_collect_then_rejects(tmp_path, monkeypatc
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
     # No telemetry written for a rejected sid.
-    assert not tel_dir.exists() or not list(tel_dir.glob("sessions-*.jsonl"))
+    assert not tel_dir.exists() or not _session_files(tel_dir)
 
 
-def test_given_new_dir_when_register_telemetry_dir_then_appends_absolute_path(tmp_path):
-    registry = tmp_path / "telemetry-dirs.txt"
+@pytest.mark.parametrize(
+    "sid",
+    ["", "..", "../escape", "a/b", "a\\b", "C:", "C:x", "\\\\server\\share", "//server/share"],
+)
+def test_given_unsafe_sid_when_is_safe_sid_then_rejects(sid):
+    """A drive or UNC anchor holds no separator yet still re-anchors a join."""
+    assert not core._is_safe_sid(sid)
+
+
+@pytest.mark.parametrize("sid", ["sid1", "abc-123", "a.b"])
+def test_given_ordinary_sid_when_is_safe_sid_then_accepts(sid):
+    assert core._is_safe_sid(sid)
+
+
+def test_given_escaped_session_dir_when_clear_then_removes_nothing(tmp_path):
+    """Containment is re-checked at the point of deletion, not only at parse."""
+    stack_dir = tmp_path / ".stacks"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("user data", encoding="utf-8")
+    stack = core._AgentStack(stack_dir, "sid1")
+    stack.session_dir = outside
+    stack.clear()
+    assert (outside / "keep.txt").exists()
+
+
+def test_given_unicode_line_when_append_line_then_writes_bytes_verbatim(tmp_path):
+    target = tmp_path / "sessions.jsonl"
+    core.append_line(target, "caf\u00e9 \u65e5\u672c\u8a9e\n")
+    core.append_line(target, "\u00fcber\n")
+    # No BOM, and no CRLF expansion from Windows text mode.
+    assert target.read_bytes() == "caf\u00e9 \u65e5\u672c\u8a9e\n\u00fcber\n".encode()
+
+
+def test_given_missing_parent_when_append_jsonl_then_creates_it(tmp_path):
+    target = tmp_path / "nested" / "sessions.jsonl"
+    core.append_jsonl(target, {"event": "PreToolUse"})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"event": "PreToolUse"}
+
+
+def test_given_append_when_written_then_leaves_no_sidecar(tmp_path):
+    """The lock lives on a byte of the log itself, so no lock file is needed."""
+    target = tmp_path / "sessions.jsonl"
+    core.append_jsonl(target, {"event": "Stop"})
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_given_refused_lock_when_appending_then_falls_back_to_private_shard(tmp_path, monkeypatch):
+    """A filesystem without working locks must not let writers interleave."""
+    target = tmp_path / "sessions-2026-01-01.jsonl"
+    core.append_jsonl(target, {"event": "first"})
+    monkeypatch.setattr(core, "_lock_append", lambda fd: False)
+    core.append_jsonl(target, {"event": "second"})
+
+    files = sorted(tmp_path.glob("*.jsonl"))
+    assert len(files) == 2
+    # The shard is a sibling of its day log, so the report's session glob and the
+    # cleanup allow-list both reach it without a separate rule.
+    shard = next(p for p in files if p != target)
+    assert shard.name.startswith("sessions-2026-01-01.")
+    # The refused write went to that shard, leaving the shared log untouched.
+    assert json.loads(target.read_text(encoding="utf-8")) == {"event": "first"}
+    records = [json.loads(p.read_text(encoding="utf-8")) for p in files]
+    assert {r["event"] for r in records} == {"first", "second"}
+
+
+def test_given_raising_shared_append_when_appending_then_still_shards(tmp_path, monkeypatch):
+    """The shard is reached when the shared write raises, not only when it returns False."""
+
+    def boom(target, payload):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(core, "_append_shared", boom)
+    target = tmp_path / "sessions-2026-01-01.jsonl"
+    core.append_jsonl(target, {"event": "rescued"})
+
+    files = sorted(tmp_path.glob("*.jsonl"))
+    assert len(files) == 1
+    assert json.loads(files[0].read_text(encoding="utf-8")) == {"event": "rescued"}
+
+
+def test_given_unwritable_store_when_appending_then_returns_quietly(tmp_path, monkeypatch):
+    """A hook that raises stalls the turn, so the last resort is to drop the record."""
+
+    def boom(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(core, "_append_shared", boom)
+    monkeypatch.setattr(core, "_append_private", boom)
+    core.append_jsonl(tmp_path / "sessions-2026-01-01.jsonl", {"event": "dropped"})
+    assert list(tmp_path.glob("*.jsonl")) == []
+
+
+def test_given_unwritable_store_when_mode_collect_then_still_succeeds(tmp_path, monkeypatch):
+    """The engine reports success so the wrapper's continue contract holds."""
+    tel_dir = tmp_path / "tel"
+    monkeypatch.setenv("HVE_TELEMETRY_DIR", str(tel_dir))
+    monkeypatch.setattr(
+        core.Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only fs"))
+    )
+    payload = {"hook_event_name": "PreToolUse", "session_id": "sid1", "tool_name": "read"}
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    assert core._mode_collect() == 0
+
+
+def test_given_short_write_when_append_line_then_finishes_the_record(tmp_path, monkeypatch):
+    """A signal or a full disk can cut os.write short and truncate a record."""
+    real_write = os.write
+    calls = []
+
+    def stingy(fd, data):
+        calls.append(bytes(data))
+        # Drip one byte at a time so a single unchecked write would truncate.
+        return real_write(fd, bytes(data)[:1])
+
+    monkeypatch.setattr(os, "write", stingy)
+    target = tmp_path / "sessions.jsonl"
+    core.append_jsonl(target, {"event": "Stop"})
+    assert len(calls) > 1
+    assert json.loads(target.read_text(encoding="utf-8")) == {"event": "Stop"}
+
+
+def test_given_repeated_calls_when_fallback_stem_then_never_repeats():
+    """Two live collectors sharing a stem would share a file and race on it."""
+    stems = {core._fallback_stem() for _ in range(200)}
+    assert len(stems) == 200
+
+
+def _run_collectors(payloads, tel_dir, home):
+    """Run one collector per payload; return their exit codes for the caller."""
+    env = {
+        **os.environ,
+        "HVE_TELEMETRY_DIR": str(tel_dir),
+        "HVE_HOME": str(home),
+        "COPILOT_HOME": str(home),
+    }
+    procs = [
+        subprocess.Popen(
+            [sys.executable, core.__file__, "collect"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        for _ in payloads
+    ]
+    try:
+        for proc, data in zip(procs, payloads):
+            proc.stdin.write(json.dumps(data).encode("utf-8"))
+        # Close in a tight loop so the collectors contend on the same write.
+        for proc in procs:
+            proc.stdin.close()
+        return [proc.wait(timeout=60) for proc in procs]
+    finally:
+        for proc in procs:
+            if proc.poll() is None:
+                proc.kill()
+
+
+@pytest.mark.slow
+def test_given_concurrent_collectors_when_appending_then_every_event_lands(tmp_path):
+    """End-to-end check that N collector processes each record their event.
+
+    They share one log per day, so this is the regression guard for the
+    overwrite the Windows CRT allows: it emulates append as seek-to-end plus
+    write, letting two writers resolve the same offset.
+    """
+    tel_dir = tmp_path / "tel"
+    count = 16
+    payloads = [
+        {
+            "hook_event_name": "PreToolUse",
+            "session_id": "race",
+            "cwd": str(tmp_path),
+            "tool_name": f"tool_{i}",
+            # Vary the record length so a lost race tears a line rather than
+            # cleanly replacing an equally sized record.
+            "tool_input": {"pad": "x" * (100 + i * 37)},
+        }
+        for i in range(count)
+    ]
+    assert _run_collectors(payloads, tel_dir, tmp_path / "home") == [0] * len(payloads)
+
+    records = _session_records(tel_dir)
+    assert len(records) == count
+    assert {r["tool"] for r in records} == {f"tool_{i}" for i in range(count)}
+    if os.name != "nt":
+        # POSIX resolves O_APPEND in the kernel, so the lock is never refused and
+        # a shard here would be a real regression. Windows can legitimately shard
+        # under contention, and readers pick it up either way.
+        assert len(_session_files(tel_dir)) == 1
+
+
+@pytest.mark.slow
+def test_given_collectors_on_one_day_when_appending_then_shares_one_day_log(tmp_path):
+    """Records are partitioned by UTC day so cleanup and reports stay day-scoped."""
+    tel_dir = tmp_path / "tel"
+    payloads = [
+        {
+            "hook_event_name": "PreToolUse",
+            "session_id": "day",
+            "cwd": str(tmp_path),
+            "tool_name": f"tool_{i}",
+        }
+        for i in range(3)
+    ]
+    assert _run_collectors(payloads, tel_dir, tmp_path / "home") == [0] * len(payloads)
+
+    files = _session_files(tel_dir)
+    assert files
+    assert all(re.fullmatch(r"sessions-\d{4}-\d{2}-\d{2}(\..+)?\.jsonl", p.name) for p in files)
+    assert len(_session_records(tel_dir)) == 3
+
+
+@pytest.mark.slow
+def test_given_concurrent_subagent_starts_when_pushing_then_keeps_every_push(tmp_path):
+    """Parallel subagents each record a start from their own collector process.
+
+    The push is an append rather than a read-modify-write, so a simultaneous
+    batch cannot lose all but one entry and misattribute later tool calls.
+    Every racing collector also registers, because each sees ``first_write``.
+    """
+    tel_dir = tmp_path / "tel"
+    home = tmp_path / "home"
+    count = 16
+    payloads = [
+        {
+            "hook_event_name": "SubagentStart",
+            "session_id": "race",
+            "cwd": str(tmp_path),
+            "agent_type": f"Agent{i}",
+        }
+        for i in range(count)
+    ]
+    assert _run_collectors(payloads, tel_dir, home) == [0] * len(payloads)
+
+    stack = core._AgentStack(tel_dir / ".stacks", "race")
+    assert sorted(stack.active()) == sorted(f"Agent{i}" for i in range(count))
+
+    # Registering is a racing whole-file write; it must converge on one entry.
+    assert core.read_registry_dirs(home / "telemetry-dirs") == [str(tel_dir.resolve())]
+
+
+def test_given_existing_file_when_write_text_atomic_then_replaces_without_residue(tmp_path):
+    target = tmp_path / "launcher.ps1"
+    target.write_text("old content")
+    core._write_text_atomic(target, "new content")
+    assert target.read_text() == "new content"
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_given_session_log_when_clean_telemetry_dir_then_removes_it(tmp_path):
+    tel_dir = tmp_path / "tel"
+    tel_dir.mkdir()
+    log = tel_dir / "sessions-2026-01-01.jsonl"
+    log.write_text("{}\n", encoding="utf-8")
+    removed = []
+    core.clean_telemetry_dir(tel_dir, dry_run=False, removed=removed)
+    assert not log.exists()
+    assert removed == [str(log)]
+
+
+def test_given_fallback_shard_when_clean_telemetry_dir_then_removes_it(tmp_path):
+    """A shard sits beside its day log, so the allow-list must reach both."""
+    tel_dir = tmp_path / "tel"
+    tel_dir.mkdir()
+    shard = tel_dir / "sessions-2026-01-01.010203000000-42-abcdef.jsonl"
+    core.append_jsonl(shard, {"event": "Stop"})
+    removed = []
+    core.clean_telemetry_dir(tel_dir, dry_run=False, removed=removed)
+    assert not shard.exists()
+    assert removed == [str(shard)]
+
+
+def test_given_unrelated_jsonl_when_clean_telemetry_dir_then_preserves_it(tmp_path):
+    """A user can point HVE_TELEMETRY_DIR at a directory holding other work."""
+    tel_dir = tmp_path / "tel"
+    tel_dir.mkdir()
+    keep_file = tel_dir / "sessions-notes.jsonl"
+    keep_file.write_text("{}\n", encoding="utf-8")
+    keep_dir = tel_dir / "notes"
+    keep_dir.mkdir()
+    (keep_dir / "a.jsonl").write_text("{}\n", encoding="utf-8")
+    removed = []
+    core.clean_telemetry_dir(tel_dir, dry_run=False, removed=removed)
+    assert keep_file.exists()
+    assert keep_dir.exists()
+    assert removed == []
+
+
+def test_given_legacy_registry_file_when_read_registry_dirs_then_imports_once(tmp_path):
+    """An upgraded install must not silently lose its registered stores."""
+    registry = tmp_path / "telemetry-dirs"
+    legacy = tmp_path / "telemetry-dirs.txt"
+    first = tmp_path / "a" / "tel"
+    second = tmp_path / "b" / "tel"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    legacy.write_text(f"{first.resolve()}\n\n{second.resolve()}\n", encoding="utf-8")
+
+    assert core.read_registry_dirs(registry) == sorted(
+        [str(first.resolve()), str(second.resolve())]
+    )
+    # The legacy file is retired rather than deleted, and is not re-read.
+    assert not legacy.exists()
+    assert (tmp_path / "telemetry-dirs.txt.migrated").is_file()
+    assert core.read_registry_dirs(registry) == sorted(
+        [str(first.resolve()), str(second.resolve())]
+    )
+
+
+def test_given_new_dir_when_register_telemetry_dir_then_records_absolute_path(tmp_path):
+    registry = tmp_path / "telemetry-dirs"
     tel_dir = tmp_path / "proj" / "tel"
     tel_dir.mkdir(parents=True)
     core.register_telemetry_dir(tel_dir, registry)
@@ -638,7 +1119,7 @@ def test_given_new_dir_when_register_telemetry_dir_then_appends_absolute_path(tm
 
 
 def test_given_existing_entry_when_register_telemetry_dir_then_dedups(tmp_path):
-    registry = tmp_path / "telemetry-dirs.txt"
+    registry = tmp_path / "telemetry-dirs"
     tel_dir = tmp_path / "tel"
     tel_dir.mkdir()
     core.register_telemetry_dir(tel_dir, registry)
@@ -646,10 +1127,19 @@ def test_given_existing_entry_when_register_telemetry_dir_then_dedups(tmp_path):
     assert core.read_registry_dirs(registry) == [str(tel_dir.resolve())]
 
 
-def test_given_blank_and_duplicate_lines_when_read_registry_dirs_then_normalizes(tmp_path):
-    registry = tmp_path / "telemetry-dirs.txt"
-    registry.write_text("/a\n\n  \n/b\n/a\n", encoding="utf-8")
-    assert core.read_registry_dirs(registry) == ["/a", "/b"]
+def test_given_several_stores_when_registered_then_each_gets_its_own_marker(tmp_path):
+    registry = tmp_path / "telemetry-dirs"
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+    core.register_telemetry_dir(first, registry)
+    core.register_telemetry_dir(second, registry)
+    core.register_telemetry_dir(first, registry)
+    assert core.read_registry_dirs(registry) == sorted(
+        [str(first.resolve()), str(second.resolve())]
+    )
+    assert len(list(registry.glob("*.path"))) == 2
 
 
 def test_given_session_start_when_mode_collect_then_registers_dir(tmp_path, monkeypatch):
@@ -662,7 +1152,7 @@ def test_given_session_start_when_mode_collect_then_registers_dir(tmp_path, monk
     payload = {"hook_event_name": "SessionStart", "session_id": "sid1"}
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
-    assert core.read_registry_dirs(hve / "telemetry-dirs.txt") == [str(tel_dir.resolve())]
+    assert core.read_registry_dirs(hve / "telemetry-dirs") == [str(tel_dir.resolve())]
     # A cross-project launcher for the host platform is emitted in the HVE home.
     if core._is_windows():
         assert (hve / "generate-report.ps1").is_file()
@@ -681,7 +1171,7 @@ def test_given_no_session_start_when_mode_collect_then_still_registers_dir(tmp_p
     payload = {"hook_event_name": "UserPromptSubmit", "session_id": "sid1", "prompt": "hi"}
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
     assert core._mode_collect() == 0
-    assert core.read_registry_dirs(hve / "telemetry-dirs.txt") == [str(tel_dir.resolve())]
+    assert core.read_registry_dirs(hve / "telemetry-dirs") == [str(tel_dir.resolve())]
 
 
 def test_given_stale_entries_when_mode_list_dirs_then_prunes_and_prints(
@@ -692,14 +1182,15 @@ def test_given_stale_entries_when_mode_list_dirs_then_prunes_and_prints(
     live = tmp_path / "live"
     live.mkdir()
     dead = tmp_path / "dead"
-    registry = hve / "telemetry-dirs.txt"
-    registry.write_text(f"{live}\n{dead}\n", encoding="utf-8")
+    registry = hve / "telemetry-dirs"
+    core.register_telemetry_dir(live, registry)
+    core.register_telemetry_dir(dead, registry)
     monkeypatch.setenv("HVE_HOME", str(hve))
     assert core._mode_list_dirs() == 0
     out = capsys.readouterr().out.splitlines()
-    assert out == [str(live)]
+    assert out == [str(live.resolve())]
     # Dead entry is pruned from the registry on read.
-    assert core.read_registry_dirs(registry) == [str(live)]
+    assert core.read_registry_dirs(registry) == [str(live.resolve())]
 
 
 def test_given_posix_when_write_report_launchers_then_writes_sh_only(tmp_path, monkeypatch):
@@ -774,13 +1265,15 @@ def _seed_telemetry_store(tel_dir):
     """Populate a telemetry directory with representative artifacts plus an
     unrelated file that cleanup must preserve."""
     tel_dir.mkdir(parents=True)
-    (tel_dir / "sessions-2026-01-01.jsonl").write_text("{}\n", encoding="utf-8")
-    (tel_dir / "sessions-2026-01-02.jsonl").write_text("{}\n", encoding="utf-8")
+    core.append_jsonl(tel_dir / "sessions-2026-01-01.jsonl", {})
+    core.append_jsonl(tel_dir / "sessions-2026-01-02.jsonl", {})
     (tel_dir / "raw-input.jsonl").write_text("{}\n", encoding="utf-8")
     (tel_dir / "report.generated.html").write_text("<html>", encoding="utf-8")
-    stacks = tel_dir / ".stacks"
-    stacks.mkdir()
-    (stacks / "sid1.json").write_text("[]", encoding="utf-8")
+    stacks = tel_dir / ".stacks" / "sid1"
+    stacks.mkdir(parents=True)
+    (stacks / "010203000000-42-aaaaaa.log").write_text(
+        '{"op": "push", "agent": "A"}\n', encoding="utf-8"
+    )
     keep = tel_dir / "keep-me.txt"
     keep.write_text("user data", encoding="utf-8")
     return keep
@@ -808,6 +1301,7 @@ def test_given_dry_run_when_clean_telemetry_dir_then_reports_without_deleting(tm
     core.clean_telemetry_dir(tel_dir, dry_run=True, removed=removed)
     assert (tel_dir / "raw-input.jsonl").exists()
     assert (tel_dir / ".stacks").exists()
+    assert (tel_dir / "sessions-2026-01-01.jsonl").exists()
     assert len(removed) == 5
 
 
@@ -818,8 +1312,8 @@ def test_given_current_store_when_mode_clean_then_cleans_only_current(tmp_path, 
     _seed_telemetry_store(current)
     _seed_telemetry_store(other)
     hve.mkdir()
-    registry = hve / "telemetry-dirs.txt"
-    registry.write_text(f"{other}\n", encoding="utf-8")
+    registry = hve / "telemetry-dirs"
+    core.register_telemetry_dir(other, registry)
     monkeypatch.setenv("HVE_TELEMETRY_DIR", str(current))
     monkeypatch.setenv("HVE_HOME", str(hve))
     assert core._mode_clean(all_dirs=False, dry_run=False) == 0
@@ -836,8 +1330,8 @@ def test_given_all_dirs_when_mode_clean_then_cleans_registry_and_home(tmp_path, 
     _seed_telemetry_store(current)
     _seed_telemetry_store(other)
     hve.mkdir()
-    registry = hve / "telemetry-dirs.txt"
-    registry.write_text(f"{other}\n", encoding="utf-8")
+    registry = hve / "telemetry-dirs"
+    core.register_telemetry_dir(other, registry)
     (hve / "report.generated.html").write_text("<html>", encoding="utf-8")
     (hve / "generate-report.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
     monkeypatch.setenv("HVE_TELEMETRY_DIR", str(current))
@@ -857,3 +1351,62 @@ def test_given_clean_mode_when_main_dispatches_then_parses_flags(tmp_path, monke
     assert core.main(["clean", "--dry-run"]) == 0
     # Dry-run leaves artifacts in place.
     assert (current / "raw-input.jsonl").exists()
+
+
+class _ByteStdin:
+    """Stdin stand-in exposing a raw byte buffer, as the real stream does.
+
+    Feeding bytes rather than str exercises the decode boundary where a host
+    locale would otherwise corrupt or reject the payload.
+    """
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _collect_one(payload_bytes, tel_dir, monkeypatch):
+    """Run a single collect pass over raw stdin bytes and return the entries."""
+    monkeypatch.setenv("HVE_TELEMETRY_DIR", str(tel_dir))
+    monkeypatch.setattr("sys.stdin", _ByteStdin(payload_bytes))
+    assert core._mode_collect() == 0
+    return _session_records(tel_dir)
+
+
+def test_given_non_ascii_utf8_stdin_bytes_when_mode_collect_then_preserves_text(
+    tmp_path, monkeypatch
+):
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sid1",
+        "timestamp": "2026-01-02T00:00:00Z",
+        "cwd": "/home/M\u00fcller/\u30d7\u30ed\u30b8\u30a7\u30af\u30c8",
+        "prompt": "caf\u00e9 \u65e5\u672c\u8a9e",
+    }
+    events = _collect_one(
+        # ensure_ascii=False emits real multi-byte UTF-8 rather than \u escapes,
+        # which is what actually crosses the decode boundary at runtime.
+        json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        tmp_path / "tel",
+        monkeypatch,
+    )
+    # cwd is a grouping key for cross-project reporting, so it must round-trip
+    # byte-for-byte rather than degrade to replacement characters.
+    assert events[0]["cwd"] == "/home/M\u00fcller/\u30d7\u30ed\u30b8\u30a7\u30af\u30c8"
+    assert events[0]["prompt"] == "caf\u00e9 \u65e5\u672c\u8a9e"
+
+
+def test_given_invalid_utf8_stdin_bytes_when_mode_collect_then_still_records_event(
+    tmp_path, monkeypatch
+):
+    # A lone 0xE9 is valid cp1252 but invalid UTF-8. UnicodeDecodeError
+    # subclasses ValueError, so an unguarded decode would drop the event as
+    # though the JSON were malformed.
+    raw = b'{"hook_event_name": "UserPromptSubmit", "session_id": "sid1", "prompt": "caf\xe9"}'
+    events = _collect_one(raw, tmp_path / "tel", monkeypatch)
+    assert events[0]["event"] == "UserPromptSubmit"
+    assert events[0]["prompt"] == "caf\ufffd"
+
+
+def test_given_stdin_without_buffer_when_read_stdin_text_then_falls_back_to_read(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("plain text"))
+    assert core._read_stdin_text() == "plain text"

--- a/docs/contributing/hooks.md
+++ b/docs/contributing/hooks.md
@@ -3,7 +3,7 @@ title: Contributing Hooks
 description: How to implement, register, and validate hook artifacts in hve-core
 sidebar_position: 7
 author: Microsoft
-ms.date: 2026-07-22
+ms.date: 2026-07-29
 ms.topic: how-to
 keywords:
   - hooks

--- a/docs/customization/local-telemetry.md
+++ b/docs/customization/local-telemetry.md
@@ -30,6 +30,10 @@ Events currently captured include:
 
 At stop time, telemetry also appends a session summary with model and token usage when available.
 
+## Prerequisites
+
+Ensure you have Bash 3.5+ (Linux/macOS) or PowerShell 7 (Windows) available, depending on your OS for running the telemetry hooks.
+
 ## Enable Local Telemetry
 
 Telemetry is opt-in. Enable it with either an environment variable or a repository marker file.

--- a/docs/customization/local-telemetry.md
+++ b/docs/customization/local-telemetry.md
@@ -32,7 +32,7 @@ At stop time, telemetry also appends a session summary with model and token usag
 
 ## Prerequisites
 
-Ensure you have Bash 3.5+ (Linux/macOS) or PowerShell 7 (Windows) available, depending on your OS for running the telemetry hooks.
+Ensure you have Bash 3.5+ (Linux/macOS) or PowerShell (Windows) and python available, depending on your OS for running the telemetry hooks. To utilize cleanup or report generation on Windows, ensure you have PowerShell 7.4+ installed.
 
 ## Enable Local Telemetry
 
@@ -248,6 +248,18 @@ The registry self-populates as you work across repositories, so no manual setup
 is required. Stale directories (deleted or moved repositories) are pruned
 automatically when the report runs. Each session is labeled with its originating
 project in the report, so combined output still reads per project.
+
+To report on a single store, pass `--path` (`-Path`). An explicit path overrides
+`--all-dirs`, so the generated cross-project launcher can also be scoped down:
+
+```bash
+bash ~/.hve/generate-report.sh --path /path/to/repo/.copilot-tracking/telemetry --date all
+```
+
+Cleanup follows the same precedence: `clean-telemetry.sh --path DIR` restricts
+removal to that one store and leaves the registry, launchers, and every other
+project untouched, even when `--all-dirs` is also present. Both entry points
+report the override on stderr, so a narrowed destructive scope is never silent.
 
 > [!NOTE]
 > **Registry-driven cleanup is name-constrained.** `clean-telemetry.sh

--- a/docs/customization/local-telemetry.md
+++ b/docs/customization/local-telemetry.md
@@ -34,13 +34,13 @@ At stop time, telemetry also appends a session summary with model and token usag
 
 All telemetry processing runs in Python. The shell entry points are thin wrappers that gate on opt-in and hand stdin to `_telemetry_core.py`.
 
-| Requirement     | Needed for                                                | Notes                                                      |
-|-----------------|-----------------------------------------------------------|------------------------------------------------------------|
+| Requirement     | Needed for                                                | Notes                                                                                    |
+|-----------------|-----------------------------------------------------------|------------------------------------------------------------------------------------------|
 | Python 3.11+    | Event collection, reports, cleanup                        | Collectors try `python3` then `python`; the report and cleanup scripts require `python3` |
-| Bash 3.2+       | Bash entry points                                         | macOS system Bash works; no Bash 4 features used           |
-| PowerShell 5.1+ | `Invoke-TelemetryCollector.ps1`                           | Written for Windows PowerShell; no `#Requires` floor       |
-| PowerShell 7.4+ | `Invoke-TelemetryReport.ps1`, `Invoke-TelemetryClean.ps1` | Enforced by `#Requires -Version 7.4`                       |
-| `jq`            | `generate-telemetry-report.sh`                            | Not needed by `Invoke-TelemetryReport.ps1`                 |
+| Bash 3.2+       | Bash entry points                                         | macOS system Bash works; no Bash 4 features used                                         |
+| PowerShell 5.1+ | `Invoke-TelemetryCollector.ps1`                           | Written for Windows PowerShell; no `#Requires` floor                                     |
+| PowerShell 7.4+ | `Invoke-TelemetryReport.ps1`, `Invoke-TelemetryClean.ps1` | Enforced by `#Requires -Version 7.4`                                                     |
+| `jq`            | `generate-telemetry-report.sh`                            | Not needed by `Invoke-TelemetryReport.ps1`                                               |
 
 You only need one shell family. Copilot selects the Bash or PowerShell entry point based on the host.
 
@@ -128,6 +128,7 @@ Key files and folders:
 | `raw-input.jsonl`                               | First few hook payloads stored verbatim; written only when `HVE_TELEMETRY_RAW=1` is set                   |
 | `.stacks/<session-id>/ops.log`                  | Append-only agent push and pop records for one session, replayed to attribute events to the calling agent |
 | `report.generated.html`                         | Optional self-contained report output                                                                     |
+
 ## Data Captured and Storage Schema
 
 This section describes the mechanics of what local telemetry collects and where each class of data comes from.

--- a/docs/customization/local-telemetry.md
+++ b/docs/customization/local-telemetry.md
@@ -3,7 +3,7 @@ title: Local Telemetry
 description: Enable local Copilot session telemetry, understand capture mechanics, and generate local reports
 sidebar_position: 10
 author: Microsoft
-ms.date: 2026-06-18
+ms.date: 2026-07-29
 ms.topic: how-to
 keywords:
   - telemetry
@@ -28,11 +28,23 @@ Events currently captured include:
 * agent stop and session end
 * pre-compact events
 
-At stop time, telemetry also appends a session summary with model and token usage when available.
+At stop time, telemetry also appends a session summary with model and token usage, but only when the surface you are running on writes a usage log it can read. See [Enrichment Coverage by Surface](#enrichment-coverage-by-surface) for what each surface provides.
 
 ## Prerequisites
 
-Ensure you have Bash 3.5+ (Linux/macOS) or PowerShell (Windows) and python available, depending on your OS for running the telemetry hooks. To utilize cleanup or report generation on Windows, ensure you have PowerShell 7.4+ installed.
+All telemetry processing runs in Python. The shell entry points are thin wrappers that gate on opt-in and hand stdin to `_telemetry_core.py`.
+
+| Requirement     | Needed for                                                | Notes                                                      |
+|-----------------|-----------------------------------------------------------|------------------------------------------------------------|
+| Python 3.11+    | Event collection, reports, cleanup                        | Collectors try `python3` then `python`; the report and cleanup scripts require `python3` |
+| Bash 3.2+       | Bash entry points                                         | macOS system Bash works; no Bash 4 features used           |
+| PowerShell 5.1+ | `Invoke-TelemetryCollector.ps1`                           | Written for Windows PowerShell; no `#Requires` floor       |
+| PowerShell 7.4+ | `Invoke-TelemetryReport.ps1`, `Invoke-TelemetryClean.ps1` | Enforced by `#Requires -Version 7.4`                       |
+| `jq`            | `generate-telemetry-report.sh`                            | Not needed by `Invoke-TelemetryReport.ps1`                 |
+
+You only need one shell family. Copilot selects the Bash or PowerShell entry point based on the host.
+
+Only `telemetry-collector.sh` checks the interpreter version, skipping a `python3` older than 3.11 and falling back to `python`. Where Python is missing or too old, the collector warns and continues without recording events, so collection never blocks a session. The report and cleanup scripts are run by hand and fail loudly instead.
 
 ## Enable Local Telemetry
 
@@ -64,7 +76,7 @@ Processed telemetry never stores full prompt text or full tool inputs (see
 [Sensitive Data and Privacy](#sensitive-data-and-privacy)). A separate,
 explicit opt-in records the first few hook payloads **verbatim** to
 `raw-input.jsonl` for deep diagnostics. It is off by default, even when
-telemetry is enabled, and is honored only by the Bash collector:
+telemetry is enabled, and both the Bash and PowerShell collectors honor it:
 
 ```bash
 export HVE_TELEMETRY_RAW=1
@@ -109,13 +121,13 @@ Override with `HVE_TELEMETRY_DIR` when needed.
 
 Key files and folders:
 
-| Path                        | Purpose                                                                                                  |
-|-----------------------------|----------------------------------------------------------------------------------------------------------|
-| `sessions-YYYY-MM-DD.jsonl` | Daily event stream with hook events and session summaries                                                |
-| `raw-input.jsonl`           | First few hook payloads stored verbatim; written only when `HVE_TELEMETRY_RAW=1` is set (Bash collector) |
-| `.stacks/`                  | Per-session agent stack tracking used for attribution                                                    |
-| `report.generated.html`     | Optional self-contained report output                                                                    |
-
+| Path                                            | Purpose                                                                                                   |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `sessions-YYYY-MM-DD.jsonl`                     | Daily event stream with hook events and session summaries                                                 |
+| `sessions-YYYY-MM-DD.<stamp>-<pid>-<hex>.jsonl` | Fallback shard written when a collector could not take the day log's lock; read alongside it              |
+| `raw-input.jsonl`                               | First few hook payloads stored verbatim; written only when `HVE_TELEMETRY_RAW=1` is set                   |
+| `.stacks/<session-id>/ops.log`                  | Append-only agent push and pop records for one session, replayed to attribute events to the calling agent |
+| `report.generated.html`                         | Optional self-contained report output                                                                     |
 ## Data Captured and Storage Schema
 
 This section describes the mechanics of what local telemetry collects and where each class of data comes from.
@@ -152,6 +164,23 @@ Additional fields are event-specific. Examples:
 * Subagent events: agent name and display name
 * Stop events: stop reason
 
+Tool events also carry two fields the bundled report does not render, kept for
+offline analysis of a full session timeline. A tool payload names no agent, and a
+turn's tool calls run in parallel, so an active subagent is not evidence that it
+issued any particular call:
+
+* `agent`: Present only when no subagent was in flight, holding `root`. This is
+  the one case where the caller is certain.
+* `agents`: The candidate list (`root` plus every started-but-not-stopped
+  subagent) when one or more subagents were running. The two fields are mutually
+  exclusive; neither resolves the caller once work overlaps.
+* `tool_use_id`: The client's identifier for one tool invocation, pairing a
+  `PreToolUse` record with its `PostToolUse` record exactly, where the report's
+  by-name correlation can only approximate the pairing under concurrency.
+
+Token attribution does not have this problem and the report does render it; see
+[Session Summary Fields](#session-summary-fields).
+
 ### Session Summary Fields
 
 When available at stop time, `SessionSummary` includes:
@@ -162,15 +191,59 @@ When available at stop time, `SessionSummary` includes:
 * `cache_read_tokens`, `cache_write_tokens`
 * `total_nano_aiu`
 * `turns`, `messages`
+* `token_source`: provenance of the token numbers (`process_log` or `state_fallback`)
 * Optional `reasoning_effort`, `subagent_map`, and `client`
+* `agent_usage`: Per-agent token counters, present only under `process_log`
+
+Unlike tool attribution, the token split is exact. Every process-log request
+records the agent that issued it, so the collector partitions requests by agent
+and resolves each id to a display name through `subagent_map`. The report shows
+the split under Token Usage, as a share of AIU (or of output tokens where the
+host reports no AIU), and rolls it up to a Subagent Share card.
+
+Where a host emits no process log, the report reconstructs the same split by
+crediting each merged subagent session its own totals and treating the balance
+as the root agent's.
 
 ### Data Sources by Layer
 
-| Data Category                                 | Source                                                                    |
-|-----------------------------------------------|---------------------------------------------------------------------------|
-| Hook lifecycle events                         | Copilot hook payloads routed through collector scripts                    |
-| Session summaries                             | `.copilot/session-state/<sid>/events.jsonl` (CLI session state)           |
-| Additional model/token enrichment for reports | VS Code debug logs and session-state aggregation during report generation |
+| Data Category             | Source                                          | Availability                   |
+|---------------------------|-------------------------------------------------|--------------------------------|
+| Hook lifecycle events     | Copilot hook payloads via the collector scripts | Any surface that runs hooks    |
+| Session summaries         | `~/.copilot/session-state/<sid>/events.jsonl`   | Copilot CLI only               |
+| Precise per-request usage | `~/.copilot/logs/process-*.log`                 | Copilot CLI only               |
+| Report-time enrichment    | VS Code `debug-logs/**/*.jsonl` (`llm_request`) | VS Code builds that write them |
+
+### Enrichment Coverage by Surface
+
+Event capture and usage enrichment are separate concerns. Hook events are recorded on any surface that runs hooks. Model and token data comes from surface-specific logs that telemetry reads but does not create, and the two sources are not interchangeable.
+
+#### Copilot CLI
+
+The CLI maintains its own session state under `~/.copilot/session-state/<sid>/` (honoring `COPILOT_HOME`).
+When that directory contains an `events.jsonl`, the collector appends a `SessionSummary` inline at `Stop`, `SessionEnd`, and `PreCompact`, and the report re-derives summaries through the `aggregate-session` pass.
+Precise per-request usage comes from `~/.copilot/logs/process-*.log`, located through the session lock PID and, once the lock is gone, by scanning for logs that reference the session's interaction ids.
+Not every state directory has an `events.jsonl`; sessions that never reached a recorded turn produce no summary.
+
+#### VS Code
+
+VS Code sessions do not appear under `~/.copilot/session-state`, so the CLI path contributes nothing for them. Their only enrichment source is the Copilot Chat debug log, discovered by globbing `debug-logs/**/*.jsonl` beneath the workspace storage roots for `.vscode-server-insiders`, `.vscode-server`, `.vscode`, and the platform user-data directories for Code - Insiders, Code, and VSCodium.
+
+> [!IMPORTANT]
+> Debug logs are not written by every VS Code build. Public (stable) VS Code on macOS has been confirmed to produce none. On such a host, telemetry still records the full event timeline, but the report shows no model, token, or cost data for those sessions, and no `SessionSummary` record is written. This is a source-availability gap, not a telemetry failure.
+
+Missing enrichment is never fatal. Both aggregation passes return a non-zero status when they find nothing, the generator silently skips the corresponding layer, and the report renders from the hook event stream alone.
+
+### Summary Provenance
+
+Each `SessionSummary` carries a `token_source` field recording where its numbers came from:
+
+| `token_source`   | Meaning                                                        |
+|------------------|----------------------------------------------------------------|
+| `process_log`    | Per-request `assistant_usage` metrics from the CLI process log |
+| `state_fallback` | Summed `session.shutdown` model metrics from `events.jsonl`    |
+
+Under `state_fallback`, shutdown metrics are summed across every run segment because a resumed session resets its counters on each resume. A live session that has not yet ended a segment knows only per-message output tokens, so input, cache, and AIU totals are reported as unknown rather than zero, keeping an in-progress session distinguishable from a free one.
 
 ### Event Naming Normalization
 
@@ -180,8 +253,10 @@ The pipeline normalizes different casing variants of event names to canonical na
 
 * Data is stored locally under `.copilot-tracking/telemetry` by default.
 * Records append to date-partitioned files (`sessions-YYYY-MM-DD.jsonl`).
+  Concurrent hook events append to that one file: POSIX resolves `O_APPEND` in the kernel, and on Windows the collector takes a byte-range lock first, because the C runtime emulates append as seek-then-write and would otherwise let one writer overwrite another.
+  A collector that cannot take the lock writes a sibling shard named `sessions-YYYY-MM-DD.<stamp>-<pid>-<hex>.jsonl`, which the report generators pick up alongside the day log.
 * A small verbatim raw payload sample is stored in `raw-input.jsonl` only when `HVE_TELEMETRY_RAW=1` is explicitly set; see [Sensitive Data and Privacy](#sensitive-data-and-privacy).
-* Per-session agent stack files are maintained under `.stacks/` for attribution and cleaned up on session stop.
+* Per-session agent stacks are maintained under `.stacks/<session-id>/ops.log`, an append-only record of agent pushes and pops that is replayed to attribute each event, and removed on session stop.
 
 ### Sensitive Data and Privacy
 
@@ -230,7 +305,7 @@ pwsh .github/hooks/shared/telemetry/Invoke-TelemetryReport.ps1 -Open
 Telemetry is captured per project, so each repository keeps its own store under
 `<repo>/.copilot-tracking/telemetry`. To view sessions across every project in a
 single report, each store is recorded once per session in a user-level registry
-at `~/.hve/telemetry-dirs.txt` (honoring `HVE_HOME`).
+at `~/.hve/telemetry-dirs` (honoring `HVE_HOME`).
 
 Generate a combined, cross-project report with `--all-dirs`:
 
@@ -263,13 +338,14 @@ report the override on stderr, so a narrowed destructive scope is never silent.
 
 > [!NOTE]
 > **Registry-driven cleanup is name-constrained.** `clean-telemetry.sh
-> --all-dirs` iterates every path in `~/.hve/telemetry-dirs.txt` and, in each
-> directory, removes only a fixed allow-list of artifact names
-> (`raw-input.jsonl`, `report.generated.html`, `sessions-*.jsonl`, and the
-> `.stacks/` directory). It never deletes a directory wholesale. A tampered
-> registry can therefore, at most, delete those specific names in an
-> attacker-chosen directory, not arbitrary files. The `.stacks/` entry is
-> removed recursively, but symlinked artifacts are unlinked rather than
+> --all-dirs` iterates every path in `~/.hve/telemetry-dirs` and, in each
+> directory, removes only a fixed allow-list of artifact names:
+> `raw-input.jsonl`, `report.generated.html`, date-shaped
+> `sessions-YYYY-MM-DD*.jsonl` logs and their fallback shards, and the
+> `.stacks/` directory. It never deletes a directory
+> wholesale. A tampered registry can therefore, at most, delete those specific
+> names in an attacker-chosen directory, not arbitrary files. The `.stacks/`
+> entry is removed recursively, but symlinked artifacts are unlinked rather than
 > followed, so the target of a symlink is never deleted. The registry lives in
 > the user-owned HVE home (`~/.hve`, honoring `HVE_HOME`), so an attacker able
 > to tamper with it already holds the user's filesystem privileges; the risk is
@@ -310,7 +386,8 @@ extension upgrade. They forward any extra arguments to the report generator.
 Common issues:
 
 * No events captured: verify one enablement gate is set and your hook manifest is active.
-* No enrichment data: model and token enrichment depends on available debug logs and session-state data.
+* Events captured but no model, token, or cost data: the surface produced no usable usage log. On the CLI, confirm `~/.copilot/session-state/<sid>/events.jsonl` exists for the session. In VS Code, confirm a `debug-logs` directory exists under your workspace storage; stable builds may not write one. See [Enrichment Coverage by Surface](#enrichment-coverage-by-surface).
+* Token totals look approximate: check `token_source` on the `SessionSummary` record. `state_fallback` means the CLI process log was unavailable and totals were summed from shutdown metrics.
 * Report generation fails: ensure `python3` is available for enrichment. The bash generator also needs `jq`; the PowerShell generator (`Invoke-TelemetryReport.ps1`) does not.
 
 ## Related Guides

--- a/plugins/hve-core-all/hooks/shared/telemetry.json
+++ b/plugins/hve-core-all/hooks/shared/telemetry.json
@@ -74,6 +74,14 @@
         "timeoutSec": 10
       }
     ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "${PLUGIN_ROOT}/hooks/shared/telemetry/telemetry-collector.sh",
+        "powershell": "${PLUGIN_ROOT}/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "timeoutSec": 10
+      }
+    ],
     "preCompact": [
       {
         "type": "command",

--- a/plugins/hve-core/hooks/shared/telemetry.json
+++ b/plugins/hve-core/hooks/shared/telemetry.json
@@ -74,6 +74,14 @@
         "timeoutSec": 10
       }
     ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "${PLUGIN_ROOT}/hooks/shared/telemetry/telemetry-collector.sh",
+        "powershell": "${PLUGIN_ROOT}/hooks/shared/telemetry/Invoke-TelemetryCollector.ps1",
+        "timeoutSec": 10
+      }
+    ],
     "preCompact": [
       {
         "type": "command",

--- a/scripts/linting/Validate-HookManifests.ps1
+++ b/scripts/linting/Validate-HookManifests.ps1
@@ -40,7 +40,8 @@ $script:HookAllowedEvents = @(
     'preCompact',
     'subagentStart',
     'subagentStop',
-    'stop'
+    'stop',
+    'agentStop'
 )
 
 $script:HookAllowedTopLevel = @('version', 'description', 'hooks')

--- a/scripts/linting/schemas/hook-manifest.schema.json
+++ b/scripts/linting/schemas/hook-manifest.schema.json
@@ -35,7 +35,8 @@
           "preCompact",
           "subagentStart",
           "subagentStop",
-          "stop"
+          "stop",
+          "agentStop"
         ]
       },
       "additionalProperties": {


### PR DESCRIPTION
# Pull Request

This PR supersedes #2532 

## Description

Local telemetry recorded incomplete and sometimes wrong data depending on which surface fired the hook and which shell ran it. This PR fixes the cross-surface payload handling in the shared telemetry engine, repairs the PowerShell and Bash entry points, and makes the report and cleanup tools behave predictably when scoped to a single store.

Kudos to @chaosdinosaur and @auyidi1 for identifying powershell/bash incompatibilities and fixes!

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses using "Fixes #123" or "Closes #123" -->
Fixes #2538

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [x] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):


## Testing
<!-- Describe how you tested these changes -->
Automated:

* `uv run pytest -q` in `.github/hooks/shared/telemetry` — **65 passed**.
* `uv run ruff check .` in `.github/hooks/shared/telemetry` — **All checks passed**.

New regression coverage:

* Snake_case `tool_response` payload infers `PostToolUse` (previously `PreToolUse`).
* Snake_case `agent_name` + `stop_reason` infers `SubagentStop` (previously `SubagentStart`).
* `tool_response` with nested `text_result_for_llm` produces a correct `tool_response_len`.
* VS Code subagent payload carrying only `agent_type` yields a named agent on the stack.
* A session whose first event is not `SessionStart` still registers its telemetry directory.

Test hygiene: added an autouse fixture pinning `HVE_HOME` to `tmp_path`. Registry and launcher tests previously wrote into the real user home directory.

Diff-based assessment: verified that `telemetry-collector.sh` and `Invoke-TelemetryCollector.ps1` contain no payload key logic of their own, so consolidating aliases in `_telemetry_core.py` leaves no second source of truth.

Alias verification: every entry in `PAYLOAD_ALIASES` was checked against the published GitHub and VS Code hooks references. An undocumented `toolResponse` alias was removed.

Manual:
* Validated powershell scripts on windows (Powershell 5.1 for collector, 7+ for other ps1)
* Validated bash in WSL


## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no `scripts/security/` changes)

## Additional Notes
<!-- Any additional information that reviewers should know -->
