### PR TITLE
docs: update custom-agents.md and prompts.md with cross-artifact reference portability rules

### DIFF
--- a/docs/contributing/custom-agents.md
+++ b/docs/contributing/custom-agents.md
@@ -334,6 +334,18 @@ Distributable agents must use the canonical path `.github/agents/<package>/<subp
 
 Ensure every declared subagent is also eligible for manifest inclusion. Update `docs/plugins/hve-core.md` when the user-visible agent surface changes, then run `npm run plugin:sync`, `npm run plugin:validate`, and `npm run docs:generate:check`.
 
+## Path Portability
+
+Agents are packaged and relocatable. The root directory varies by distribution context (in-repo, Copilot CLI plugin, VS Code extension). To ensure references to other artifacts remain portable and do not break across environments, follow these cross-artifact reference rules:
+
+* **Refer by name:** Refer to a skill, agent, subagent, or prompt by the `name:` value from its frontmatter, not by a hard-coded path.
+* **Instruction files:** Refer to an instruction file by its full `<name>.instructions.md` filename.
+* **Bundled resources:** Reserve file paths for an agent's own bundled resources (relative to the agent root only).
+* **No hard-coded paths:** Never hard-code a skill's `SKILL.md` path, another agent's file path, or a cross-artifact directory path.
+* **File inclusions:** Use `#file:` only when the agent must pull in another file's full contents.
+
+Repo-root-relative paths (such as `.github/agents/...` or `.github/skills/...`) break portability and should not be used for cross-artifact references.
+
 ## Agent Content Structure Standards
 
 ### Required Sections

--- a/docs/contributing/prompts.md
+++ b/docs/contributing/prompts.md
@@ -212,6 +212,18 @@ Distributable prompts must use the canonical path `.github/prompts/<package>/<su
 
 Update `docs/plugins/hve-core.md` when the user-visible prompt surface changes, then run `npm run plugin:validate` and `npm run docs:generate:check`.
 
+## Path Portability
+
+Prompts are packaged and relocatable. The root directory varies by distribution context (in-repo, Copilot CLI plugin, VS Code extension). To ensure references to other artifacts remain portable and do not break across environments, follow these cross-artifact reference rules:
+
+* **Refer by name:** Refer to a skill, agent, subagent, or prompt by the `name:` value from its frontmatter, not by a hard-coded path.
+* **Instruction files:** Refer to an instruction file by its full `<name>.instructions.md` filename.
+* **Bundled resources:** Reserve file paths for a prompt's own bundled resources (relative to the prompt root only).
+* **No hard-coded paths:** Never hard-code a skill's `SKILL.md` path, an agent's file path, or a cross-artifact directory path.
+* **File inclusions:** Use `#file:` only when the prompt must pull in another file's full contents.
+
+Repo-root-relative paths (such as `.github/prompts/...` or `.github/skills/...`) break portability and should not be used for cross-artifact references.
+
 ## Prompt Content Structure Standards
 
 ### Required Sections


### PR DESCRIPTION
## Description

Adds a **Cross-Artifact Reference Portability** section to both `docs/contributing/custom-agents.md` and `docs/contributing/prompts.md`, documenting the cross-artifact reference rules introduced by commit db1e8f (PR #2599).

Previously, only `docs/contributing/skills.md` (via its `Path Portability` section) documented these rules. This meant authors of agents and prompts did not receive equivalent guidance, creating an inconsistency across the contributing documentation.

### Changes

**`docs/contributing/custom-agents.md`** — Added new section after `Plugin Manifest Registration`:
- Refer to skills, agents, subagents, and prompts by their `name:` frontmatter value, not hard-coded paths
- Refer to instruction files by full `<name>.instructions.md` filename
- Reserve file paths for an agent's own bundled resources (relative to agent root only)
- Never hard-code a skill's `SKILL.md` path or cross-artifact directory paths
- Use `#file:` only when full file contents must be pulled in

**`docs/contributing/prompts.md`** — Added equivalent section after `Plugin Manifest Registration`:
- Same five rules, adapted for prompt authors (prompt root instead of agent root)

Both sections mirror the structure and intent of the existing `Path Portability` guidance in `docs/contributing/skills.md`.

## Related Issue(s)

Fixes #2662

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)


## Testing

Ran the following local validation commands relevant to documentation-only changes:

```
npm run lint:md          ✅ Passed
npm run spell-check      ✅ Passed
npm run lint:md-links    ✅ Passed
npm run lint:frontmatter ✅ Passed
```


## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (if applicable)

### AI Artifact Contributions

Not applicable — no AI artifacts were added or modified.

### Required Local Checks

* [x] Local validation aggregate: `npm run validate:local`
* [x] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [x] Security-related scripts follow the principle of least privilege

## Additional Notes

- The new sections are placed immediately after the `Plugin Manifest Registration` section in both files, which is the natural location since portability rules follow directly from distribution/packaging context.
- The content adapts the existing rules from `docs/contributing/skills.md § Path Portability` and `.github/instructions/hve-core/hve-builder.instructions.md § Referencing Other Artifacts` to be contextually appropriate for agent and prompt authors respectively.
- No existing content was removed or modified — this is a pure addition.
