### PR TITLE
docs(scripts): document PowerShell Pester gotchas

### DIFF
--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -2,7 +2,7 @@
 title: Test Scripts
 description: Pester test runner, changed-file detection, and test directory organization
 author: HVE Core Team
-ms.date: 2026-08-13
+ms.date: 2026-08-21
 ms.topic: reference
 keywords:
   - powershell
@@ -126,6 +126,58 @@ Planner-related tests are split intentionally: rule-validator suites (state
 schema, cadence ordering, startup blocks, risk-grid grammar) live under
 `linting/` alongside other linter tests, while artifact-signing and runtime
 concerns (e.g. `Sign-PlannerArtifacts.Tests.ps1`) live under `security/`.
+
+## PowerShell 7 and Pester gotchas
+
+### Read empty files as empty strings
+
+In PowerShell 7, `Get-Content -Raw` returns `$null` for a 0-byte file instead of
+an empty string. This can make string assertions fail unexpectedly. Check the
+file size and use `[System.IO.File]::ReadAllText` when a string result is
+required:
+
+```powershell
+$Bytes = if (Test-Path $Path) { (Get-Item $Path).Length } else { -1 }
+$Content = if ($Bytes -gt 0) {
+    [System.IO.File]::ReadAllText($Path)
+}
+else {
+    ''
+}
+```
+
+### Wait for redirected output to flush
+
+`Start-Process -Wait` can return before redirected output file handles finish
+flushing, especially for small payloads in a Pester runspace. Call
+`WaitForExit()`, check the output size, and use a short retry when successful
+execution should have produced output:
+
+```powershell
+$Process = Start-Process -FilePath 'pwsh' -ArgumentList $Arguments `
+    -RedirectStandardOutput $OutputPath -Wait -PassThru
+$Process.WaitForExit()
+
+$Bytes = if (Test-Path $OutputPath) { (Get-Item $OutputPath).Length } else { -1 }
+if ($Bytes -eq 0 -and $Process.ExitCode -eq 0) {
+    Start-Sleep -Milliseconds 100
+    $Bytes = (Get-Item $OutputPath).Length
+}
+```
+
+### Put diagnostic context in assertions
+
+`[System.IO.File]::AppendAllText` calls inside Pester `It` blocks can be
+silently swallowed, so in-test diagnostic files are unreliable. Add context
+with `Should -Because`; the test runner preserves it in
+`logs/pester-failures.json`:
+
+```powershell
+$Result.StdOut | Should -Match 'expected text' -Because (
+    "ExitCode=$($Result.ExitCode); StdOutBytes=$($Result.StdOutBytes); " +
+    "StdErr=[$($Result.StdErr)]"
+)
+```
 
 ## Related Documentation
 

--- a/scripts/tests/linting/Test-Format-MarkdownTables.Tests.ps1
+++ b/scripts/tests/linting/Test-Format-MarkdownTables.Tests.ps1
@@ -138,6 +138,7 @@ function script:Invoke-SutInFixture {
         -RedirectStandardError $stderrPath `
         -Wait -PassThru -NoNewWindow
 
+    # See ../README.md#powershell-7-and-pester-gotchas for these mitigations.
     # Belt-and-suspenders: ensure the process has fully exited and OS file
     # buffers have flushed before we read. Tiny stdout payloads under the
     # Pester runspace can race the file-handle close.


### PR DESCRIPTION
## Description

Documented three PowerShell 7 and Pester troubleshooting patterns:

* Handle `Get-Content -Raw` returning `$null` for 0-byte files.
* Wait for redirected `Start-Process` output to flush.
* Use `Should -Because` for diagnostics captured in
  `logs/pester-failures.json`.

Cross-linked the existing markdown-table test mitigation to the new README
section. No executable behavior changed.

## Related Issue(s)

Fixes #1513

## Type of Change

* [x] Documentation update

## Sample Prompts (for AI Artifact Contributions)

Not applicable.

## Testing

* Passed `npm run validate:local`.
* Passed `npm run lint:md`.
* Passed `npm run spell-check`.
* Passed `npm run lint:md-links`.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (N/A: no functionality changed)

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [x] Local validation aggregate: `npm run validate:local`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A: no dependencies changed)
* [ ] Security-related scripts follow the principle of least privilege (N/A: no security scripts changed)