### PR TITLE
feat(agents): consolidate RAI planner phase files into rai-plan.md

### DIFF
--- a/.github/CUSTOM-AGENTS.md
+++ b/.github/CUSTOM-AGENTS.md
@@ -236,15 +236,17 @@ Users are responsible for verifying their repository's `.gitignore` configuratio
 
 ### rai-planner
 
-**Creates:** Nine artifacts across 6 phases under `.copilot-tracking/rai-plans/{project-slug}/`:
+**Creates:** One consolidated `rai-plan.md` plus session state under `.copilot-tracking/rai-plans/{project-slug}/`:
 
 * `state.json` (session state for resume capability)
-* `system-definition-pack.md`, `stakeholder-impact-map.md` (Phase 1: AI System Scoping)
-* Risk classification screening output (Phase 2: Risk Classification)
-* `rai-standards-mapping.md` (Phase 3: RAI Standards Mapping)
-* `rai-threat-addendum.md` (Phase 4: RAI Security Model Analysis)
-* `control-surface-catalog.md`, `evidence-register.md`, `rai-tradeoffs.md` (Phase 5: RAI Impact Assessment)
-* `rai-review-summary.md` and backlog items (Phase 6: Review and Handoff)
+* `rai-plan.md` with eight sections in phase order:
+  * `## System Definition` (with an `### AI Component Inventory` table subsection) and `## Stakeholder Impact` (Phase 1: AI System Scoping)
+  * `### Risk Classification Screening` under `## System Definition` (Phase 2: Risk Classification)
+  * `## Standards Mapping` (Phase 3: RAI Standards Mapping)
+  * `## Threat Addendum` (Phase 4: RAI Security Model Analysis)
+  * `## Control Surface Catalog`, `## Evidence Register`, `## Tradeoffs` (Phase 5: RAI Impact Assessment)
+  * `## Review Summary` (Phase 6: Review and Handoff)
+* Backlog items and `artifact-manifest.json` when signing is accepted (Phase 6: Review and Handoff)
 
 **Workflow:** Six sequential phases mapped to NIST AI RMF functions: AI System Scoping (Govern + Map) → Risk Classification (Govern) → RAI Standards Mapping (Govern + Measure) → RAI Security Model Analysis (Measure) → RAI Impact Assessment (Manage) → Review and Handoff (Manage)
 

--- a/.github/agents/rai-planning/rai-planner.agent.md
+++ b/.github/agents/rai-planning/rai-planner.agent.md
@@ -20,7 +20,7 @@ tools:
 
 # RAI Planner
 
-Responsible AI assessment planning agent that guides users through structured planning for AI system review against NIST AI RMF 1.0 as the default evaluation framework, replaceable when users supply custom framework documents. Prepares 8 artifacts across 6 phases, covering RAI-specific security model analysis, impact assessment planning, control surface cataloging, and dual-format backlog handoff. All artifacts are stored under `.copilot-tracking/rai-plans/{project-slug}/`.
+Responsible AI assessment planning agent that guides users through structured planning for AI system review against NIST AI RMF 1.0 as the default evaluation framework, replaceable when users supply custom framework documents. Prepares one consolidated `rai-plan.md` with eight sections across 6 phases, covering RAI-specific security model analysis, impact assessment planning, control surface cataloging, and dual-format backlog handoff. The consolidated plan and supporting state are stored under `.copilot-tracking/rai-plans/{project-slug}/`.
 
 Works iteratively with up to 7 questions per turn, using emoji checklists to track progress: ❓ pending, ✅ complete, ❌ blocked or skipped.
 
@@ -49,13 +49,13 @@ RAI assessment follows six sequential phases. Each phase collects input through 
 
 Explore the AI system's purpose, technology stack, deployment model, stakeholder roles, data inputs and outputs, and intended use context. Identify the system's AI components and suggest assessment boundaries. Populate `state.json` with initial project metadata including project slug, entry mode, and AI element inventory. Ask whether the user has specific evaluation standards, risk indicator categories, or output format requirements to incorporate per the User-Supplied Reference Content Protocol in the identity instruction file.
 
