### PR TITLE
fix(build): replace vulnerable image-size dependency

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -53,21 +53,8 @@ jobs:
           # safe_globals() protection applies and the path is not exploitable.
           # The only patched release (5.0.0rc3) is a pre-release that breaks
           # detoxify==0.5.2, which requires transformers<5.
-          #
-          # GHSA-5p2g-fcmc-qvqq (CVE-2025-71329) and GHSA-w3rx-r6r6-pgpr:
-          # image-size infinite-loop denial of service in the JXL, HEIF, and
-          # ICNS parsers. Both advisories cover every published version
-          # (<= 2.0.2) and report no patched version, so no upgrade clears
-          # them. The package reaches this repository only as a transitive
-          # dependency of @docusaurus/mdx-loader, which measures repository
-          # controlled documentation images at site-build time. The
-          # attacker-supplied image buffer the advisories require is not
-          # reachable, and the site ships as static output with no runtime
-          # image parsing. Revisit when upstream publishes a fix.
           allow-ghsas: >-
-            GHSA-69w3-r845-3855,
-            GHSA-5p2g-fcmc-qvqq,
-            GHSA-w3rx-r6r6-pgpr
+            GHSA-69w3-r845-3855
           comment-summary-in-pr: always
           license-check: true
           allow-licenses: >-

--- a/docs/docusaurus/package-lock.json
+++ b/docs/docusaurus/package-lock.json
@@ -3894,6 +3894,19 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+      "name": "image-size-next",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/image-size-next/-/image-size-next-2.1.1.tgz",
+      "integrity": "sha512-n+DFjUct+G9mxZck+lvzqrTsqBJvSHMs6iEo//W5iAgRV7oUbrh1JWmKgAEpmyRB5lw6plIQizS1wK1dvrsvAw==",
+      "license": "MIT",
+      "bin": {
+        "image-size-next": "bin/image-size-next.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@docusaurus/mdx-loader/node_modules/micromark-extension-directive": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
@@ -15643,18 +15656,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -83,6 +83,7 @@
     "express": "5.2.1",
     "fast-uri": "3.1.5",
     "http-proxy-middleware": "2.0.10",
+    "image-size": "npm:image-size-next@2.1.1",
     "js-yaml@^3": "3.15.1",
     "js-yaml@^4": "4.3.1",
     "joi": "17.13.4",


### PR DESCRIPTION
## Description
Replaced the vulnerable transitive `image-size` implementation used by
Docusaurus with the exact `image-size-next` 2.1.1 npm alias.

* Added the exact override while preserving the dependency key expected by
  `@docusaurus/mdx-loader`.
* Regenerated the lockfile with the replacement package's canonical public npm
  URL and sha512 integrity.
* Removed the two `image-size` advisory exceptions and their obsolete rationale
  from Dependency Review.

## Related Issue(s)
fixes #2793

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [ ] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [x] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [ ] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

**Execution Flow:**

**Output Artifacts:**

**Success Indicators:**

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

Existing implementation checks completed successfully:

* `npm run lint:public-dependency-feeds`
* `npm run lint:yaml`
* `npm --prefix docs/docusaurus run typecheck`
* `npm --prefix docs/docusaurus run test` (78 tests)
* `npm --prefix docs/docusaurus run build`
* `npm --prefix docs/docusaurus audit --json` (zero vulnerabilities)
* Installed dependency identity and `image-size/fromFile` export checks
* Parent-enforced malicious ICNS child-process probe

Manual testing was not performed.

## Checklist

### Required Checks

* [ ] Documentation is updated (N/A - dependency metadata only)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [ ] Tests added for new functionality (N/A - no new functionality)

### AI Artifact Contributions

* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations

* [x] This PR does not contain any sensitive or NDA information
* [x] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege (N/A - no security scripts changed)

### Dependency provenance and security review

`docs/docusaurus` pins the transitive `image-size` dependency key to the exact
npm alias `npm:image-size-next@2.1.1`. The lockfile resolves the package from the
public npm registry with recorded SHA-512 integrity.

[`image-size-next@v2.1.1`](https://github.com/lcf2212dev/image-size-next/releases/tag/v2.1.1)
is a Git descendant of upstream
[`image-size@v2.0.2`](https://github.com/image-size/image-size/releases/tag/v2.0.2),
as shown by the [upstream-to-fork comparison](https://github.com/image-size/image-size/compare/v2.0.2...lcf2212dev:image-size-next:v2.1.1).
The upstream release commit is
[`032c3347b86f09a2e16449e17537cf5e1009520c`](https://github.com/image-size/image-size/commit/032c3347b86f09a2e16449e17537cf5e1009520c),
and fork tag `v2.1.1` resolves to commit
[`a55acb520fd9ab9136b0b4568afbdb452c88c77d`](https://github.com/lcf2212dev/image-size-next/commit/a55acb520fd9ab9136b0b4568afbdb452c88c77d).
The fork retains the upstream commit and contributor history.

The tagged source and published package are MIT licensed. The
[tagged license](https://github.com/lcf2212dev/image-size-next/blob/v2.1.1/LICENSE)
preserves the upstream Aditya Yadav and contributors copyright and permission
notice and adds the fork maintainer's notice.

Code review covered security commit
[`3b4976fc84da6e4adf56cf82fcc6226a81a1eaef`](https://github.com/lcf2212dev/image-size-next/commit/3b4976fc84da6e4adf56cf82fcc6226a81a1eaef),
whose direct parent is upstream `v2.0.2` commit `032c3347`. In particular:

* `lib/types/utils.ts` validates minimum ISO-BMFF box headers, rejects unsupported
  or undersized boxes, and requires offsets to advance monotonically.
* `lib/types/icns.ts` rejects incomplete or undersized entries and requires each
  entry offset to advance, addressing the zero-length ICNS loop in
  CVE-2025-71330.
* `lib/types/heif.ts` bounds traversal to the containing box, rejects undersized
  and out-of-container child boxes, and requires forward progress, addressing
  the ISO-BMFF loop condition in CVE-2025-71329.

The complete security commit also updates `jp2.ts`, `jpg.ts`, `jxl.ts`, and
`specs/security-dos.spec.ts`; the review covered that full seven-file patch.
These checks support the reported infinite-loop remediation without claiming
comprehensive malformed-input hardening.

This is a temporary exact-pinned replacement from a new community-maintained
fork. Dependency Review reports an unknown OpenSSF Scorecard, and npm currently
lists one collaborator. Retain the exact pin and lockfile integrity, monitor the
fork while it is in use, and remove the alias after an official Docusaurus
release no longer installs the vulnerable package.

## Additional Notes

The alias is an exact temporary replacement. It should be removed after an
official Docusaurus release no longer installs the vulnerable package.

The production build passed with one pre-existing broken-anchor warning for the
comparison page's `marketplace-install` link.
