### PR TITLE
docs(scripts): document Validate-Marketplace.ps1 in plugins README

### DIFF
--- a/scripts/plugins/README.md
+++ b/scripts/plugins/README.md
@@ -8,10 +8,11 @@ manifests.
 
 ## Scripts
 
-| Script                     | npm Command               | Description                                  |
-|----------------------------|---------------------------|----------------------------------------------|
-| Generate-Plugins.ps1       | `npm run plugin:generate` | Generate plugin directories from collections |
-| Modules/PluginHelpers.psm1 | (library)                 | Plugin symlink, manifest, and packaging      |
+| Script                     | npm Command                | Description                                  |
+|----------------------------|----------------------------|----------------------------------------------|
+| Generate-Plugins.ps1       | `npm run plugin:generate`  | Generate plugin directories from collections |
+| Validate-Marketplace.ps1   | `npm run lint:marketplace` | Validate marketplace.json plugin manifest    |
+| Modules/PluginHelpers.psm1 | (library)                  | Plugin symlink, manifest, and packaging      |
 
 ## Prerequisites
 
@@ -32,6 +33,25 @@ npm run plugin:generate
 ```
 
 This regenerates all plugins from their collection manifests.
+
+## Marketplace Validation
+
+`Validate-Marketplace.ps1` validates `.github/plugin/marketplace.json` against
+its JSON schema and checks plugin source directory existence, name-source
+consistency, version alignment with the root `package.json`, and absence of
+path separators in source values.
+
+```bash
+npm run lint:marketplace
+```
+
+Parameters:
+
+* `-OutputPath` (default: `logs/marketplace-validation-results.json`): path
+  for the structured JSON report, absolute or relative to the repository root
+
+The script writes structured JSON results to `logs/`, consistent with the rest
+of the linting pipeline. Pass `-OutputPath ''` to suppress the report file.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Description

Documents `Validate-Marketplace.ps1` and its `npm run lint:marketplace` command in `scripts/plugins/README.md`, closing the gap left after [PR #1430](https://github.com/microsoft/hve-core/pull/1430) added structured JSON output to the script.

Two changes to `scripts/plugins/README.md`:

1. Added `Validate-Marketplace.ps1` to the Scripts table with its `npm run lint:marketplace` command.
2. Added a new **Marketplace Validation** section that describes what the script validates, documents the `-OutputPath` parameter (default: `logs/marketplace-validation-results.json`), and notes that structured JSON results are written to `logs/`, consistent with the rest of the linting pipeline.

`scripts/README.md` already lists the script and links to `plugins/README.md`, so no other files need to be updated.

## Related Issue(s)

Fixes #1485

## Type of Change

**Code & Documentation:**

* [x] Documentation update

## Testing

Prose describing the script's behavior was cross-checked against the script's own `.SYNOPSIS`/`.DESCRIPTION` and the `Write-MarketplaceValidationReport` helper to confirm accuracy of the parameter default, the report location, and the described validation checks. Only `scripts/plugins/README.md` is modified; no code, scripts, or generated docs are changed.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)

### Required Local Checks

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Scope is intentionally minimal: one Scripts table row and one short reference section added, no other edits to the file or repository.