-* Artifacts: `system-definition-pack.md`, `stakeholder-impact-map.md`
+* Artifacts: `rai-plan.md` sections `## System Definition` (with an `### AI Component Inventory` table subsection) and `## Stakeholder Impact`
 
 ### Phase 2: Risk Classification (NIST Govern)
 
 Classify risk level using the active framework's risk indicators. The default NIST framework uses three indicators: `safety_reliability` (binary), `rights_fairness_privacy` (categorical), and `security_explainability` (continuous). Run the Prohibited Uses Gate first using any `prohibited-use-framework` references or the active framework's prohibited uses definitions. Then evaluate each risk indicator; for activated indicators, ask depth questions to capture evidence and context. Determine the suggested assessment depth tier based on activated count (0 = Basic, 1 = Standard, 2+ = Comprehensive). When a custom framework is active (`replaceDefaultIndicators: true`), use the custom framework's indicators and assessment methods instead. Present risk classification screening summary and suggested depth tier for user confirmation before advancing.
 
-* Artifacts: Risk classification screening summary in `system-definition-pack.md`
+* Artifacts: Risk classification screening summary in the `### Risk Classification Screening` subsection under `## System Definition` in `rai-plan.md`
 
 #### Mural Board Bootstrap (optional)
 
@@ -70,7 +70,7 @@ Verb sequence:
 3. `mural area list` to resolve A1, A2, A3 by title substring.
 4. `mural tag create` to re-assert the reserved tag manifest (`authored-by-ai`, `rai-phase2`).
 5. `mural area probe` before any parented `mural widget create-bulk` call.
-6. `mural widget create-bulk` per area, decomposing source rows: A1 from numbered sections in `system-definition-pack.md`; A2 from AI component table rows in §2; A3 from bullets in `stakeholder-impact-map.md`.
+6. `mural widget create-bulk` per area, decomposing source rows: A1 from the numbered subsections within `## System Definition` in `rai-plan.md`; A2 from the AI component table rows in the `### AI Component Inventory` subsection under `## System Definition`; A3 from bullets in `## Stakeholder Impact`.
 7. `mural widget update-bulk` for anchor inheritance: copy `(x, y, w, h, style.backgroundColor)` from per-area placeholder anchors onto the new widgets.
 8. `mural widget delete` for consumed anchors only.
 9. `mural widget list-with-context` for readback verification.
@@ -84,19 +84,19 @@ When the decision rule selects sticky-note widgets, cap sticky text at 8 words. 
 
 Map the AI system's components and behaviors to NIST AI RMF 1.0 trustworthiness characteristics: Valid and Reliable, Safe, Secure and Resilient, Accountable and Transparent, Explainable and Interpretable, Privacy-Enhanced, and Fair with Harmful Bias Managed. When a custom framework is active (`replaceDefaultFramework: true`), use the active framework's characteristic names instead. Identify applicable regulatory jurisdictions and suggest framework priorities. Cross-reference with NIST AI RMF subcategories when NIST is active; use the custom framework's phase mappings otherwise. Update the `principleTracker` for each mapped characteristic and display per-characteristic status in the Phase 3 summary.
 
-* Artifacts: `rai-standards-mapping.md`
+* Artifacts: `rai-plan.md` section `## Standards Mapping`
 
 ### Phase 4: RAI Security Model Analysis (NIST Measure)
 
 Facilitate AI-specific threat analysis per component. Catalog potential threats using the dual threat ID convention: `T-RAI-{NNN}` for sequential RAI threat IDs and `T-{BUCKET}-AI-{NNN}` for Security Planner cross-references when overlap exists. Threat categories include data poisoning, model evasion, prompt injection, output manipulation, bias amplification, privacy leakage, and misuse escalation. Assess potential impact and concern level for each identified threat.
 
-* Artifacts: `rai-threat-addendum.md`
+* Artifacts: `rai-plan.md` section `## Threat Addendum`
 
 ### Phase 5: RAI Impact Assessment (NIST Manage)
 
 Explore control surface coverage for each identified threat. Document evidence of existing mitigations and highlight potential gaps. Explore appropriate reliance by examining trust calibration mechanisms, human-in-the-loop design for high-stakes decisions, and patterns of over-reliance or under-reliance. Explore tradeoffs between competing trustworthiness characteristics (for example, transparency versus privacy). Prepare the control surface catalog and evidence register.
 
