### PR TITLE
fix(skills): emit code scanning alerts as a JSON array for every result size

### DIFF
--- a/.github/skills/security/gh-code-scanning/scripts/Get-CodeScanningAlerts.ps1
+++ b/.github/skills/security/gh-code-scanning/scripts/Get-CodeScanningAlerts.ps1
@@ -111,7 +111,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             $Grouped | Format-Table -AutoSize -Property Count, SecuritySeverity, RuleId, RuleDescription
         }
         { $_ -in 'Json', 'GroupedJson' } {
-            $Grouped | ConvertTo-Json -Depth 5
+            # The array wrapper keeps the output a JSON array for every result size.
+            # Piping to ConvertTo-Json emits a bare object for a single group and nothing at all for none.
+            ConvertTo-Json -InputObject @($Grouped) -Depth 5
         }
     }
 

--- a/.github/skills/security/gh-code-scanning/tests/Get-CodeScanningAlerts.Tests.ps1
+++ b/.github/skills/security/gh-code-scanning/tests/Get-CodeScanningAlerts.Tests.ps1
@@ -94,6 +94,40 @@ Describe 'Get-CodeScanningAlerts' -Tag 'Unit' {
             $rawJson | Should -Match '"AffectedPaths":\s*\['
         }
 
+        It 'Serializes a single rule group as a JSON array' {
+            # Regression: one group previously serialized as a bare object, which broke the
+            # workflow consumer that iterates with jq '.[]'. Json and GroupedJson share the
+            # same switch branch, so this covers both.
+            $singleRuleJson = '[{"number":1,"rule":{"id":"VulnerabilitiesID","description":"Vulnerabilities","security_severity_level":"high"},"tool":{"name":"Scorecard"},"most_recent_instance":{"location":{"path":"no file associated with this alert"}}}]'
+            ${Function:gh} = {
+                $global:LASTEXITCODE = 0
+                return $singleRuleJson
+            }.GetNewClosure()
+
+            $rawJson = (& $script:ScriptPath -Owner 'testorg' -Repo 'testrepo' -OutputFormat Json | Out-String).Trim()
+
+            $rawJson | Should -BeLike '`[*`]'
+            $rawJson | ConvertFrom-Json | Should -HaveCount 1
+        }
+
+        It 'Serializes an empty result as an empty JSON array' {
+            ${Function:gh} = {
+                $global:LASTEXITCODE = 0
+                return '[]'
+            }.GetNewClosure()
+
+            $rawJson = (& $script:ScriptPath -Owner 'testorg' -Repo 'testrepo' -OutputFormat Json | Out-String).Trim()
+
+            $rawJson | Should -Be '[]'
+        }
+
+        It 'Serializes multiple rule groups as a JSON array' {
+            $rawJson = (& $script:ScriptPath -Owner 'testorg' -Repo 'testrepo' -OutputFormat Json | Out-String).Trim()
+
+            $rawJson | Should -BeLike '`[*`]'
+            $rawJson | ConvertFrom-Json | Should -HaveCount 2
+        }
+
         It 'Serializes AffectedPaths as empty array and sets HasFilePaths false when alert has no associated file path' {
             $noPathJson = '[{"number":10,"rule":{"id":"BranchProtectionID","description":"Branch-Protection","security_severity_level":"high"},"tool":{"name":"Scorecard"},"most_recent_instance":{"location":{"path":"no file associated with this alert"}}}]'
             ${Function:gh} = {

--- a/.github/workflows/create-gh-code-scanning-issues.yml
+++ b/.github/workflows/create-gh-code-scanning-issues.yml
@@ -39,6 +39,13 @@ jobs:
         shell: bash
         run: |
             set -euo pipefail
+            # Fail at the boundary on a malformed artifact rather than mid-loop.
+            # An empty array is valid and yields no work.
+            if ! jq -e 'type == "array"' alerts.json > /dev/null; then
+              echo "::error::alerts.json is not a JSON array. The alert fetch step produced a malformed artifact; no issues were processed."
+              exit 1
+            fi
+
             while IFS= read -r alert; do
             RULE_ID=$(echo "$alert" | jq -r '.RuleId')
             RULE_DESC=$(echo "$alert" | jq -r '.RuleDescription')


### PR DESCRIPTION
# Pull Request

## Description

`Get-CodeScanningAlerts.ps1` piped its grouped result straight into `ConvertTo-Json`. PowerShell unrolls a pipeline, so the serialized shape depended on how many rule groups existed:

| Rule groups | Emitted                  |
|-------------|--------------------------|
| 0           | *nothing*                |
| 1           | a bare object `{ ... }`  |
| 2 or more   | an array `[ {...}, ... ]` |

Only the third case is correct. `create-gh-code-scanning-issues.yml` consumes the artifact with `jq -c '.[]'`, which iterates an object's *values* rather than failing loudly, so each loop variable became a bare string and `.RuleId` resolved to null. That is the live production failure behind the stale automated issues.

This is a bug fix rather than a contract change. `SKILL.md` already documents the output as "a JSON array of alert groups" and shows an array in its JSON output shape example, and the bash sibling `get-code-scanning-alerts.sh` already emits an array unconditionally via `jq -s 'group_by(...) | map({...})'`. The PowerShell script was the only implementation violating the documented contract.

**Fix:** serialize with an explicit array wrapper, `ConvertTo-Json -InputObject @($Grouped) -Depth 5`.

Note that `-AsArray` — the approach originally proposed in the issue — is *not* sufficient. It corrects the single-group case but still emits nothing for zero groups, and zero is the current live repository state:

```text
                     0 groups        1 group
-AsArray             <no output>     [ {...} ]
-InputObject @(...)  []              [ {...} ]
```

The wrapper is safe on empty because an empty pipeline assigns `AutomationNull`, which `@()` unrolls to an empty array. A literal `$null` would instead produce `[ null ]`. Issue #2762 has been corrected to describe this.

**Defense in depth:** the consumer workflow now validates artifact shape at the boundary before iterating, so a future malformed artifact fails with a clear error rather than silently producing garbage issues mid-loop. An empty array remains valid and yields no work.

## Related Issue(s)

Fixes #2762

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`) (N/A — files inside a skill changed, but `SKILL.md` itself is unmodified)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`) (N/A — no AI artifact definition changed)

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

**User Request:**
<!-- What natural language request would trigger this agent/prompt/instruction? -->

**Execution Flow:**
<!-- Step-by-step: what happens when invoked? Include tool usage, decision points -->

**Output Artifacts:**
<!-- What files/content are created? Show first 10-20 lines as preview -->

**Success Indicators:**
<!-- How does user know it worked correctly? What validation should they perform? -->

## Testing

Automated validation run locally:

| Check                                                       | Result                |
|-------------------------------------------------------------|-----------------------|
| `npm run test:ps -- -TestPath ".github/skills/security/gh-code-scanning/tests/"` | 20/20 pass |
| `npm run lint:ps`                                           | 0 issues, 253 files   |
| `actionlint` on both changed workflows                      | clean                 |

**Red-without-fix verification.** The three new tests were confirmed to fail against the unpatched script before being accepted, so they demonstrably exercise the defect rather than passing vacuously:

```text
[-] Serializes a single rule group as a JSON array
[-] Serializes an empty result as an empty JSON array
[+] Serializes multiple rule groups as a JSON array
Tests Passed: 18, Failed: 2
```

The third case passes both before and after, as expected — multiple groups were never broken.

**Not verified locally:** the `jq` shape guard added to `create-gh-code-scanning-issues.yml` was not executed, because `jq` and `shellcheck` are unavailable in this environment (which also means `actionlint` skipped run-block shell linting). CI is the first execution of that guard. `jq` is preinstalled on `ubuntu-latest`.

Manual testing was not performed.

### What a post-merge dispatch would and would not prove

`weekly-gh-code-scanning.yml` carries `workflow_dispatch` and is the only entry point; both downstream workflows are `workflow_call`-only and cannot be triggered in isolation.

Because the repository currently has zero open code-scanning alerts, the consumer's loop body never executes, so a dispatch creates and edits no issues. That makes it cheap to run, but it constrains what it demonstrates:

| Path | Covered by a dispatch today |
|------|------------------------------|
| `Set-Content` writes non-empty content for the empty case | Yes |
| `upload-artifact` to `download-artifact` handoff | Yes |
| Guard accepts a legitimate `[]` without a false positive | Yes |
| `jq -c '.[]'` over `[]` yields zero iterations | Yes |
| **Single rule group serializes as an array** | **No - no alert exists to produce one** |

The single-group case is the reported defect, and it is covered by the regression tests above rather than by any dispatch. A green dispatch should be read as a smoke test of the artifact contract, not as verification of the fix.

## Checklist

### Required Checks

* [ ] Documentation is updated (if applicable) (N/A — `SKILL.md` already documents array output; the code now matches it)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable) — output now conforms to the already-documented contract
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

