### PR TITLE
fix(docs): restore focus to main landmark on cross-layout navigation

### DIFF
--- a/docs/docusaurus/e2e/focus-management.spec.ts
+++ b/docs/docusaurus/e2e/focus-management.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { SITE_PAGES, visitInvariantPage } from './_helpers/a11yInvariants';
 import { testFocusTrapEscape, validateRovingTabindex } from './_helpers/focus';
 
@@ -10,6 +11,59 @@ import { testFocusTrapEscape, validateRovingTabindex } from './_helpers/focus';
 // order (2.4.3), focus visibility (2.4.7), and focus indicator size (2.4.11).
 // Contrast and structural ARIA checks stay in the existing axe specs to avoid
 // redundant coverage.
+
+// Assert that keyboard focus rests on the route's main landmark.
+//
+// The assertion is deliberately positive: it compares the active element by
+// identity against <main>. Asserting only that focus is *not* on the skip link
+// passes when focus is lost to <body>, since <body> carries no href. Reporting
+// the element that actually held focus keeps a failure diagnosable.
+async function expectFocusOnMainLandmark(page: Page, context: string): Promise<void> {
+  const focusState = await page.evaluate(() => {
+    const main = document.querySelector('main, [role="main"]');
+    const active = document.activeElement as HTMLElement | null;
+    const describe = (el: Element | null) => {
+      if (!el) return 'null';
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'body') return 'body (focus lost)';
+      const className = String(el.className || '').split(' ').filter(Boolean)[0];
+      return className ? `${tag}.${className}` : tag;
+    };
+    return {
+      hasMain: Boolean(main),
+      focusIsMain: Boolean(main && active === main),
+      activeDescription: describe(active),
+    };
+  });
+
+  expect(focusState.hasMain, `${context}: the destination route should render a main landmark`).toBe(true);
+  expect(
+    focusState.focusIsMain,
+    `${context}: focus should rest on the main landmark, but it was on ${focusState.activeDescription}`,
+  ).toBe(true);
+}
+
+// Assert that the next Tab enters main content rather than restarting the focus
+// order at the skip link (WCAG 2.4.3).
+async function expectNextTabEntersMain(page: Page, context: string): Promise<void> {
+  await page.keyboard.press('Tab');
+
+  const tabState = await page.evaluate(() => {
+    const main = document.querySelector('main, [role="main"]');
+    const active = document.activeElement as HTMLElement | null;
+    return {
+      insideMain: Boolean(main && active && main.contains(active)),
+      activeDescription: active
+        ? `${active.tagName.toLowerCase()}${active.getAttribute('href') ? ` href=${active.getAttribute('href')}` : ''}`
+        : 'null',
+    };
+  });
+
+  expect(
+    tabState.insideMain,
+    `${context}: the first Tab after navigation should focus an element inside main content, but focus moved to ${tabState.activeDescription}`,
+  ).toBe(true);
+}
 
 test.describe('Focus management', () => {
   for (const pageCase of SITE_PAGES.filter(({ path }) => path.includes('/docs/') || path === '/hve-core/')) {
@@ -115,7 +169,10 @@ test.describe('Focus management', () => {
       .not.toBe(initialTheme);
   });
 
-  test('activating a top navigation link does not leave focus on the skip link', async ({ page }) => {
+  // WCAG 2.4.3 Focus Order: activating a top-level navbar link crosses a layout
+  // boundary, which remounts the Layout component. Focus must still land on the
+  // destination route's main landmark rather than being lost to <body>.
+  test('activating a top navigation link moves focus to main content', async ({ page }) => {
     await page.goto('/hve-core/');
 
     const primaryLink = page.locator('.navbar__link[href*="/docs/"]').filter({ hasNot: page.locator('.navbar__link[href="/hve-core/"]') }).first();
@@ -127,12 +184,8 @@ test.describe('Focus management', () => {
     await primaryLink.click();
     await page.waitForLoadState('networkidle');
 
-    const focusIsOnSkipLink = await page.evaluate(() => {
-      const active = document.activeElement as HTMLElement | null;
-      return Boolean(active && active.getAttribute('href')?.includes('skip'));
-    });
-
-    expect(focusIsOnSkipLink, 'Focus should not remain on the skip link after using a top navigation link').toBe(false);
+    await expectFocusOnMainLandmark(page, 'After activating a top navigation link');
+    await expectNextTabEntersMain(page, 'After activating a top navigation link');
   });
 
   // WCAG 2.1.1 Keyboard / 2.4.3 Focus Order: opening the navbar dropdown (when
@@ -184,6 +237,69 @@ test.describe('Focus management', () => {
       await link.focus();
       await expect(link).toBeFocused();
     }
+  });
+
+  // WCAG 2.4.3 Focus Order: a dropdown item reaches the same cross-layout
+  // remount as a plain navbar link, so it must also land focus on main content.
+  test('activating a navbar dropdown item moves focus to main content', async ({ page }) => {
+    await page.goto('/hve-core/');
+
+    const dropdownToggle = page.locator('.navbar__item.dropdown .navbar__link').first();
+    if ((await dropdownToggle.count()) === 0) {
+      test.skip(true, 'No dropdown navbar item is configured.');
+      return;
+    }
+
+    // Open via the keyboard path a keyboard user actually takes, matching the
+    // operable path asserted by the dropdown keyboard-reachability test above.
+    await dropdownToggle.focus();
+    await dropdownToggle.press('ArrowDown');
+
+    const dropdownMenu = page.locator('.navbar__item.dropdown .dropdown__menu').first();
+    await expect(dropdownMenu).toBeVisible();
+
+    const firstItem = dropdownMenu.locator('a').first();
+    await firstItem.focus();
+    await firstItem.press('Enter');
+    await page.waitForLoadState('networkidle');
+
+    await expectFocusOnMainLandmark(page, 'After activating a navbar dropdown item');
+    await expectNextTabEntersMain(page, 'After activating a navbar dropdown item');
+  });
+
+  // WCAG 2.4.3 Focus Order: the defect is direction-agnostic, so navigating
+  // from a docs route back to the landing page must behave identically.
+  test('returning to the landing page moves focus to main content', async ({ page }) => {
+    await page.goto('/hve-core/docs/getting-started/');
+
+    const brand = page.locator('.navbar__brand').first();
+    if ((await brand.count()) === 0) {
+      test.skip(true, 'No navbar brand link is configured for this build.');
+      return;
+    }
+
+    await brand.click();
+    await page.waitForLoadState('networkidle');
+
+    await expectFocusOnMainLandmark(page, 'After returning to the landing page');
+  });
+
+  // Regression guard: navigation that stays inside one layout keeps the same
+  // Layout instance and already focuses main content. The remount fix widens
+  // when the route-change effect runs, so this path must not regress.
+  test('navigating between docs pages moves focus to main content', async ({ page }) => {
+    await page.goto('/hve-core/docs/getting-started/');
+
+    const sidebarLink = page.locator('a.menu__link[href$="/getting-started/install"]').first();
+    if ((await sidebarLink.count()) === 0) {
+      test.skip(true, 'No sibling docs sidebar link is configured for this build.');
+      return;
+    }
+
+    await sidebarLink.click();
+    await page.waitForLoadState('networkidle');
+
+    await expectFocusOnMainLandmark(page, 'After navigating between docs pages');
   });
 });
 

--- a/docs/docusaurus/e2e/focus-management.spec.ts
+++ b/docs/docusaurus/e2e/focus-management.spec.ts
@@ -52,7 +52,10 @@ async function expectNextTabEntersMain(page: Page, context: string): Promise<voi
     const main = document.querySelector('main, [role="main"]');
     const active = document.activeElement as HTMLElement | null;
     return {
-      insideMain: Boolean(main && active && main.contains(active)),
+      // Require focus to move strictly *inside* main. `contains` is true for
+      // main itself, so without the identity check this would also pass when
+      // Tab moved focus nowhere at all.
+      insideMain: Boolean(main && active && active !== main && main.contains(active)),
       activeDescription: active
         ? `${active.tagName.toLowerCase()}${active.getAttribute('href') ? ` href=${active.getAttribute('href')}` : ''}`
         : 'null',
@@ -288,13 +291,26 @@ test.describe('Focus management', () => {
   // Layout instance and already focuses main content. The remount fix widens
   // when the route-change effect runs, so this path must not regress.
   test('navigating between docs pages moves focus to main content', async ({ page }) => {
-    await page.goto('/hve-core/docs/getting-started/');
+    const startPath = '/hve-core/docs/getting-started/';
+    await page.goto(startPath);
 
-    const sidebarLink = page.locator('a.menu__link[href$="/getting-started/install"]').first();
-    if ((await sidebarLink.count()) === 0) {
-      test.skip(true, 'No sibling docs sidebar link is configured for this build.');
-      return;
-    }
+    // Resolve any sidebar link that leaves the current page rather than naming
+    // one slug. A hard-coded slug turns a renamed page into a silent skip,
+    // which would leave this guard permanently green while never running.
+    const sidebarLink = page
+      .locator('a.menu__link')
+      .filter({ hasNot: page.locator(`[href="${startPath}"]`) })
+      .first();
+
+    const target = await sidebarLink.getAttribute('href');
+    expect(
+      target,
+      'The docs sidebar should expose a sibling page link for the intra-layout focus guard',
+    ).toBeTruthy();
+    expect(
+      target,
+      'The intra-layout focus guard needs a sidebar link that navigates away from the starting page',
+    ).not.toBe(startPath);
 
     await sidebarLink.click();
     await page.waitForLoadState('networkidle');

--- a/docs/docusaurus/src/theme/Layout/index.jsx
+++ b/docs/docusaurus/src/theme/Layout/index.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import {useLocation} from '@docusaurus/router';
 import Layout from '@theme-original/Layout';
 
@@ -9,6 +9,15 @@ import Layout from '@theme-original/Layout';
 // link resolves to a non-landmark and there is nothing for it to move focus to.
 const SKIP_TO_CONTENT_FALLBACK_ID = '__docusaurus_skipToContent_fallback';
 
+// Whether the first document load has already been observed. This is module
+// scope rather than component state on purpose: navigating across a layout
+// boundary unmounts and remounts Layout, so an instance-scoped ref would reset
+// to its initial value and the route-change effect below would skip focusing
+// main content. The guard's intent is "do not steal focus on the initial page
+// load", which is a per-document condition. A module-scope flag has exactly
+// that lifetime, persisting across remounts and resetting on a full page load.
+let hasCompletedInitialLoad = false;
+
 const isSearchRoute = (pathname) => /(^|\/)search\/?$/.test(pathname);
 
 // Move keyboard focus to the main landmark after a route change so that
@@ -16,7 +25,6 @@ const isSearchRoute = (pathname) => /(^|\/)search\/?$/.test(pathname);
 // WCAG 2.4.3 Focus Order.
 export default function LayoutWrapper(props) {
   const {pathname, hash} = useLocation();
-  const isInitialRender = useRef(true);
 
   // The upstream search page owns its own Layout, so a landmark cannot be
   // inserted around its content from here without enclosing the header and
@@ -42,9 +50,9 @@ export default function LayoutWrapper(props) {
   }, [pathname]);
 
   useEffect(() => {
-    // Skip the first render (initial page load) and in-page anchor navigation.
-    if (isInitialRender.current) {
-      isInitialRender.current = false;
+    // Skip the initial page load and in-page anchor navigation.
+    if (!hasCompletedInitialLoad) {
+      hasCompletedInitialLoad = true;
       return;
     }
     if (hash) {


### PR DESCRIPTION
# Pull Request

## Description

Activating a top-level navbar link on the documentation site dropped keyboard focus onto `document.body`. No focus indicator was visible, and the next `Tab` restarted the focus order at the skip link instead of continuing into page content. This is a WCAG 2.4.3 (Focus Order, Level A) failure.

### Root cause

The site has two navigation classes that behaved differently:

| Navigation | `Layout` instance | Focus handlers | Resulting focus |
|------------|-------------------|----------------|-----------------|
| Docs page to a different docs page (sidebar) | Persists | Both run | `main` landmark |
| Landing page to docs, or docs to landing (navbar) | **Remounts** | **Neither runs** | **`body`** |

Crossing a layout boundary unmounts and remounts `Layout`. The route-change focus effect was guarded by an `isInitialRender` `useRef`, which is scoped to the component instance, so a remounted `Layout` started with the guard set and returned before focusing `main`. The upstream `useLocationChange` handler skipped for the same reason: it early-returns when `previousLocation` is undefined, which is the case on a fresh mount. With the activated link unmounted and nothing reassigning focus, focus fell to `body`, and `body` is the document focus origin, so the next `Tab` restarted at the skip link.

The guard's intent was "do not steal focus on the initial page load", which is a per-document condition rather than a per-instance one. The fix replaces the ref with a module-scope flag, whose lifetime matches that intent exactly: it persists across remounts within a document and resets on a full page load.

### Why the existing regression test did not catch it

The prior guard test asserted only that the focused element's `href` did not contain `skip`. When focus is lost, `document.activeElement` is `body`, which has no `href`, so the assertion passed. The test was green in precisely the failure state it was written to catch. It has been rewritten to compare the active element by identity against the `main` landmark, so a lost-focus state now fails and reports which element actually held focus.

### Verification approach

Tests were authored before the fix, and validation was deliberately deferred until implementation was complete. Because the e2e lane serves a compiled static bundle, the negative control required its own build: the fix was reverted, the bundle rebuilt, and the tests observed failing; the fix was then restored, the bundle rebuilt again, and the suite observed passing. Reverting source against a shared build would have silently tested the fixed bundle and proven nothing.

## Related Issue(s)

Fixes #2714

Follow-up to #2374, which was closed by #2391. The main-nav bullet in that issue was addressed for intra-layout navigation but not for navigation that remounts `Layout`.

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

**User Request:**
<!-- What natural language request would trigger this agent/prompt/instruction? -->

**Execution Flow:**
<!-- Step-by-step: what happens when invoked? Include tool usage, decision points -->

**Output Artifacts:**
<!-- What files/content are created? Show first 10-20 lines as preview -->

**Success Indicators:**
<!-- How does user know it worked correctly? What validation should they perform? -->

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

### Negative control: tests fail without the fix

The fix was reverted, the production bundle rebuilt from that source, and the focus spec run. Result: **3 failed, 31 passed**.

The three failures were exactly the cross-layout tests, each reporting `focus should rest on the main landmark, but it was on body (focus lost)`:

* `activating a top navigation link moves focus to main content`
* `activating a navbar dropdown item moves focus to main content`
* `returning to the landing page moves focus to main content`

The intra-layout guard and the cold-load skip-link test passed in this run, confirming the three failures are attributable to the defect rather than to unrelated state or a broken harness.

### Final validation: tests pass with the fix

| Check | Scope | Result |
|-------|-------|--------|
| `ci:test:e2e` | All 23 e2e spec files | 290 passed, 3 skipped, 0 failed (6.9m) |
| Focus spec, isolated | `focus-management.spec.ts` | 34 passed, 0 failed |
| `typecheck` | `docs/docusaurus` | Passed |
| `lint:a11y` | `docs/docusaurus` | Passed |
| `lint:md` | Repository markdown | 0 issues in 485 files |

The 3 skips are the suite's own conditional guards on contrast tests (`home`, `search`, `not-found`) and are unrelated to focus.

Because the fix alters focus behavior on every layout-crossing navigation, the full lane was run rather than the focus spec alone. Specs that assert focus position or focus sequence after navigation all passed: `search-keyboard`, `doc-navigation`, `sidebar-disclosure`, `keyboard-nav`, and `skip-link`. Structural, target-size, text-zoom, table-accessibility, and contrast specs also passed.

### Independent confirmation against the original reproduction

The e2e tests were authored as part of this change, so passing them is not by itself proof the reported defect is gone. A reproduction harness written before any fix existed was re-run against the post-fix build. Both originally reported paths now settle on the `main` landmark, and the next `Tab` reaches a breadcrumb link inside main content rather than the skip link.

### Focus transition timing

Focus sampled every 8ms from keypress, comparing the fixed path against the path that already worked:

```text
CROSS-LAYOUT (home to docs), fixed by this change
  body 10-49ms -> a 57-113ms -> body 275ms -> main 287ms+

INTRA-LAYOUT (docs to docs), already worked before this change
  body 10-33ms -> a 42-72ms -> main 160ms+
```

Both paths pass through a brief `body` state before settling on `main`. The intra-layout path has the same shape and is not considered defective, so the transient is inherent to asynchronous SPA route loading rather than introduced here; `main` does not exist until the destination route renders. What changed is the resting state: focus previously remained on `body` indefinitely on cross-layout navigation and now reaches `main` in under 300ms.

### Review-driven test hardening

A functional review of this diff found no defect in the production fix, but flagged two ways the new tests could give false assurance. Both were corrected in a follow-up commit, because a test that silently stops running is the same failure class this PR exists to eliminate:

* The intra-layout regression guard originally located its sibling page by a hard-coded slug and skipped when it was absent. Renaming that page would have left the guard permanently green while never executing. It now resolves any sidebar link that leaves the current page and fails loudly if none exists.
* `expectNextTabEntersMain` used `main.contains(active)`, which is true for `main` itself, so it would have passed if Tab moved focus nowhere. It now requires focus to land strictly inside `main`.

The focus spec was re-run after these changes: 34 passed, 0 failed.

### Known limits of this verification

Recorded so the evidence is not read as broader than it is:

* A `Tab` pressed during the sub-300ms transition can still reach the skip link. This is present on the pre-existing intra-layout path and is not a regression, but "focus never passes through `body`" is not a claim this change supports.
* The e2e assertions run after `networkidle`, so they confirm the resting focus position but do not bound how long the transition takes.
* Mobile-viewport cross-layout navigation has no focus-order test. The reported defect was desktop and the mobile sidebar is a separate component, so this is uncovered surface rather than a known failure.
* Screen-reader announcement of the new page context after focus moves is not verified by any automated check. Focus movement is confirmed; what a screen reader announces is not.
* The module-scope flag resets when the dev server re-evaluates the module under hot module replacement, so a single navigation may skip focusing `main` during `npm start`. Production builds and the e2e lane are unaffected because both load the module once.

Manual screen-reader testing was not performed.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — behavioral fix with no documented interface change)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local` (fails on a pre-existing dead link unrelated to this PR — see Additional Notes)
* [ ] Documentation validation (if docs changed): `npm run validate:docs` (not run; no documentation pages changed)
* [ ] Spell checking: `npm run spell-check` (not run separately)
* [ ] Link validation: `npm run lint:md-links` (ran within `validate:local`; only the unrelated pre-existing failure reported)

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [ ] Security-related scripts follow the principle of least privilege (N/A — no security scripts modified)

## Additional Notes

### `validate:local` status

`npm run validate:local` exits non-zero on this branch, but not because of anything in it. The sole failure is a dead external link:

```text
.github/skills/project-planning/security-planning/references/data-classification.md
  https://learn.microsoft.com/compliance/assurance/assurance-data-classification -> 404
```

That file arrived with #2574 and is untouched here; this branch changes only two files under `docs/docusaurus`. The failure reproduces on `main` independently of this PR, so it is recorded rather than fixed, to avoid widening scope. Every other check in the aggregate passed.

### Change surface

The change surface is deliberately two files:

* `docs/docusaurus/src/theme/Layout/index.jsx` — the guard, plus removal of the now-unused `useRef` import. The hash early return, the `requestAnimationFrame` call, the search-route landmark promotion, and the focus target are unchanged. No timer, retry, or polling construct was introduced; the defect was a guard-lifetime bug, not a timing bug.
* `docs/docusaurus/e2e/focus-management.spec.ts` — two spec-local assertion helpers and four focus-order tests, one of which replaces the false-negative guard.

Alternatives considered and rejected: swizzling `SkipToContent` to retain `tabindex` (fixes a blur that does not occur on the failing path, since the upstream handler never runs there); removing the repo effect and adopting upstream behavior unchanged (leaves focus on `body` and regresses working intra-layout navigation); and adding a delay or retry after `requestAnimationFrame` (treats a guard bug as a timing bug and is inherently flaky).