-* Artifacts: `control-surface-catalog.md`, `evidence-register.md`, `rai-tradeoffs.md`
+* Artifacts: `rai-plan.md` sections `## Control Surface Catalog`, `## Evidence Register`, and `## Tradeoffs`
 
 ### Phase 6: Review and Handoff (NIST Manage)
 
@@ -106,7 +106,7 @@ If the assessment surfaced architectural decisions worth preserving — model se
 
 When presenting the final handoff message, render the produced artifacts using the Final Handoff Summary table in the `rai-planner` skill `references/backlog-handoff.md` rather than a flat list of filenames.
 
-* Artifacts: `rai-review-summary.md`, backlog items, `artifact-manifest.json` (when signing accepted)
+* Artifacts: `rai-plan.md` section `## Review Summary`, backlog items, `artifact-manifest.json` (when signing accepted)
 
 ## Entry Modes
 

--- a/.github/instructions/rai-planning/rai-identity.instructions.md
+++ b/.github/instructions/rai-planning/rai-identity.instructions.md
@@ -47,7 +47,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: New session started or `from-prd`/`from-security-plan` entry mode activated.
 * **Activities**: Scan `.copilot-tracking/rai-plans/references/` for existing reference content and `.copilot-tracking/rai-plans/{project-slug}/state.json` for existing `referencesProcessed` entries. If existing references are found, present them for confirmation. Otherwise, conduct reference content discovery: ask about evaluation standards, output format requirements, and code-of-conduct documents per the User-Supplied Reference Content Protocol and Code-of-Conduct Discovery sections. Capture output preferences (outputDetailLevel, targetSystem, audienceProfile, includeOptionalArtifacts). Then proceed with the AI system scoping interview: discover AI system purpose, technology stack, model types, deployment model, stakeholder roles, data inputs, outputs, representativeness, and demographic coverage, intended use contexts, out-of-scope and prohibited use contexts, and autonomous decision boundaries. Classify AI components (model type, training approach, inference pipeline). Establish assessment boundaries and exclusions.
 * **Exit criteria**: Summary-and-advance: present a summary of captured context, AI element inventory, stakeholder map, and output preferences. Advance unless the user objects.
-* **Artifacts**: `system-definition-pack.md`, `stakeholder-impact-map.md`
+* **Artifacts**: `rai-plan.md` sections `## System Definition` (with an `### AI Component Inventory` table subsection) and `## Stakeholder Impact`
 * **Transition**: Advance to Phase 2 after summary.
 
 ### Phase 2: Risk Classification (NIST Govern)
@@ -55,7 +55,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: Phase 1 complete; system scope confirmed.
 * **Activities**: Classify risk level using the active framework's risk indicators. The default NIST framework uses three indicators: `safety_reliability` (binary), `rights_fairness_privacy` (categorical), and `security_explainability` (continuous). Each indicator maps to NIST MEASURE subcategories. Run the Prohibited Uses Gate first using any `prohibited-use-framework` references or the active framework's prohibited uses definitions. Then evaluate each risk indicator; for activated indicators, ask depth questions to capture evidence and context. Determine the suggested assessment depth tier based on activated count (0 = `basic`, 1 = `standard`, 2+ = `comprehensive`). When a custom framework is active (`replaceDefaultIndicators: true`), use the custom framework's indicators and assessment methods instead.
 * **Exit criteria**: Hard gate: present risk classification screening summary and suggested depth tier assignment. User must confirm tier before advancing. Rationale: tier-change affects scope and effort of all downstream phases.
-* **Artifacts**: Risk classification screening summary added to `system-definition-pack.md`
+* **Artifacts**: Risk classification screening summary added to the `### Risk Classification Screening` subsection under `## System Definition` in `rai-plan.md`
 * **Transition**: Advance to Phase 3 after user confirms depth tier.
 
 ### Phase 3: RAI Standards Mapping (NIST Govern + Measure)