> Targeted checks (`test:ps`, `lint:ps`, `actionlint`) passed. The aggregates above have not yet been run for this branch.

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A — no dependency changes)
* [x] Security-related scripts follow the principle of least privilege — the changed script's API surface and permissions are untouched; only local serialization changed

## Additional Notes

**Out of scope, tracked separately in #2763.** The consumer workflow has three further defects this PR deliberately does not touch:

1. Dedupe searches with `--state open`, so a reopened rule creates a duplicate rather than reopening.
2. `gh issue edit --title --body --add-label "automated,needs-triage"` overwrites human edits and re-adds `needs-triage` every week.
3. There is no close path, so issues never close when their alert is fixed. This is what produced the stale automated issues.

Item 3 also depends on `Get-CodeScanningAlerts.ps1` querying `state=open` (line 73), which means the workflow structurally cannot observe a fixed alert. That query change belongs with the close path in #2763, not here.

**The guard and the serialization fix are coupled.** Before this change, the zero-group case assigned `AutomationNull` to `$alerts`, so `$alerts | Set-Content alerts.json` wrote an empty file. `jq -e` given empty input produces no output and exits 4, which the new guard treats as malformed. Landing the workflow guard without the script fix would therefore convert today's silent zero-alert no-op into a hard failure. Both hunks belong in the same change and should not be split or cherry-picked apart.

> The `AutomationNull` behavior was verified empirically. The `Set-Content`-writes-an-empty-file step was traced from the code path rather than executed, and is offered as reasoning rather than as a measured result.

**Verification opportunity.** With zero open alerts, a `workflow_dispatch` run after merge exercises precisely the zero-group path that `-AsArray` would have left broken - see the scope table under Testing for what that run does and does not establish.
