### PR TITLE
feat(agents): consolidate data-spec summary into the data dictionary

### DIFF
--- a/.github/CUSTOM-AGENTS.md
+++ b/.github/CUSTOM-AGENTS.md
@@ -325,10 +325,9 @@ It dispatches thin perspective subagents under `.github/agents/coding-standards/
 
 **Creates:** Data documentation artifacts:
 
-* `outputs/data-dictionary-{{dataset}}-{{YYYY-MM-DD}}.md` (column definitions and semantics)
+* `outputs/data-dictionary-{{dataset}}-{{YYYY-MM-DD}}.md` (column definitions and semantics, with a human-readable summary section)
 * `outputs/data-profile-{{dataset}}-{{YYYY-MM-DD}}.json` (statistical profile for downstream tools)
 * `outputs/data-objectives-{{dataset}}-{{YYYY-MM-DD}}.json` (analysis goals and constraints)
-* `outputs/data-summary-{{dataset}}-{{YYYY-MM-DD}}.md` (human-readable overview)
 
 **Workflow:** Confirm Scope → Discover Data → Sample & Infer Schema → Profile → Clarify → Emit Artifacts
 

--- a/.github/agents/data-science/gen-data-spec.agent.md
+++ b/.github/agents/data-science/gen-data-spec.agent.md
@@ -128,8 +128,9 @@ All outputs go in `outputs/` (create if missing). Use kebab-case dataset name.
 1. Data Dictionary (Markdown): `outputs/data-dictionary-{{dataset}}-{{YYYY-MM-DD}}.md`
 2. Data Profile (JSON): `outputs/data-profile-{{dataset}}-{{YYYY-MM-DD}}.json`
 3. Objectives (JSON): `outputs/data-objectives-{{dataset}}-{{YYYY-MM-DD}}.json`
-4. Summary Index (Markdown): `outputs/data-summary-{{dataset}}-{{YYYY-MM-DD}}.md`
-5. (Optional Multi) If multiple datasets: `outputs/data-multi-summary-{{YYYY-MM-DD}}.md`
+4. (Optional Multi) If multiple datasets: `outputs/data-multi-summary-{{YYYY-MM-DD}}.md`
+
+The Data Dictionary is the single Markdown deliverable. It opens with a required summary section (see Data Dictionary Summary Section Must Contain) and is followed by the full column-level dictionary.
 
 ### Data Profile JSON Schema (Must Follow)
 
@@ -194,7 +195,9 @@ All outputs go in `outputs/` (create if missing). Use kebab-case dataset name.
 }
 ```
 
-### Summary Markdown Must Contain
+### Data Dictionary Summary Section Must Contain
+
+The Data Dictionary opens with a required summary section (before the column-level dictionary) containing:
 
 * Dataset name & date generated
 * Primary key candidates
@@ -202,7 +205,7 @@ All outputs go in `outputs/` (create if missing). Use kebab-case dataset name.
 * Column counts by semantic role
 * Objectives bullet list
 * Quick quality highlights (top 3)
-* Paths to artifacts
+* Paths to artifacts (Data Profile JSON and Objectives JSON)
 
 ## Minimal Clarifying Question Strategy
 
@@ -214,7 +217,7 @@ Other agents will:
 
 * Parse Data Profile JSON to auto-build EDA notebooks (type-based plots)
 * Parse Objectives JSON to prioritize visualizations
-* Read Summary Markdown for human context panel
+* Read the Data Dictionary summary section for human context panel
 
 Therefore consistency & schema adherence is mandatory.
 
@@ -232,7 +235,6 @@ Therefore consistency & schema adherence is mandatory.
 outputs/data-dictionary-home-assistant-2025-09-03.md
 outputs/data-profile-home-assistant-2025-09-03.json
 outputs/data-objectives-home-assistant-2025-09-03.json