@@ -63,7 +63,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: Phase 2 complete; risk classification confirmed.
 * **Activities**: Map AI system components and behaviors to NIST AI RMF 1.0 trustworthiness characteristics: Valid and Reliable, Safe, Secure and Resilient, Accountable and Transparent, Explainable and Interpretable, Privacy-Enhanced, and Fair with Harmful Bias Managed. When a custom framework is active (`replaceDefaultFramework: true`), use the active framework's characteristic names instead. Identify regulatory jurisdiction and framework priorities (conditional on active framework). Cross-reference with NIST AI RMF subcategories (Govern 1-6, Map 1-5, Measure 1-4, Manage 1-4) when NIST is active; use the custom framework's phase mappings otherwise. Document existing compliance posture and gaps.
 * **Exit criteria**: Hard gate: present standards mapping summary and scope determination. Update `principleTracker` for each characteristic mapped during this phase (set `mappedInPhase3: true`, update `suggestedStatus`). Display the per-characteristic tracker status in the summary so the user can see which characteristics have been mapped and which remain uncovered. User must confirm scope before advancing. Rationale: scope-change affects breadth of security model and impact assessment.
-* **Artifacts**: `rai-standards-mapping.md`
+* **Artifacts**: `rai-plan.md` section `## Standards Mapping`
 * **Transition**: Advance to Phase 4 after user confirmation.
 
 ### Phase 4: RAI Security Model Analysis (NIST Measure)
@@ -71,7 +71,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: Phase 3 complete; standards mapping confirmed.
 * **Activities**: Apply AI-specific security model analysis per component. Identify threats using the dual threat ID convention: `T-RAI-{NNN}` for sequential RAI threat IDs and `T-{BUCKET}-AI-{NNN}` for Security Planner cross-references when overlap exists. Threat categories include data poisoning, model evasion, prompt injection, output manipulation, bias amplification, privacy leakage, and misuse escalation. Assess potential impact and concern level per the AI STRIDE overlay in the `rai-standards` skill. When operating in `from-security-plan` mode, start threat IDs at the next sequence number after the security plan's threat count.
 * **Exit criteria**: Summary-and-advance: present security model analysis summary with threat table and concern levels. Advance unless the user raises concerns.
-* **Artifacts**: `rai-threat-addendum.md`
+* **Artifacts**: `rai-plan.md` section `## Threat Addendum`
 * **Transition**: Advance to Phase 5 after summary.
 
 ### Phase 5: RAI Impact Assessment (NIST Manage)
@@ -79,7 +79,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: Phase 4 complete; security model confirmed.
 * **Activities**: Evaluate control surface completeness for each identified threat. Document evidence of existing mitigations and identify coverage gaps. Analyze tradeoffs between competing trustworthiness characteristics (for example, transparency versus privacy, fairness versus performance). Generate the control surface catalog, evidence register, and tradeoffs analysis.
 * **Exit criteria**: Summary-and-advance: present impact assessment summary with maturity indicators and generated observations. Advance unless the user raises concerns.
-* **Artifacts**: `control-surface-catalog.md`, `evidence-register.md`, `rai-tradeoffs.md`
+* **Artifacts**: `rai-plan.md` sections `## Control Surface Catalog`, `## Evidence Register`, and `## Tradeoffs`
 * **Transition**: Advance to Phase 6 after summary.
 
 ### Phase 6: Review and Handoff (NIST Manage)
@@ -87,7 +87,7 @@ Six sequential phases structure the RAI assessment. Each phase declares entry cr
 * **Entry criteria**: Phase 5 complete; impact assessment confirmed.
 * **Activities**: Generate review summary covering observations across six dimensions: scope boundary clarity, risk identification coverage, control surface adequacy, evidence sufficiency, future work governance, and risk classification alignment. Generate backlog items for identified gaps using the appropriate format (ADO, GitHub, or both) per user preference. Present findings for final review. After handoff generation, offer cryptographic signing of all session artifacts per the Artifact Signing subsection in the `rai-planner` skill's backlog handoff reference. When the user accepts, invoke `npm run rai:sign -- -ProjectSlug {project-slug}` to generate a SHA-256 manifest and optionally sign with cosign.
 * **Exit criteria**: Hard gate: present complete review summary with observations, backlog items, and handoff summary. User must confirm before work items are created. Rationale: external-effect, created work items are visible to others.
-* **Artifacts**: `rai-review-summary.md`, backlog items, `artifact-manifest.json` (when signing accepted)
+* **Artifacts**: `rai-plan.md` section `## Review Summary`, backlog items, `artifact-manifest.json` (when signing accepted)
 * **Transition**: Assessment complete. State file updated with observations and `handoffGenerated` updated with platform-specific flags.
 
 ## Entry Modes

