### PR TITLE
docs(contributing): add docs:generate and lint:asset-docs to Automated Validation

### DIFF
--- a/docs/contributing/ai-artifacts-common.md
+++ b/docs/contributing/ai-artifacts-common.md
@@ -3,7 +3,7 @@ title: 'AI Artifacts Common Standards'
 description: 'Common standards and quality gates for all AI artifact contributions to hve-core'
 sidebar_position: 2
 author: Microsoft
-ms.date: 2026-07-15
+ms.date: 2026-07-30
 ms.topic: reference
 ---
 
@@ -747,6 +747,12 @@ npm run lint:ps
 
 # Validate skill structure (if applicable)
 npm run validate:skills
+
+# Scaffold reference pages for new documentable assets
+npm run docs:generate
+
+# Validate asset reference pages and AUTO-GENERATED regions
+npm run lint:asset-docs
 ```
 
 ### Quality Gates

--- a/docs/contributing/custom-agents.md
+++ b/docs/contributing/custom-agents.md
@@ -3,7 +3,7 @@ title: 'Contributing Agents to HVE Core'
 description: 'Requirements and standards for contributing GitHub Copilot agent files to hve-core'
 sidebar_position: 5
 author: Microsoft
-ms.date: 2026-07-15
+ms.date: 2026-07-30
 ms.topic: how-to
 ---
 
@@ -584,6 +584,8 @@ Run these commands before submission (see [Common Standards - Common Validation]
 * `npm run lint:md`
 * `npm run spell-check`
 * `npm run lint:md-links`
+* `npm run docs:generate` (required when adding a new agent; scaffolds the reference page under `docs/reference/agents/`)
+* `npm run lint:asset-docs`
 
 All checks **MUST** pass before merge.
 

--- a/docs/contributing/instructions.md
+++ b/docs/contributing/instructions.md
@@ -3,7 +3,7 @@ title: 'Contributing Instructions to HVE Core'
 description: 'Requirements and standards for contributing GitHub Copilot instruction files to hve-core'
 sidebar_position: 3
 author: Microsoft
-ms.date: 2026-07-15
+ms.date: 2026-07-30
 ms.topic: how-to
 ---
 
@@ -639,6 +639,8 @@ Run these commands before submission (see [Common Standards - Common Validation]
 * `npm run lint:md`
 * `npm run spell-check`
 * `npm run lint:md-links`
+* `npm run docs:generate` (required when adding a new instruction; scaffolds the reference page under `docs/reference/instructions/`)
+* `npm run lint:asset-docs`
 
 All checks **MUST** pass before merge.
 

--- a/docs/contributing/prompts.md
+++ b/docs/contributing/prompts.md
@@ -3,7 +3,7 @@ title: 'Contributing Prompts to HVE Core'
 description: 'Requirements and standards for contributing GitHub Copilot prompt files to hve-core'
 sidebar_position: 4
 author: Microsoft
-ms.date: 2026-07-08
+ms.date: 2026-07-30
 ms.topic: how-to
 ---
 
@@ -599,6 +599,8 @@ Run these commands before submission (see [Common Standards - Common Validation]
 * `npm run lint:md`
 * `npm run spell-check`
 * `npm run lint:md-links`
+* `npm run docs:generate` (required when adding a new prompt; scaffolds the reference page under `docs/reference/prompts/`)
+* `npm run lint:asset-docs`
 
 All checks **MUST** pass before merge.
 

--- a/docs/contributing/skills.md
+++ b/docs/contributing/skills.md
@@ -3,7 +3,7 @@ title: Contributing Skills to HVE Core
 description: Requirements and standards for contributing skill packages to hve-core
 sidebar_position: 6
 author: Microsoft
-ms.date: 2026-06-30
+ms.date: 2026-07-30
 ms.topic: how-to
 keywords:
   - skills
@@ -588,6 +588,8 @@ npm run lint:md               # Validate markdown formatting
 npm run validate:skills       # Validate skill directory structure
 npm run test:ps               # Run PowerShell unit tests
 npm run docs:test             # Validate Docusaurus artifact counts
+npm run docs:generate         # Scaffold reference page under docs/reference/skills/ (new skills)
+npm run lint:asset-docs       # Validate asset reference pages and AUTO-GENERATED regions
 ```
 
 All checks **MUST** pass before merge.


### PR DESCRIPTION
# Pull Request

## Description

After [PR #2389](https://github.com/microsoft/hve-core/pull/2389) scaffolded the Asset Catalog under `docs/reference/`, adding a new documentable asset (agent, prompt, instruction, or skill) requires:

* Running `npm run docs:generate` to scaffold or refresh the reference page under `docs/reference/<kind>/`.
* Running `npm run lint:asset-docs` to validate that every documentable asset has a corresponding reference page and that AUTO-GENERATED regions stay consistent (this is now part of `npm run lint:all`).

Neither command was mentioned in the per-type contributing guides or the common validation section, so contributors could merge assets without generating the required reference page and see `lint:asset-docs` fail in CI.

This PR adds both commands to the **Automated Validation** section of each per-type contributing guide (`custom-agents.md`, `prompts.md`, `instructions.md`, `skills.md`) and to the **Common Validation Standards** section of `ai-artifacts-common.md`. Wording, backticked-command style, and use of parentheticals mirror the existing entries in each file. `ms.date` is bumped in every touched file.

## Related Issue(s)

Fixes #2469

## Type of Change

**Code & Documentation:**

* [x] Documentation update

## Testing

Cross-checked new commands against `package.json` and `scripts/docs/Generate-AssetDocs.ps1`, verified the reference directory layout under `docs/reference/` (`agents/`, `prompts/`, `instructions/`, `skills/`), and confirmed each new entry matches its host file's style (bullet list in the per-type guides, aligned code fence with inline comments in `skills.md`, comment-header code block in `ai-artifacts-common.md`). No content beyond the two new entries and the `ms.date` bumps was changed.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)

### Required Local Checks

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

Scope is intentionally minimal: two commands added to the Automated Validation section of each of the five contributing docs, plus a `ms.date` refresh on each touched file.