-outputs/data-summary-home-assistant-2025-09-03.md
 ```
 
 Proceed efficiently: extract, profile, clarify minimally, emit artifacts.

--- a/.github/agents/data-science/gen-jupyter-notebook.agent.md
+++ b/.github/agents/data-science/gen-jupyter-notebook.agent.md
@@ -15,7 +15,7 @@ Collect information about available data before generating notebook cells.
 
 Actions:
 
-1. Inspect data dictionary outputs in `outputs/` (for example, `data-dictionary-*.md`, `data-summary-*.md`).
+1. Inspect data dictionary outputs in `outputs/` (for example, `data-dictionary-*.md`).
 2. Identify dataset locations in `data/` and determine relative paths from `notebooks/`.
 3. Catalog primary entities, variable types (numeric, categorical, datetime, boolean), and potential join keys or time indices.
 

--- a/evals/agent-behavior/expectations/gen-data-spec.expectations.yml
+++ b/evals/agent-behavior/expectations/gen-data-spec.expectations.yml
@@ -35,28 +35,32 @@ expectations:
     contract_ref: "agent §Output Artifacts (All outputs go in `outputs/`)"
 
   - expectation_id: required-artifact-set
-    summary: Four required artifacts are produced for a single dataset.
-    signal: Output lists Markdown dictionary, JSON profile, JSON objectives,
-      and Markdown summary files for the dataset.
+    summary: Three required artifacts are produced for a single dataset.
+    signal: Output lists a Markdown dictionary (with an opening summary section),
+      a JSON profile, and a JSON objectives file for the dataset.
     pass_criteria: |
-      For a single-dataset request the response reports all four required
-      artifact paths in `outputs/`: the data dictionary `.md`, data profile
-      `.json`, objectives `.json`, and summary index `.md`.
+      For a single-dataset request the response reports all three required
+      artifact paths in `outputs/`: the data dictionary `.md` (whose opening
+      summary section carries the dataset/date, primary-key candidates, primary
+      time column, column-counts-by-semantic-role, objectives, top-3 quality
+      highlights, and artifact paths), the data profile `.json`, and the
+      objectives `.json`.
     failure_modes:
       - Produces only a single markdown file (current 2026-05-28 output is
         one `customers-table-spec.md` with DDL).
       - Drops the JSON profile or objectives artifact.
-      - Replaces the summary index with prose in chat instead of a file.
+      - Omits the required summary section from the data dictionary, or emits
+        the summary as chat prose instead of within the dictionary file.
     priority: high
-    contract_ref: "agent §Output Artifacts items 1–4"
+    contract_ref: "agent §Output Artifacts items 1–3 + §Data Dictionary Summary Section Must Contain"
 
   - expectation_id: filename-convention
     summary: Output filenames follow the kebab-case `{type}-{dataset}-{YYYY-MM-DD}` pattern.
     signal: Reported filenames match
-      `outputs/(data-dictionary|data-profile|data-objectives|data-summary)-<dataset>-\d{4}-\d{2}-\d{2}\.(md|json)`.
+      `outputs/(data-dictionary|data-profile|data-objectives)-<dataset>-\d{4}-\d{2}-\d{2}\.(md|json)`.
     pass_criteria: |
       Each reported filename is kebab-case, includes the dataset slug, ends
-      with a UTC `YYYY-MM-DD` date, and uses `.md` for dictionary/summary,
+      with a UTC `YYYY-MM-DD` date, and uses `.md` for the dictionary,
       `.json` for profile/objectives.
     failure_modes:
       - Filename omits the date (e.g., `customers-table-spec.md`,
@@ -108,12 +112,12 @@ expectations:
     pass_criteria: |
       Every column entry assigns `semantic_role` from
       `{id, time, metric, category, text, boolean, derived, unknown}`. The
-      summary lists column counts by semantic role.
+      data dictionary summary section lists column counts by semantic role.
     failure_modes:
       - `semantic_role` absent or free-form (e.g., "primary identifier").
-      - Summary omits the column-counts-by-role section.
+      - Data dictionary summary omits the column-counts-by-role section.
     priority: medium
-    contract_ref: "agent §Step 3 Sample & Infer Schema + §Summary Markdown Must Contain"
+    contract_ref: "agent §Step 3 Sample & Infer Schema + §Data Dictionary Summary Section Must Contain"
 
   - expectation_id: scope-confirmation-step
     summary: First turn confirms scope and objectives before profiling.

--- a/evals/agent-behavior/expectations/gen-jupyter-notebook.expectations.yml
+++ b/evals/agent-behavior/expectations/gen-jupyter-notebook.expectations.yml
@@ -111,10 +111,10 @@ expectations:
   - expectation_id: data-dictionary-referenced
     summary: Notebook references existing data dictionaries instead of inlining them.
     signal: Markdown cells link to or summarize `outputs/data-dictionary-*.md`
-      and `outputs/data-summary-*.md` artifacts rather than copying their text.
+      artifacts rather than copying their text.
     pass_criteria: |
-      Data Assets Summary section links to or briefly summarizes existing
-      dictionary/summary files under `outputs/`. Notebook does not paste
+      Data Assets Summary section links to or briefly summarizes the existing
+      data dictionary files under `outputs/`. Notebook does not paste
       multi-paragraph dictionary content inline.
     failure_modes:
       - Copies full dictionary markdown into a notebook cell.


### PR DESCRIPTION
# feat(agents): consolidate data-spec summary into the data dictionary

## Description

This PR reduces the number of output files the DS Gen Data Spec agent produces per run from four to three, so results are more concise for users. The standalone Summary Index Markdown file was folded into the Data Dictionary as a required opening summary section, and every named consumer of the removed file was updated in the same change.

* Reduced DS Gen Data Spec required outputs from four to three: the standalone `data-summary-{{dataset}}-{{YYYY-MM-DD}}.md` was removed, and its content became a required "Data Dictionary Summary Section Must Contain" section at the top of the Data Dictionary (dataset and date, primary-key candidates, primary time column, column counts by semantic role, objectives, top-3 quality highlights, and artifact paths). The two JSON outputs and the optional multi-dataset summary are unchanged.
* Updated the DS Gen Jupyter Notebook consumer so its Phase 1 inspect step references only `data-dictionary-*.md`.
* Updated both eval expectation files: `gen-data-spec.expectations.yml` now expects three artifacts with the summary carried inside the dictionary, drops `data-summary` from the filename regex, and retargets the `semantic-role-classification` expectation to the merged dictionary section; `gen-jupyter-notebook.expectations.yml` drops the `data-summary-*.md` reference from its `data-dictionary-referenced` signal. The `data-profile-schema-conformance` and `objectives-json-present` expectations are unchanged.
* Refreshed the `CUSTOM-AGENTS.md` gen-data-spec output enumeration to list the three outputs.

## Related Issue(s)

Closes #2544

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [x] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Only contributions targeting the **latest Anthropic and OpenAI models** will be accepted. Older model versions (e.g., GPT-3.5, Claude 3) will be rejected.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

Generate a data spec for the `home-assistant` dataset in `data/`.

**Execution Flow:**

The DS Gen Data Spec agent confirms scope, discovers and samples the data, infers the schema, profiles it, then emits its artifacts to `outputs/`. Following this change it writes three required files instead of four, with the human-readable summary now carried as the opening section of the Data Dictionary.

**Output Artifacts:**

* `outputs/data-dictionary-home-assistant-YYYY-MM-DD.md` (opens with the required summary section, then the column-level dictionary)
* `outputs/data-profile-home-assistant-YYYY-MM-DD.json`
* `outputs/data-objectives-home-assistant-YYYY-MM-DD.json`

**Success Indicators:**

Three artifacts appear under `outputs/`; the Data Dictionary begins with the dataset/date, primary-key candidates, primary time column, column counts by semantic role, objectives, top-3 quality highlights, and artifact paths; no standalone `data-summary-*.md` is produced.

## Testing

Ran scoped validation on the changed files: markdown frontmatter validation (3 files, 0 errors), markdownlint (0 errors), a repository-wide grep confirming no remaining in-scope `data-summary` reference, a prose grep confirming no stale "Summary Markdown"/"Summary Index" reference, and a structural parse of the eval expectation files confirming the `data-profile-schema-conformance` and `objectives-json-present` expectations are unchanged.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

This is Wave 1 of a staged effort to reduce agent output-artifact counts. Later waves (RAI planner phase-file consolidation, backlog-manager log/handoff merge, and others) are tracked separately and are out of scope here.

📉 - Generated by Copilot