--- a/.github/skills/project-planning/rai-planner/references/backlog-handoff.md
+++ b/.github/skills/project-planning/rai-planner/references/backlog-handoff.md
@@ -31,26 +31,26 @@ Select the output target and autonomy tier that fit the project context. Persist
 
 ## Final Handoff Summary
 
-When presenting the final handoff to the user, render the produced artifacts as a descriptive table rather than a flat list of filenames. Group rows by the phase that produced each artifact, link to the real relative paths under the project slug folder, and give each artifact a short "what it contains" description so the user knows why to open it.
+When presenting the final handoff to the user, render the produced artifacts as a descriptive table rather than a flat list of filenames. The phase deliverables are sections of the single consolidated `rai-plan.md`; group rows by the phase that produced each section, link to the real relative path with the section anchor under the project slug folder, and give each row a short "what it contains" description so the user knows why to open it. The backlog-handoff files and the signing manifest remain separate files.
 
 Apply these rules to the artifacts table:
 
 * Use relative links to the actual files, never absolute or editor-shell paths. Do not wrap links in backticks.
-* Keep one row per artifact with columns for phase, artifact, and a concise description of the contents.
+* Keep one row per deliverable with columns for phase, artifact, and a concise description of the contents.
 * Replace bracketed placeholders with the values from session state; omit rows for artifacts the session did not produce.
 
-| Phase         | Artifact                                                        | What it contains                                                                                            |
-|---------------|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| 1 — Scoping   | [system-definition-pack.md]({slug}/system-definition-pack.md)   | System boundary, components, data flows, and intended use                                                   |
-| 1 — Scoping   | [stakeholder-impact-map.md]({slug}/stakeholder-impact-map.md)   | Affected stakeholders and how each is impacted                                                              |
-| 3 — Standards | [rai-standards-mapping.md]({slug}/rai-standards-mapping.md)     | Framework mapping across the selected trustworthiness characteristics                                       |
-| 4 — Threats   | [rai-threat-addendum.md]({slug}/rai-threat-addendum.md)         | Identified threats with IDs and the high-concern subset                                                     |
-| 5 — Impact    | [control-surface-catalog.md]({slug}/control-surface-catalog.md) | Controls and their coverage across the framework functions                                                  |
-| 5 — Impact    | [evidence-register.md]({slug}/evidence-register.md)             | Evidence backing each control claim                                                                         |
-| 5 — Impact    | [rai-tradeoffs.md]({slug}/rai-tradeoffs.md)                     | Tradeoffs needing human adjudication                                                                        |
-| 6 — Handoff   | [rai-review-summary.md]({slug}/rai-review-summary.md)           | Posture, gaps, and the human-review gate                                                                    |
-| 6 — Handoff   | [ado-backlog-handoff.md]({slug}/ado-backlog-handoff.md)         | Drafted backlog items in ADO format (present when the target system includes ADO), ready after review       |
-| 6 — Handoff   | [github-backlog-handoff.md]({slug}/github-backlog-handoff.md)   | Drafted backlog items in GitHub format (present when the target system includes GitHub), ready after review |
+| Phase         | Artifact                                                                            | What it contains                                                                                            |
+|---------------|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| 1 — Scoping   | [rai-plan.md — System Definition]({slug}/rai-plan.md#system-definition)             | System boundary, components, data flows, and intended use                                                   |
+| 1 — Scoping   | [rai-plan.md — Stakeholder Impact]({slug}/rai-plan.md#stakeholder-impact)           | Affected stakeholders and how each is impacted                                                              |
+| 3 — Standards | [rai-plan.md — Standards Mapping]({slug}/rai-plan.md#standards-mapping)             | Framework mapping across the selected trustworthiness characteristics                                       |
+| 4 — Threats   | [rai-plan.md — Threat Addendum]({slug}/rai-plan.md#threat-addendum)                 | Identified threats with IDs and the high-concern subset                                                     |
+| 5 — Impact    | [rai-plan.md — Control Surface Catalog]({slug}/rai-plan.md#control-surface-catalog) | Controls and their coverage across the framework functions                                                  |
+| 5 — Impact    | [rai-plan.md — Evidence Register]({slug}/rai-plan.md#evidence-register)             | Evidence backing each control claim                                                                         |
+| 5 — Impact    | [rai-plan.md — Tradeoffs]({slug}/rai-plan.md#tradeoffs)                             | Tradeoffs needing human adjudication                                                                        |
+| 6 — Handoff   | [rai-plan.md — Review Summary]({slug}/rai-plan.md#review-summary)                   | Posture, gaps, and the human-review gate                                                                    |
+| 6 — Handoff   | [ado-backlog-handoff.md]({slug}/ado-backlog-handoff.md)                             | Drafted backlog items in ADO format (present when the target system includes ADO), ready after review       |
+| 6 — Handoff   | [github-backlog-handoff.md]({slug}/github-backlog-handoff.md)                       | Drafted backlog items in GitHub format (present when the target system includes GitHub), ready after review |
 
 ## Content Hygiene
 


### PR DESCRIPTION
# Pull Request

## Description

Consolidates the RAI Planner's per-run output from **eight separate per-phase Markdown files into one `rai-plan.md`** with eight sections in phase order, matching the consolidated single-plan pattern the Security and SSSC planners already use. This rewrites only the authoring specification (agent + instruction + skill reference + docs); it does not touch any generated working file under `.copilot-tracking/rai-plans/` and preserves all assessment content, phase order, NIST mappings, threat IDs, signing, and backlog handoff semantics.

* `feat(agents)`: rewrote the six phase `Artifacts:` lines in `rai-planner.agent.md` to name sections of one `rai-plan.md` (`## System Definition` with an `### AI Component Inventory` subsection and a `### Risk Classification Screening` subsection, `## Stakeholder Impact`, `## Standards Mapping`, `## Threat Addendum`, `## Control Surface Catalog`, `## Evidence Register`, `## Tradeoffs`, `## Review Summary`), and reworded the intro to describe one consolidated plan.
* `feat(agents)`: repointed the Phase-1 Mural `create-bulk` bindings so A1/A2/A3 read from the consolidated `## System Definition` numbered subsections, the `### AI Component Inventory` table, and the `## Stakeholder Impact` bullets instead of the former standalone files.
* `feat(instructions)`: mirrored the consolidated layout in the six phase Artifacts lines of `rai-identity.instructions.md`, keeping the always-required output-layout invariants in the instruction.
* `feat(skills)`: rewrote the `rai-planner` skill `backlog-handoff.md` Final Handoff Summary table so the eight phase deliverables link to `rai-plan.md` section anchors, keeping the ADO/GitHub backlog-handoff files and signing manifest as separate rows.
* `docs`: updated the `.github/CUSTOM-AGENTS.md` RAI output enumeration to describe the single consolidated `rai-plan.md`.

## Related Issue(s)

Closes #2565

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [x] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [x] Copilot agent (`.github/agents/*.agent.md`)
* [x] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing

Local-safe validation run against the change:

* `npm run lint:ai-artifacts` (Validate-PlannerArtifacts) — 78 files scanned, 0 issues.
* `npm run ci:eval:lint:schema` — 10 eval specs validated, 0 failed, 40/40 agent behavior coverage.
* `npm run ci:eval:lint:text` — passed (only pre-existing design-thinking doc warnings, none in changed files).
* `npm run test:ps -- -TestPath scripts/tests/linting/Validate-PlannerArtifacts.Tests.ps1` — 36 passed, 0 failed.
* `markdownlint` on changed files and `npm run lint:frontmatter` (825 files) — 0 errors.
* `npm run plugin:validate` — 14 collections, 0 errors; `plugin:generate` / `extension:prepare` / `docs:generate` re-run idempotently.
* Per-file check confirmed both the agent and instruction retain their canonical RAI disclaimer reference and Disclaimer/Attribution protocol.
* `ci:eval:lint:vally` and `ci:eval:lint:skills` are pending CI — the `vally` CLI is not available locally.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable)
* [ ] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

* The `footer-with-review.yml` RAI artifact stems are intentionally left dormant/unchanged: the planner-artifact validator matches by filename basename and cannot classify the H2 sections of a consolidated file, and CI does not scan the generated `.copilot-tracking/rai-plans/` output. Section-aware footer enforcement is recorded as a follow-up rather than applied here.
* Relocating the phase output contract from the instruction into the `rai-planner` skill was assessed and deferred as a follow-up: the skill loads references only at phase boundaries, so moving the always-required output contract could change behavior. The invariants stay in the instruction.

🗂️ - Generated by Copilot
