### PR TITLE
feat(scripts): install HVE Core plugin from pinned SHA

### DIFF
--- a/docs/getting-started/methods/cli-plugins.md
+++ b/docs/getting-started/methods/cli-plugins.md
@@ -3,7 +3,7 @@ title: Copilot CLI Plugin
 description: Register an HVE Core catalog ref and install the complete hve-core plugin
 sidebar_position: 2
 author: Microsoft
-ms.date: 2026-08-19
+ms.date: 2026-08-31
 ms.topic: how-to
 keywords:
   - copilot cli
@@ -16,6 +16,9 @@ Install the complete HVE Core component set as a Copilot CLI plugin for terminal
 ## Prerequisites
 
 * GitHub Copilot CLI installed and authenticated
+
+Pinned-commit installation also requires Git and PowerShell 7.4. The same
+installer works on Windows and macOS through `pwsh`.
 
 ## Register hve-core as a Plugin Marketplace
 
@@ -47,6 +50,63 @@ A published channel release provides release assurance for its exact tag,
 including release gates, SBOMs, attestations, provenance verification, and the
 configured publication path. The development tip does not provide that
 published-release assurance.
+
+## Install an Arbitrary Pinned Commit
+
+Use the HVE Core installer when you need an exact commit that has no published
+release tag. The script version comes from your trusted HVE Core checkout; the
+plugin content it installs comes from the commit supplied through `CommitSha`.
+You can run the script while your terminal is in any downstream repository by
+using the script's absolute path.
+
+From a trusted HVE Core checkout, install the default pinned commit
+`0c14eea959a5ff355871205acf14807c7fa7d4a7`:
+
+```powershell
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1
+```
+
+Install a different exact commit or preview the operation:
+
+```powershell
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1 -CommitSha <full-commit-sha>
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1 -WhatIf
+```
+
+The installer accepts only a full 40-character hexadecimal object ID. It
+fetches that object directly, verifies that it is the detached `HEAD`, checks
+the plugin metadata, and stores the immutable pin at:
+
+```text
+$HOME/.hve-core/copilot-plugin-pins/<full-commit-sha>/
+├── marketplace.json
+└── source/
+```
+
+The generated marketplace is named `hve-core-<full-commit-sha>`. It locates
+the contained plugin source at `./source`, then installs the qualified plugin
+`hve-core@hve-core-<full-commit-sha>`.
+
+> [!IMPORTANT]
+> `-WhatIf` performs no acquisition or mutation. It validates parameters,
+> prerequisites, and an existing pin read-only. For a missing pin, remote
+> commit and manifest verification remain pending until a real installation.
+
+The script never removes or replaces an existing marketplace or installed
+plugin. If the SHA-specific marketplace name already exists, inspect the
+registration before changing it. If registration succeeds but installation
+fails, retry the qualified install shown in the error. For the default pin, the
+recovery command is:
+
+```bash
+copilot plugin install hve-core@hve-core-0c14eea959a5ff355871205acf14807c7fa7d4a7
+```
+
+This commit pin proves exact object equality to the SHA you selected. It does
+not provide the release attestations or provenance guarantees associated with
+an HVE Core release tag. The implementation uses platform-neutral PowerShell
+and Git behavior; an authorized live macOS installation remains required before
+claiming observed macOS verification.
 
 ## Browse Available Plugins
 
@@ -90,7 +150,11 @@ Each plugin includes:
 | Skills       | Yes           | Self-contained skill packages                      |
 | Instructions | No            | Included for `#file:` references, not auto-applied |
 
-The one marketplace entry resolves the repository root. Root `plugin.json` declares the complete agents, commands, rules, skills, and hook membership as repository-relative `.github/...` paths. The client resolves the root README and LICENSE; no generated plugin tree or plugin ZIP participates in Git-source installation.
+The one marketplace entry resolves the repository root. Root `plugin.json`
+declares the complete agents, commands, rules, and skills as repository-relative
+`.github/...` paths. It declares no hooks. The client resolves the root README
+and LICENSE; no generated plugin tree or plugin ZIP participates in Git-source
+installation.
 
 ## Limitations
 

--- a/scripts/plugins/Install-HveCorePlugin.ps1
+++ b/scripts/plugins/Install-HveCorePlugin.ps1
@@ -1,0 +1,838 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+#Requires -Version 7.4
+
+<#
+.SYNOPSIS
+    Installs HVE Core from an exact Git commit through a local Copilot marketplace.
+.DESCRIPTION
+    Fetches an exact 40-character commit from microsoft/hve-core into a durable,
+    SHA-specific checkout, verifies the source and plugin metadata, generates a
+    contained local marketplace, and installs the qualified HVE Core plugin.
+
+    The script never follows a moving branch or tag and never removes or replaces
+    an existing marketplace or plugin. Use -WhatIf to inspect prerequisites and
+    an existing pin without creating files, mutating Git state, or invoking
+    Copilot marketplace and plugin changes.
+.PARAMETER CommitSha
+    Full 40-character Git commit SHA to install. Defaults to the reviewed HVE
+    Core commit selected for this installer.
+.PARAMETER InstallRoot
+    Absolute local filesystem directory that stores immutable plugin pins.
+    Defaults to $HOME/.hve-core/copilot-plugin-pins.
+.EXAMPLE
+    ./Install-HveCorePlugin.ps1
+.EXAMPLE
+    ./Install-HveCorePlugin.ps1 -CommitSha 0c14eea959a5ff355871205acf14807c7fa7d4a7 -WhatIf
+.NOTES
+    Requires PowerShell 7.4, Git, network access to GitHub, and an authenticated
+    GitHub Copilot CLI. The same script supports Windows and macOS.
+#>
+
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$CommitSha = '0c14eea959a5ff355871205acf14807c7fa7d4a7',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$InstallRoot = (Join-Path $HOME '.hve-core/copilot-plugin-pins')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$script:HveCoreRepositoryUrl = 'https://github.com/microsoft/hve-core.git'
+$script:HveCorePluginName = 'hve-core'
+$script:SourceDirectoryName = 'source'
+$script:MarketplaceFileName = 'marketplace.json'
+$script:SourceMarketplacePath = '.github/plugin/marketplace.json'
+$script:RequiredSourceFile = @('plugin.json', 'README.md', 'LICENSE', $script:SourceMarketplacePath)
+$script:PluginMetadataField = @('description', 'version', 'author', 'homepage', 'repository', 'license', 'keywords')
+
+#region Input and path handling
+
+function ConvertTo-NormalizedCommitSha {
+    <#
+    .SYNOPSIS
+        Validates and normalizes a full Git commit SHA.
+    .PARAMETER Value
+        Candidate commit SHA.
+    .OUTPUTS
+        [string] Lowercase 40-character commit SHA.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Value
+    )
+
+    if ($Value -cnotmatch '^[0-9A-Fa-f]{40}$') {
+        throw 'CommitSha must be a full 40-character hexadecimal Git object ID.'
+    }
+
+    return $Value.ToLowerInvariant()
+}
+
+function Resolve-LocalInstallRoot {
+    <#
+    .SYNOPSIS
+        Resolves an absolute local filesystem installation root.
+    .PARAMETER Path
+        PowerShell path supplied by the caller.
+    .OUTPUTS
+        [string] Absolute filesystem path.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    $DriveName = $null
+    if (-not $ExecutionContext.SessionState.Path.IsPSAbsolute($Path, [ref]$DriveName)) {
+        throw "InstallRoot must be an absolute local filesystem path: $Path"
+    }
+
+    $Drive = if ([string]::IsNullOrWhiteSpace($DriveName)) {
+        Get-PSDrive -PSProvider FileSystem | Select-Object -First 1
+    }
+    else {
+        Get-PSDrive -Name $DriveName -ErrorAction SilentlyContinue
+    }
+    if ($null -eq $Drive -or $Drive.Provider.Name -ne 'FileSystem') {
+        throw "InstallRoot must use the FileSystem provider: $Path"
+    }
+
+    $Resolved = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+    return [System.IO.Path]::GetFullPath($Resolved)
+}
+
+function Get-RequiredApplication {
+    <#
+    .SYNOPSIS
+        Resolves an external application from PATH.
+    .PARAMETER Name
+        Command name to discover.
+    .OUTPUTS
+        [string] Resolved application path.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    $Command = Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $Command) {
+        throw "Required application '$Name' was not found on PATH."
+    }
+
+    return $Command.Path
+}
+
+function Get-PinnedMarketplaceName {
+    <#
+    .SYNOPSIS
+        Builds the deterministic marketplace name for a commit.
+    .PARAMETER CommitSha
+        Normalized full commit SHA.
+    .OUTPUTS
+        [string] SHA-specific marketplace name.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-f]{40}$')]
+        [string]$CommitSha
+    )
+
+    return "$script:HveCorePluginName-$CommitSha"
+}
+
+function Resolve-CanonicalPath {
+    <#
+    .SYNOPSIS
+        Resolves links in every segment of an existing filesystem path.
+    .PARAMETER Path
+        Existing path to resolve.
+    .OUTPUTS
+        [string] Canonical absolute path.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    $FullPath = [System.IO.Path]::GetFullPath($Path)
+    $PathRoot = [System.IO.Path]::GetPathRoot($FullPath)
+    $Current = $PathRoot
+    $Relative = $FullPath.Substring($PathRoot.Length)
+    foreach ($Segment in $Relative.Split(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.StringSplitOptions]::RemoveEmptyEntries
+        )) {
+        $Current = Join-Path $Current $Segment
+        $Item = Get-Item -LiteralPath $Current -Force
+        if ($Item.LinkType) {
+            $ResolvedTarget = $Item.ResolveLinkTarget($true)
+            if ($null -eq $ResolvedTarget) {
+                throw "Filesystem link cannot be resolved: $Current"
+            }
+            $Current = $ResolvedTarget.FullName
+        }
+    }
+
+    return [System.IO.Path]::GetFullPath($Current)
+}
+
+function Test-ContainedPath {
+    <#
+    .SYNOPSIS
+        Indicates whether an existing path resolves within an existing root.
+    .PARAMETER Root
+        Existing containment root.
+    .PARAMETER Candidate
+        Existing path expected beneath the root.
+    .OUTPUTS
+        [bool] True when the canonical candidate is contained by the root.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Root,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Candidate
+    )
+
+    $ResolvedRoot = (Resolve-CanonicalPath -Path $Root).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    $ResolvedCandidate = Resolve-CanonicalPath -Path $Candidate
+    $Comparison = if ($IsWindows) {
+        [System.StringComparison]::OrdinalIgnoreCase
+    }
+    else {
+        [System.StringComparison]::Ordinal
+    }
+    $Prefix = $ResolvedRoot + [System.IO.Path]::DirectorySeparatorChar
+
+    return $ResolvedCandidate.Equals($ResolvedRoot, $Comparison) -or
+        $ResolvedCandidate.StartsWith($Prefix, $Comparison)
+}
+
+function Get-RequiredRegularFile {
+    <#
+    .SYNOPSIS
+        Returns a required nonempty regular file and rejects links.
+    .PARAMETER Path
+        Required file path.
+    .OUTPUTS
+        [System.IO.FileInfo] Validated file.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Required plugin file is missing or not a regular file: $Path"
+    }
+
+    $Item = Get-Item -LiteralPath $Path -Force
+    if ($Item.LinkType -or $Item.Length -eq 0) {
+        throw "Required plugin file must be nonempty and must not be a link: $Path"
+    }
+
+    return $Item
+}
+
+#endregion Input and path handling
+
+#region External applications
+
+function Invoke-ExternalApplication {
+    <#
+    .SYNOPSIS
+        Invokes one external application with a discrete argument array.
+    .PARAMETER FilePath
+        Resolved application path.
+    .PARAMETER ArgumentList
+        Arguments passed directly to the application.
+    .OUTPUTS
+        [System.Collections.Specialized.OrderedDictionary] Exit code and output.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyCollection()]
+        [string[]]$ArgumentList = @()
+    )
+
+    $Output = @(& $FilePath @ArgumentList 2>&1)
+    return [ordered]@{
+        ExitCode = $LASTEXITCODE
+        Output   = @($Output | ForEach-Object { $_.ToString() })
+    }
+}
+
+function Invoke-CheckedApplication {
+    <#
+    .SYNOPSIS
+        Invokes an external application and requires a zero exit code.
+    .PARAMETER FilePath
+        Resolved application path.
+    .PARAMETER ArgumentList
+        Arguments passed directly to the application.
+    .PARAMETER Operation
+        Safe operation label used in error messages.
+    .OUTPUTS
+        [string[]] Application output lines.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyCollection()]
+        [string[]]$ArgumentList = @(),
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Operation
+    )
+
+    $Result = Invoke-ExternalApplication -FilePath $FilePath -ArgumentList $ArgumentList
+    if ($Result.ExitCode -ne 0) {
+        $Detail = @($Result.Output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
+        $Suffix = if ($Detail.Count -gt 0) { " $($Detail[0])" } else { '' }
+        throw "$Operation failed with exit code $($Result.ExitCode).$Suffix"
+    }
+
+    return @($Result.Output)
+}
+
+#endregion External applications
+
+#region Source and marketplace validation
+
+function ConvertTo-DeterministicJson {
+    <#
+    .SYNOPSIS
+        Serializes an object as newline-normalized JSON.
+    .PARAMETER InputObject
+        Object to serialize.
+    .OUTPUTS
+        [string] JSON with LF endings and one trailing newline.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject
+    )
+
+    $Json = ($InputObject | ConvertTo-Json -Depth 10) -replace "`r`n", "`n"
+    return $Json.TrimEnd("`n") + "`n"
+}
+
+function New-PinnedMarketplaceContent {
+    <#
+    .SYNOPSIS
+        Validates plugin metadata and builds the SHA-specific marketplace JSON.
+    .PARAMETER SourceRoot
+        Exact HVE Core checkout root.
+    .PARAMETER CommitSha
+        Normalized full commit SHA.
+    .OUTPUTS
+        [string] Deterministic marketplace JSON.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SourceRoot,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-f]{40}$')]
+        [string]$CommitSha
+    )
+
+    foreach ($RelativePath in $script:RequiredSourceFile) {
+        $File = Get-RequiredRegularFile -Path (Join-Path $SourceRoot $RelativePath)
+        if (-not (Test-ContainedPath -Root $SourceRoot -Candidate $File.FullName)) {
+            throw "Required plugin file resolves outside the source root: $RelativePath"
+        }
+    }
+
+    try {
+        $Manifest = Get-Content -LiteralPath (Join-Path $SourceRoot 'plugin.json') -Raw |
+            ConvertFrom-Json -AsHashtable
+        $Catalog = Get-Content -LiteralPath (Join-Path $SourceRoot $script:SourceMarketplacePath) -Raw |
+            ConvertFrom-Json -AsHashtable
+    }
+    catch {
+        throw "Pinned plugin metadata is not valid JSON: $($_.Exception.Message)"
+    }
+
+    if ($Manifest['name'] -cne $script:HveCorePluginName) {
+        throw "Pinned plugin manifest name must be '$script:HveCorePluginName'."
+    }
+
+    $Entries = @($Catalog['plugins'])
+    if ($Entries.Count -ne 1) {
+        throw 'Pinned marketplace must contain exactly one plugin entry.'
+    }
+    $SourceEntry = $Entries[0]
+    if ($SourceEntry['name'] -cne $script:HveCorePluginName -or $SourceEntry['source'] -cne '.') {
+        throw "Pinned marketplace must locate '$script:HveCorePluginName' at canonical source '.'."
+    }
+    if ([string]::IsNullOrWhiteSpace($Manifest['version']) -or
+        $SourceEntry['version'] -cne $Manifest['version'] -or
+        $Catalog['metadata']['version'] -cne $Manifest['version']) {
+        throw 'Pinned plugin and marketplace versions must agree.'
+    }
+
+    foreach ($Field in $script:PluginMetadataField) {
+        $ManifestHasField = $Manifest.ContainsKey($Field)
+        $EntryHasField = $SourceEntry.ContainsKey($Field)
+        if ($ManifestHasField -ne $EntryHasField) {
+            throw "Pinned marketplace field '$Field' presence must match plugin.json."
+        }
+        if ($ManifestHasField) {
+            $ManifestValue = ConvertTo-Json $Manifest[$Field] -Depth 10 -Compress
+            $EntryValue = ConvertTo-Json $SourceEntry[$Field] -Depth 10 -Compress
+            if ($ManifestValue -cne $EntryValue) {
+                throw "Pinned marketplace field '$Field' must match plugin.json."
+            }
+        }
+    }
+
+    $MarketplaceName = Get-PinnedMarketplaceName -CommitSha $CommitSha
+    $GeneratedEntry = [ordered]@{
+        name   = $script:HveCorePluginName
+        source = './source'
+    }
+    foreach ($Field in $script:PluginMetadataField) {
+        if ($SourceEntry.ContainsKey($Field)) {
+            $GeneratedEntry[$Field] = $SourceEntry[$Field]
+        }
+    }
+
+    $GeneratedCatalog = [ordered]@{
+        name     = $MarketplaceName
+        metadata = [ordered]@{
+            description = "HVE Core pinned to commit $CommitSha"
+            version     = $Manifest['version']
+        }
+        owner    = [ordered]@{ name = 'Microsoft' }
+        plugins  = @($GeneratedEntry)
+    }
+
+    return ConvertTo-DeterministicJson -InputObject $GeneratedCatalog
+}
+
+function Test-PinnedCheckout {
+    <#
+    .SYNOPSIS
+        Validates the Git and filesystem identity of an exact checkout.
+    .PARAMETER GitPath
+        Resolved Git application path.
+    .PARAMETER PinRoot
+        Pin root containing the source directory.
+    .PARAMETER CommitSha
+        Normalized expected commit SHA.
+    .OUTPUTS
+        [bool] True when every checkout invariant passes.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GitPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PinRoot,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-f]{40}$')]
+        [string]$CommitSha
+    )
+
+    $PinItem = Get-Item -LiteralPath $PinRoot -Force
+    if (-not $PinItem.PSIsContainer -or $PinItem.LinkType) {
+        throw "Pin root must be a regular directory and must not be a link: $PinRoot"
+    }
+
+    $SourceRoot = Join-Path $PinRoot $script:SourceDirectoryName
+    $SourceItem = Get-Item -LiteralPath $SourceRoot -Force -ErrorAction SilentlyContinue
+    if ($null -eq $SourceItem -or -not $SourceItem.PSIsContainer -or $SourceItem.LinkType -or
+        -not (Test-ContainedPath -Root $PinRoot -Candidate $SourceRoot)) {
+        throw "Pinned source must be a regular directory inside the pin root: $SourceRoot"
+    }
+
+    $Inside = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'rev-parse', '--is-inside-work-tree') `
+        -Operation 'Git worktree validation'
+    if (($Inside -join '').Trim() -cne 'true') {
+        throw 'Pinned source is not a Git worktree.'
+    }
+
+    $Bare = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'rev-parse', '--is-bare-repository') `
+        -Operation 'Git bare-repository validation'
+    if (($Bare -join '').Trim() -cne 'false') {
+        throw 'Pinned source must not be a bare repository.'
+    }
+
+    $Origin = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'remote', 'get-url', 'origin') `
+        -Operation 'Git origin validation'
+    if (($Origin -join '').Trim() -cne $script:HveCoreRepositoryUrl) {
+        throw "Pinned source origin must be $script:HveCoreRepositoryUrl."
+    }
+
+    $ObjectType = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'cat-file', '-t', $CommitSha) `
+        -Operation 'Git object validation'
+    if (($ObjectType -join '').Trim() -cne 'commit') {
+        throw "Pinned object is not a commit: $CommitSha"
+    }
+
+    $Head = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'rev-parse', 'HEAD') `
+        -Operation 'Git HEAD validation'
+    if (($Head -join '').Trim().ToLowerInvariant() -cne $CommitSha) {
+        throw "Pinned HEAD does not match requested commit $CommitSha."
+    }
+
+    $Branch = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'branch', '--show-current') `
+        -Operation 'Git detached-HEAD validation'
+    if (-not [string]::IsNullOrWhiteSpace(($Branch -join '').Trim())) {
+        throw 'Pinned source must use a detached HEAD.'
+    }
+
+    $Status = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, '-c', 'core.longpaths=true', 'status', '--porcelain=v1', '--untracked-files=all') `
+        -Operation 'Git worktree cleanliness validation'
+    if (-not [string]::IsNullOrWhiteSpace(($Status -join '').Trim())) {
+        $DirtyPath = @($Status | Select-Object -First 5) -join ', '
+        throw "Pinned source worktree must be clean, including untracked files: $DirtyPath"
+    }
+
+    $Index = Invoke-CheckedApplication -FilePath $GitPath `
+        -ArgumentList @('-C', $SourceRoot, 'ls-files', '-s') `
+        -Operation 'Git link validation'
+    if (@($Index | Where-Object { $_ -match '^120000 ' }).Count -gt 0) {
+        throw 'Pinned source must not contain tracked symbolic links.'
+    }
+
+    return $true
+}
+
+function Test-PinnedMarketplaceRoot {
+    <#
+    .SYNOPSIS
+        Validates an immutable pin and its deterministic marketplace wrapper.
+    .PARAMETER GitPath
+        Resolved Git application path.
+    .PARAMETER PinRoot
+        Existing final or staging pin root.
+    .PARAMETER CommitSha
+        Normalized expected commit SHA.
+    .OUTPUTS
+        [bool] True when checkout and wrapper invariants pass.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GitPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PinRoot,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-f]{40}$')]
+        [string]$CommitSha
+    )
+
+    [void](Test-PinnedCheckout -GitPath $GitPath -PinRoot $PinRoot -CommitSha $CommitSha)
+    $SourceRoot = Join-Path $PinRoot $script:SourceDirectoryName
+    $Expected = New-PinnedMarketplaceContent -SourceRoot $SourceRoot -CommitSha $CommitSha
+    $MarketplacePath = Join-Path $PinRoot $script:MarketplaceFileName
+    $MarketplaceFile = Get-RequiredRegularFile -Path $MarketplacePath
+    if (-not (Test-ContainedPath -Root $PinRoot -Candidate $MarketplaceFile.FullName)) {
+        throw 'Generated marketplace resolves outside the pin root.'
+    }
+
+    $Actual = (Get-Content -LiteralPath $MarketplacePath -Raw) -replace "`r`n", "`n"
+    if ($Actual -cne $Expected) {
+        throw 'Existing pinned marketplace content does not match the verified source.'
+    }
+
+    return $true
+}
+
+#endregion Source and marketplace validation
+
+#region Acquisition and installation
+
+function New-PinnedCheckout {
+    <#
+    .SYNOPSIS
+        Acquires and atomically publishes one exact HVE Core pin.
+    .PARAMETER GitPath
+        Resolved Git application path.
+    .PARAMETER InstallRoot
+        Absolute installation root.
+    .PARAMETER CommitSha
+        Normalized expected commit SHA.
+    .OUTPUTS
+        [string] Final pin root.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GitPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$InstallRoot,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-f]{40}$')]
+        [string]$CommitSha
+    )
+
+    New-Item -ItemType Directory -Path $InstallRoot -Force | Out-Null
+    $StagingRoot = Join-Path $InstallRoot ".staging-$CommitSha-$([guid]::NewGuid().ToString('N'))"
+    $SourceRoot = Join-Path $StagingRoot $script:SourceDirectoryName
+    $FinalRoot = Join-Path $InstallRoot $CommitSha
+    $Promoted = $false
+
+    try {
+        New-Item -ItemType Directory -Path $SourceRoot -Force | Out-Null
+        [void](Invoke-CheckedApplication -FilePath $GitPath -ArgumentList @('init', $SourceRoot) -Operation 'Git initialization')
+        [void](Invoke-CheckedApplication -FilePath $GitPath -ArgumentList @('-C', $SourceRoot, 'remote', 'add', 'origin', $script:HveCoreRepositoryUrl) -Operation 'Git origin configuration')
+        [void](Invoke-CheckedApplication -FilePath $GitPath -ArgumentList @('-C', $SourceRoot, 'fetch', '--depth', '1', 'origin', $CommitSha) -Operation 'Exact commit fetch')
+
+        $Fetched = Invoke-CheckedApplication -FilePath $GitPath `
+            -ArgumentList @('-C', $SourceRoot, 'rev-parse', 'FETCH_HEAD') `
+            -Operation 'Fetched commit validation'
+        if (($Fetched -join '').Trim().ToLowerInvariant() -cne $CommitSha) {
+            throw "Fetched object does not match requested commit $CommitSha."
+        }
+
+        [void](Invoke-CheckedApplication -FilePath $GitPath `
+            -ArgumentList @('-C', $SourceRoot, '-c', 'core.longpaths=true', 'checkout', '--detach', 'FETCH_HEAD') `
+            -Operation 'Detached checkout')
+        $MarketplaceContent = New-PinnedMarketplaceContent -SourceRoot $SourceRoot -CommitSha $CommitSha
+        Set-Content -LiteralPath (Join-Path $StagingRoot $script:MarketplaceFileName) `
+            -Value $MarketplaceContent -Encoding UTF8 -NoNewline
+        [void](Test-PinnedMarketplaceRoot -GitPath $GitPath -PinRoot $StagingRoot -CommitSha $CommitSha)
+
+        if (Test-Path -LiteralPath $FinalRoot) {
+            throw "Final pin path appeared during acquisition and was not replaced: $FinalRoot"
+        }
+        Move-Item -LiteralPath $StagingRoot -Destination $FinalRoot
+        $Promoted = $true
+        [void](Test-PinnedMarketplaceRoot -GitPath $GitPath -PinRoot $FinalRoot -CommitSha $CommitSha)
+        return $FinalRoot
+    }
+    catch {
+        if (Test-Path -LiteralPath $StagingRoot) {
+            Remove-Item -LiteralPath $StagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        if ($Promoted -and (Test-Path -LiteralPath $FinalRoot)) {
+            Remove-Item -LiteralPath $FinalRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        throw
+    }
+}
+
+function Invoke-HveCorePluginInstall {
+    <#
+    .SYNOPSIS
+        Acquires, registers, and installs an exact HVE Core plugin commit.
+    .PARAMETER CommitSha
+        Full commit SHA to install.
+    .PARAMETER InstallRoot
+        Absolute durable installation root.
+    .OUTPUTS
+        [System.Collections.Specialized.OrderedDictionary] Installation result.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$CommitSha,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$InstallRoot
+    )
+
+    $NormalizedSha = ConvertTo-NormalizedCommitSha -Value $CommitSha
+    $ResolvedInstallRoot = Resolve-LocalInstallRoot -Path $InstallRoot
+    $GitPath = Get-RequiredApplication -Name 'git'
+    $CopilotPath = Get-RequiredApplication -Name 'copilot'
+    $PinRoot = Join-Path $ResolvedInstallRoot $NormalizedSha
+    $MarketplaceName = Get-PinnedMarketplaceName -CommitSha $NormalizedSha
+    $QualifiedPlugin = "$script:HveCorePluginName@$MarketplaceName"
+    $PinExists = Test-Path -LiteralPath $PinRoot
+    $PlannedActions = [System.Collections.Generic.List[string]]::new()
+    if (-not $PinExists) {
+        $PlannedActions.Add("Acquire and verify HVE Core commit $NormalizedSha in a staging directory")
+        $PlannedActions.Add("Publish the verified pin at $PinRoot")
+    }
+    $PlannedActions.Add("Register local marketplace $MarketplaceName at $PinRoot")
+    $PlannedActions.Add("Install qualified plugin $QualifiedPlugin")
+
+    if ($PinExists) {
+        [void](Test-PinnedMarketplaceRoot -GitPath $GitPath -PinRoot $PinRoot -CommitSha $NormalizedSha)
+    }
+    elseif (-not $PSCmdlet.ShouldProcess($PinRoot, "Acquire and verify HVE Core commit $NormalizedSha")) {
+        return [ordered]@{
+            Status              = 'Planned'
+            CommitSha           = $NormalizedSha
+            PinRoot             = $PinRoot
+            Marketplace         = $MarketplaceName
+            Plugin              = $QualifiedPlugin
+            VerificationPending = $true
+            WhatIf              = [bool]$WhatIfPreference
+            PlannedActions      = @($PlannedActions)
+        }
+    }
+    else {
+        $PinRoot = New-PinnedCheckout -GitPath $GitPath -InstallRoot $ResolvedInstallRoot -CommitSha $NormalizedSha
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($MarketplaceName, "Register local marketplace at $PinRoot")) {
+        return [ordered]@{
+            Status              = 'Planned'
+            CommitSha           = $NormalizedSha
+            PinRoot             = $PinRoot
+            Marketplace         = $MarketplaceName
+            Plugin              = $QualifiedPlugin
+            VerificationPending = $false
+            WhatIf              = [bool]$WhatIfPreference
+            PlannedActions      = @($PlannedActions)
+        }
+    }
+
+    $AddResult = Invoke-ExternalApplication -FilePath $CopilotPath `
+        -ArgumentList @('plugin', 'marketplace', 'add', $PinRoot)
+    if ($AddResult.ExitCode -ne 0) {
+        throw "Copilot marketplace registration failed with exit code $($AddResult.ExitCode). The SHA-specific marketplace may already exist. Inspect it before removing or replacing anything: $MarketplaceName"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($QualifiedPlugin, 'Install qualified HVE Core plugin')) {
+        return [ordered]@{
+            Status              = 'MarketplaceRegistered'
+            CommitSha           = $NormalizedSha
+            PinRoot             = $PinRoot
+            Marketplace         = $MarketplaceName
+            Plugin              = $QualifiedPlugin
+            VerificationPending = $false
+            WhatIf              = [bool]$WhatIfPreference
+            PlannedActions      = @($PlannedActions)
+        }
+    }
+
+    $InstallResult = Invoke-ExternalApplication -FilePath $CopilotPath `
+        -ArgumentList @('plugin', 'install', $QualifiedPlugin)
+    if ($InstallResult.ExitCode -ne 0) {
+        throw "Copilot plugin installation failed with exit code $($InstallResult.ExitCode). The verified marketplace remains registered. Retry explicitly with: copilot plugin install $QualifiedPlugin"
+    }
+
+    return [ordered]@{
+        Status              = 'Installed'
+        CommitSha           = $NormalizedSha
+        PinRoot             = $PinRoot
+        Marketplace         = $MarketplaceName
+        Plugin              = $QualifiedPlugin
+        VerificationPending = $false
+    }
+}
+
+#endregion Acquisition and installation
+
+#region Main execution
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        $Result = Invoke-HveCorePluginInstall `
+            -CommitSha $CommitSha `
+            -InstallRoot $InstallRoot `
+            -WhatIf:$WhatIfPreference
+
+        switch ($Result.Status) {
+            'Installed' {
+                Write-Host "Installed $($Result.Plugin) from commit $($Result.CommitSha)." -ForegroundColor Green
+                Write-Host "Pinned source: $($Result.PinRoot)" -ForegroundColor Green
+            }
+            'MarketplaceRegistered' {
+                Write-Host "Registered $($Result.Marketplace); plugin installation was not approved." -ForegroundColor Yellow
+            }
+            default {
+                if ($Result.WhatIf) {
+                    Write-Host 'Planned action sequence:' -ForegroundColor Yellow
+                    foreach ($Action in $Result.PlannedActions) {
+                        Write-Host "  - $Action" -ForegroundColor Yellow
+                    }
+                }
+                else {
+                    Write-Host "Installation was not performed for $($Result.Plugin)." -ForegroundColor Yellow
+                }
+                if ($Result.VerificationPending) {
+                    Write-Host 'Remote commit and plugin metadata verification remain pending because the pin does not exist.' -ForegroundColor Yellow
+                }
+            }
+        }
+        exit 0
+    }
+    catch {
+        Write-Error -ErrorAction Continue "Install-HveCorePlugin failed: $($_.Exception.Message)"
+        exit 1
+    }
+}
+
+#endregion Main execution

--- a/scripts/plugins/README.md
+++ b/scripts/plugins/README.md
@@ -7,12 +7,12 @@ PowerShell tooling for synchronizing root `plugin.json` with the complete distri
 
 ## Scripts
 
-| Script                          | Invocation                      | Description                                                 |
-|---------------------------------|---------------------------------|-------------------------------------------------------------|
-| Install-HveCorePlugin.ps1       | Direct `pwsh` script            | Install HVE Core through a marketplace at an exact Git SHA  |
-| Sync-PluginManifest.ps1         | `npm run plugin:sync`           | Write deterministic membership and locator parity          |
-| Sync-PluginManifest.ps1 -Check  | `npm run lint:plugin-manifest`  | Fail on manifest or marketplace locator drift               |
-| Aggregate validation            | `npm run plugin:validate`       | Check the manifest and locator                              |
+| Script                         | Invocation                     | Description                                                |
+|--------------------------------|--------------------------------|------------------------------------------------------------|
+| Install-HveCorePlugin.ps1      | Direct `pwsh` script           | Install HVE Core through a marketplace at an exact Git SHA |
+| Sync-PluginManifest.ps1        | `npm run plugin:sync`          | Write deterministic membership and locator parity          |
+| Sync-PluginManifest.ps1 -Check | `npm run lint:plugin-manifest` | Fail on manifest or marketplace locator drift              |
+| Aggregate validation           | `npm run plugin:validate`      | Check the manifest and locator                             |
 
 ## Prerequisites
 

--- a/scripts/plugins/README.md
+++ b/scripts/plugins/README.md
@@ -7,16 +7,60 @@ PowerShell tooling for synchronizing root `plugin.json` with the complete distri
 
 ## Scripts
 
-| Script                         | npm Command                    | Description                                       |
-|--------------------------------|--------------------------------|---------------------------------------------------|
-| Sync-PluginManifest.ps1        | `npm run plugin:sync`          | Write deterministic membership and locator parity |
-| Sync-PluginManifest.ps1 -Check | `npm run lint:plugin-manifest` | Fail on manifest or marketplace locator drift     |
-| Aggregate validation           | `npm run plugin:validate`      | Check the manifest and locator                    |
+| Script                          | Invocation                      | Description                                                 |
+|---------------------------------|---------------------------------|-------------------------------------------------------------|
+| Install-HveCorePlugin.ps1       | Direct `pwsh` script            | Install HVE Core through a marketplace at an exact Git SHA  |
+| Sync-PluginManifest.ps1         | `npm run plugin:sync`           | Write deterministic membership and locator parity          |
+| Sync-PluginManifest.ps1 -Check  | `npm run lint:plugin-manifest`  | Fail on manifest or marketplace locator drift               |
+| Aggregate validation            | `npm run plugin:validate`       | Check the manifest and locator                              |
 
 ## Prerequisites
 
 * PowerShell 7.4+
 * Git, because membership is derived from tracked source paths
+
+Pinned plugin installation also requires network access and an authenticated
+GitHub Copilot CLI. These prerequisites apply on Windows and macOS.
+
+## Installing a Pinned Plugin Commit
+
+Run the installer from a trusted HVE Core checkout. Its location is independent
+of the repository where you plan to use the plugin.
+
+```powershell
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1
+```
+
+The default commit is
+`0c14eea959a5ff355871205acf14807c7fa7d4a7`. Supply another full
+40-character commit or preview the operation when needed:
+
+```powershell
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1 -CommitSha <full-commit-sha>
+pwsh -NoProfile -File ./scripts/plugins/Install-HveCorePlugin.ps1 -WhatIf
+```
+
+The installer stores immutable pins under
+`$HOME/.hve-core/copilot-plugin-pins` by default. Each pin contains the exact
+checkout in `<sha>/source` and a generated `<sha>/marketplace.json`. The
+generated marketplace is named `hve-core-<full-sha>` and locates its contained
+checkout at `./source`.
+
+`-WhatIf` validates parameters, prerequisites, and an existing pin without
+creating files or invoking mutating Git or Copilot commands. When the pin does
+not exist, remote commit and manifest verification remain pending.
+
+The installer never removes or replaces an existing marketplace or plugin. A
+marketplace collision stops with inspection guidance. If marketplace
+registration succeeds but plugin installation fails, the verified registration
+is retained and the error supplies the qualified `copilot plugin install`
+command for recovery.
+
+Run the isolated installer tests with:
+
+```powershell
+npm run test:ps -- -TestPath scripts/tests/plugins/Install-HveCorePlugin.Tests.ps1
+```
 
 ## Source to Manifest Pipeline
 
@@ -54,7 +98,13 @@ Check mode writes nothing and exits nonzero on manifest or locator drift.
 
 ## Locator Validation
 
-Check mode requires `.github/plugin/marketplace.json` to contain exactly one `hve-core` entry whose relative source is `.github`. It verifies parity for every retained manifest metadata field, source containment, manifest existence, component coverage, and the absence of recipe fields such as `agents`, `commands`, `rules`, `skills`, `hooks`, or `x-hve` on the locator entry.
+Check mode requires `.github/plugin/marketplace.json` to contain exactly one
+`hve-core` entry whose relative source is `.`. This canonical locator differs
+from the pinned installer's generated wrapper source, `./source`. Check mode
+verifies parity for every retained manifest metadata field, source containment,
+manifest existence, component coverage, and the absence of recipe fields such
+as `agents`, `commands`, `rules`, `skills`, `hooks`, or `x-hve` on the locator
+entry.
 
 The moving registrations `microsoft/hve-core#release/prerelease` and `microsoft/hve-core#release/stable` select reviewed branch state. Exact `prerelease-v<version>` and `v<version>` registrations select immutable release state. The catalog always locates the plugin root relative to the selected repository ref.
 

--- a/scripts/tests/plugins/Install-HveCorePlugin.Tests.ps1
+++ b/scripts/tests/plugins/Install-HveCorePlugin.Tests.ps1
@@ -1,0 +1,423 @@
+#Requires -Modules Pester
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../plugins/Install-HveCorePlugin.ps1')
+    Mock Write-Host {}
+
+    $script:DefaultSha = '0c14eea959a5ff355871205acf14807c7fa7d4a7'
+
+    function New-TestPluginSource {
+        <#
+        .SYNOPSIS
+            Creates a valid minimal HVE Core plugin source fixture.
+        .PARAMETER Path
+            Fixture source path.
+        .OUTPUTS
+            [string] Created source path.
+        #>
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Path
+        )
+
+        New-Item -ItemType Directory -Path (Join-Path $Path '.github/plugin') -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $Path 'README.md') -Value '# Fixture' -Encoding UTF8
+        Set-Content -LiteralPath (Join-Path $Path 'LICENSE') -Value 'MIT' -Encoding UTF8
+
+        $Manifest = [ordered]@{
+            name        = 'hve-core'
+            description = 'Fixture plugin'
+            version     = '3.2.2'
+            author      = [ordered]@{ name = 'Microsoft'; url = 'https://www.microsoft.com' }
+            homepage    = 'https://github.com/microsoft/hve-core'
+            repository  = 'https://github.com/microsoft/hve-core'
+            license     = 'MIT'
+            keywords    = @('hve', 'plugins')
+            agents      = @()
+            commands    = @()
+            rules       = @()
+            skills      = @()
+        }
+        Set-Content -LiteralPath (Join-Path $Path 'plugin.json') `
+            -Value (ConvertTo-DeterministicJson -InputObject $Manifest) -Encoding UTF8 -NoNewline
+
+        $Catalog = [ordered]@{
+            name     = 'hve-core'
+            metadata = [ordered]@{ description = 'HVE Core'; version = '3.2.2' }
+            owner    = [ordered]@{ name = 'Microsoft' }
+            plugins  = @(
+                [ordered]@{
+                    name        = 'hve-core'
+                    source      = '.'
+                    description = 'Fixture plugin'
+                    version     = '3.2.2'
+                    author      = [ordered]@{ name = 'Microsoft'; url = 'https://www.microsoft.com' }
+                    homepage    = 'https://github.com/microsoft/hve-core'
+                    repository  = 'https://github.com/microsoft/hve-core'
+                    license     = 'MIT'
+                    keywords    = @('hve', 'plugins')
+                }
+            )
+        }
+        Set-Content -LiteralPath (Join-Path $Path '.github/plugin/marketplace.json') `
+            -Value (ConvertTo-DeterministicJson -InputObject $Catalog) -Encoding UTF8 -NoNewline
+        return $Path
+    }
+
+    function New-TestPinRoot {
+        <#
+        .SYNOPSIS
+            Creates a valid filesystem fixture for an existing pin.
+        .PARAMETER Path
+            Pin root path.
+        .PARAMETER CommitSha
+            Expected normalized commit SHA.
+        .OUTPUTS
+            [string] Created pin root.
+        #>
+        [CmdletBinding()]
+        [OutputType([string])]
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]$Path,
+
+            [Parameter(Mandatory = $true)]
+            [string]$CommitSha
+        )
+
+        $SourceRoot = New-TestPluginSource -Path (Join-Path $Path 'source')
+        $Content = New-PinnedMarketplaceContent -SourceRoot $SourceRoot -CommitSha $CommitSha
+        Set-Content -LiteralPath (Join-Path $Path 'marketplace.json') `
+            -Value $Content -Encoding UTF8 -NoNewline
+        return $Path
+    }
+
+}
+
+Describe 'ConvertTo-NormalizedCommitSha' -Tag 'Unit' {
+    It 'Normalizes a full uppercase SHA' {
+        ConvertTo-NormalizedCommitSha -Value $script:DefaultSha.ToUpperInvariant() |
+            Should -BeExactly $script:DefaultSha
+    }
+
+    It 'Rejects invalid or abbreviated value <Value>' -ForEach @(
+        @{ Value = '0c14eea' }
+        @{ Value = ('g' * 40) }
+        @{ Value = ('0' * 41) }
+    ) {
+        { ConvertTo-NormalizedCommitSha -Value $Value } |
+            Should -Throw '*full 40-character hexadecimal*'
+    }
+}
+
+Describe 'Resolve-LocalInstallRoot' -Tag 'Unit' {
+    It 'Resolves an absolute filesystem path independently of the working directory' {
+        $Expected = [System.IO.Path]::GetFullPath((Join-Path $TestDrive 'pins'))
+        Resolve-LocalInstallRoot -Path $Expected | Should -BeExactly $Expected
+    }
+
+    It 'Rejects a relative path' {
+        { Resolve-LocalInstallRoot -Path 'relative/pins' } |
+            Should -Throw '*absolute local filesystem path*'
+    }
+}
+
+Describe 'Resolve-CanonicalPath' -Tag 'Unit' {
+    It 'Rejects a filesystem link that cannot be resolved' {
+        Mock Get-Item {
+            $Item = [pscustomobject]@{ LinkType = 'SymbolicLink' }
+            $Item | Add-Member -MemberType ScriptMethod -Name ResolveLinkTarget -Value { $null }
+            return $Item
+        }
+
+        { Resolve-CanonicalPath -Path (Join-Path $TestDrive 'broken-link') } |
+            Should -Throw '*Filesystem link cannot be resolved*'
+    }
+}
+
+Describe 'Get-RequiredApplication' -Tag 'Unit' {
+    It 'Returns the discovered external application path' {
+        Mock Get-Command { [pscustomobject]@{ Path = '/tools/git' } } `
+            -ParameterFilter { $Name -eq 'git' -and $CommandType -eq 'Application' }
+
+        Get-RequiredApplication -Name 'git' | Should -BeExactly '/tools/git'
+    }
+
+    It 'Rejects a missing application' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'copilot' }
+
+        { Get-RequiredApplication -Name 'copilot' } |
+            Should -Throw "*Required application 'copilot'*"
+    }
+}
+
+Describe 'New-PinnedMarketplaceContent' -Tag 'Unit' {
+    BeforeEach {
+        $script:SourceRoot = New-TestPluginSource -Path (Join-Path $TestDrive ([guid]::NewGuid().ToString('N')))
+    }
+
+    It 'Builds a deterministic SHA-specific marketplace with a contained source' {
+        $Content = New-PinnedMarketplaceContent `
+            -SourceRoot $script:SourceRoot `
+            -CommitSha $script:DefaultSha
+        $Catalog = $Content | ConvertFrom-Json -AsHashtable
+
+        $Catalog['name'] | Should -BeExactly "hve-core-$script:DefaultSha"
+        @($Catalog['plugins']) | Should -HaveCount 1
+        @($Catalog['plugins'])[0]['name'] | Should -BeExactly 'hve-core'
+        @($Catalog['plugins'])[0]['source'] | Should -BeExactly './source'
+        $Content | Should -Not -Match "`r"
+        $Content.EndsWith("}`n") | Should -BeTrue
+    }
+
+    It 'Rejects a canonical source other than dot' {
+        $Path = Join-Path $script:SourceRoot '.github/plugin/marketplace.json'
+        $Catalog = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+        @($Catalog['plugins'])[0]['source'] = '.github'
+        Set-Content -LiteralPath $Path -Value (ConvertTo-DeterministicJson $Catalog) -Encoding UTF8 -NoNewline
+
+        { New-PinnedMarketplaceContent -SourceRoot $script:SourceRoot -CommitSha $script:DefaultSha } |
+            Should -Throw "*canonical source '.'*"
+    }
+
+    It 'Rejects mismatched metadata field <Field>' -ForEach @(
+        @{ Field = 'version'; Value = '9.9.9' }
+        @{ Field = 'description'; Value = 'Different' }
+        @{ Field = 'license'; Value = 'Apache-2.0' }
+    ) {
+        $Path = Join-Path $script:SourceRoot '.github/plugin/marketplace.json'
+        $Catalog = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+        @($Catalog['plugins'])[0][$Field] = $Value
+        Set-Content -LiteralPath $Path -Value (ConvertTo-DeterministicJson $Catalog) -Encoding UTF8 -NoNewline
+
+        { New-PinnedMarketplaceContent -SourceRoot $script:SourceRoot -CommitSha $script:DefaultSha } |
+            Should -Throw
+    }
+
+    It 'Rejects a missing required root file' {
+        Remove-Item -LiteralPath (Join-Path $script:SourceRoot 'LICENSE') -Force
+
+        { New-PinnedMarketplaceContent -SourceRoot $script:SourceRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*Required plugin file*'
+    }
+}
+
+Describe 'Test-PinnedCheckout' -Tag 'Unit' {
+    BeforeEach {
+        $script:PinRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:PinRoot 'source') -Force | Out-Null
+        Mock Invoke-CheckedApplication {
+            $Joined = $ArgumentList -join ' '
+            switch -Regex ($Joined) {
+                'rev-parse --is-inside-work-tree$' { return 'true' }
+                'rev-parse --is-bare-repository$' { return 'false' }
+                'remote get-url origin$' { return 'https://github.com/microsoft/hve-core.git' }
+                'cat-file -t ' { return 'commit' }
+                'rev-parse HEAD$' { return $script:DefaultSha }
+                'branch --show-current$' { return '' }
+                'status --porcelain=v1 --untracked-files=all$' { return '' }
+                'ls-files -s$' { return '100644 abc 0 plugin.json' }
+                default { throw "Unexpected Git invocation: $Joined" }
+            }
+        }
+    }
+
+    It 'Accepts the exact detached clean commit' {
+        Test-PinnedCheckout -GitPath '/tools/git' -PinRoot $script:PinRoot -CommitSha $script:DefaultSha |
+            Should -BeTrue
+    }
+
+    It 'Rejects a mismatched HEAD' {
+        Mock Invoke-CheckedApplication {
+            if (($ArgumentList -join ' ') -match 'rev-parse HEAD$') {
+                return ('f' * 40)
+            }
+            return ''
+        } -ParameterFilter { ($ArgumentList -join ' ') -match 'rev-parse HEAD$' }
+
+        { Test-PinnedCheckout -GitPath '/tools/git' -PinRoot $script:PinRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*HEAD does not match*'
+    }
+
+    It 'Rejects tracked symbolic links' {
+        Mock Invoke-CheckedApplication { '120000 abc 0 linked-file' } `
+            -ParameterFilter { ($ArgumentList -join ' ') -match 'ls-files -s$' }
+
+        { Test-PinnedCheckout -GitPath '/tools/git' -PinRoot $script:PinRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*symbolic links*'
+    }
+}
+
+Describe 'Test-PinnedMarketplaceRoot' -Tag 'Unit' {
+    BeforeEach {
+        $script:PinRoot = New-TestPinRoot `
+            -Path (Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))) `
+            -CommitSha $script:DefaultSha
+        Mock Test-PinnedCheckout { $true }
+    }
+
+    It 'Accepts exact deterministic wrapper content' {
+        Test-PinnedMarketplaceRoot -GitPath '/tools/git' -PinRoot $script:PinRoot -CommitSha $script:DefaultSha |
+            Should -BeTrue
+    }
+
+    It 'Rejects modified wrapper content without overwriting it' {
+        $Path = Join-Path $script:PinRoot 'marketplace.json'
+        Set-Content -LiteralPath $Path -Value '{"name":"different"}' -Encoding UTF8 -NoNewline
+
+        { Test-PinnedMarketplaceRoot -GitPath '/tools/git' -PinRoot $script:PinRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*does not match*'
+        (Get-Content -LiteralPath $Path -Raw) | Should -BeExactly '{"name":"different"}'
+    }
+}
+
+Describe 'New-PinnedCheckout' -Tag 'Unit' {
+    BeforeEach {
+        $script:InstallRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $script:GitCalls = [System.Collections.Generic.List[string]]::new()
+        Mock Invoke-CheckedApplication {
+            $Joined = $ArgumentList -join ' '
+            $script:GitCalls.Add($Joined)
+            if ($Operation -eq 'Detached checkout') {
+                New-TestPluginSource -Path $ArgumentList[1] | Out-Null
+            }
+            switch -Regex ($Joined) {
+                'rev-parse FETCH_HEAD$' { return $script:DefaultSha }
+                'rev-parse --is-inside-work-tree$' { return 'true' }
+                'rev-parse --is-bare-repository$' { return 'false' }
+                'remote get-url origin$' { return 'https://github.com/microsoft/hve-core.git' }
+                'cat-file -t ' { return 'commit' }
+                'rev-parse HEAD$' { return $script:DefaultSha }
+                'branch --show-current$' { return '' }
+                'status --porcelain=v1 --untracked-files=all$' { return '' }
+                'ls-files -s$' { return '100644 abc 0 plugin.json' }
+                default { return '' }
+            }
+        }
+    }
+
+    It 'Fetches the full SHA without clone or branch arguments and promotes the pin' {
+        $Result = New-PinnedCheckout `
+            -GitPath '/tools/git' `
+            -InstallRoot $script:InstallRoot `
+            -CommitSha $script:DefaultSha
+
+        $Result | Should -BeExactly (Join-Path $script:InstallRoot $script:DefaultSha)
+        Test-Path -LiteralPath (Join-Path $Result 'marketplace.json') | Should -BeTrue
+        ($script:GitCalls -join "`n") | Should -Match "fetch --depth 1 origin $script:DefaultSha"
+        ($script:GitCalls -join "`n") | Should -Match '-c core\.longpaths=true checkout --detach FETCH_HEAD'
+        ($script:GitCalls -join "`n") | Should -Match '-c core\.longpaths=true status --porcelain=v1 --untracked-files=all'
+        ($script:GitCalls -join "`n") | Should -Not -Match '(^| )clone( |$)'
+        ($script:GitCalls -join "`n") | Should -Not -Match '--branch'
+    }
+
+    It 'Cleans staging and publishes no final pin after a fetch failure' {
+        Mock Invoke-CheckedApplication { throw 'fetch failed' } `
+            -ParameterFilter { $Operation -eq 'Exact commit fetch' }
+
+        { New-PinnedCheckout -GitPath '/tools/git' -InstallRoot $script:InstallRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*fetch failed*'
+        Test-Path -LiteralPath (Join-Path $script:InstallRoot $script:DefaultSha) | Should -BeFalse
+        @(Get-ChildItem -LiteralPath $script:InstallRoot -Filter '.staging-*' -ErrorAction SilentlyContinue) |
+            Should -HaveCount 0
+    }
+
+    It 'Removes the promoted pin when final validation fails' {
+        Mock Test-PinnedMarketplaceRoot {
+            if ((Split-Path -Leaf $PinRoot) -notlike '.staging-*') {
+                throw 'post-promotion validation failed'
+            }
+            return $true
+        }
+
+        { New-PinnedCheckout -GitPath '/tools/git' -InstallRoot $script:InstallRoot -CommitSha $script:DefaultSha } |
+            Should -Throw '*post-promotion validation failed*'
+        Test-Path -LiteralPath (Join-Path $script:InstallRoot $script:DefaultSha) | Should -BeFalse
+        @(Get-ChildItem -LiteralPath $script:InstallRoot -Filter '.staging-*' -ErrorAction SilentlyContinue) |
+            Should -HaveCount 0
+    }
+}
+
+Describe 'Invoke-HveCorePluginInstall' -Tag 'Unit' {
+    BeforeEach {
+        $script:InstallRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $script:PinRoot = Join-Path $script:InstallRoot $script:DefaultSha
+        New-Item -ItemType Directory -Path $script:PinRoot -Force | Out-Null
+        $script:ApplicationCalls = [System.Collections.Generic.List[string]]::new()
+
+        Mock Get-RequiredApplication {
+            if ($Name -eq 'git') { return '/tools/git' }
+            return '/tools/copilot'
+        }
+        Mock Test-PinnedMarketplaceRoot { $true }
+        Mock Invoke-ExternalApplication {
+            $script:ApplicationCalls.Add("$FilePath $($ArgumentList -join ' ')")
+            return [ordered]@{ ExitCode = 0; Output = @() }
+        }
+    }
+
+    It 'Registers the local marketplace before installing the qualified plugin' {
+        $Result = Invoke-HveCorePluginInstall -CommitSha $script:DefaultSha -InstallRoot $script:InstallRoot
+
+        $Result.Status | Should -BeExactly 'Installed'
+        $script:ApplicationCalls | Should -HaveCount 2
+        $script:ApplicationCalls[0] | Should -BeExactly "/tools/copilot plugin marketplace add $script:PinRoot"
+        $script:ApplicationCalls[1] | Should -BeExactly "/tools/copilot plugin install hve-core@hve-core-$script:DefaultSha"
+        ($script:ApplicationCalls -join "`n") | Should -Not -Match 'microsoft/hve-core#'
+    }
+
+    It 'Stops before install when marketplace registration fails' {
+        Mock Invoke-ExternalApplication {
+            $script:ApplicationCalls.Add("$FilePath $($ArgumentList -join ' ')")
+            return [ordered]@{ ExitCode = 5; Output = @() }
+        } -ParameterFilter { $ArgumentList[1] -eq 'marketplace' }
+
+        { Invoke-HveCorePluginInstall -CommitSha $script:DefaultSha -InstallRoot $script:InstallRoot } |
+            Should -Throw '*marketplace registration failed*'
+        $script:ApplicationCalls | Should -HaveCount 1
+        ($script:ApplicationCalls -join "`n") | Should -Not -Match 'plugin install'
+    }
+
+    It 'Reports the qualified recovery command when installation fails' {
+        Mock Invoke-ExternalApplication {
+            $script:ApplicationCalls.Add("$FilePath $($ArgumentList -join ' ')")
+            return [ordered]@{ ExitCode = 7; Output = @() }
+        } -ParameterFilter { $ArgumentList[1] -eq 'install' }
+
+        { Invoke-HveCorePluginInstall -CommitSha $script:DefaultSha -InstallRoot $script:InstallRoot } |
+            Should -Throw "*copilot plugin install hve-core@hve-core-$script:DefaultSha*"
+        $script:ApplicationCalls | Should -HaveCount 2
+    }
+
+    It 'Performs no external mutation when WhatIf plans a missing pin' {
+        Remove-Item -LiteralPath $script:PinRoot -Recurse -Force
+
+        $Result = Invoke-HveCorePluginInstall `
+            -CommitSha $script:DefaultSha `
+            -InstallRoot $script:InstallRoot `
+            -WhatIf
+
+        $Result.Status | Should -BeExactly 'Planned'
+        $Result.VerificationPending | Should -BeTrue
+        $Result.WhatIf | Should -BeTrue
+        $Result.PlannedActions | Should -Be @(
+            "Acquire and verify HVE Core commit $script:DefaultSha in a staging directory"
+            "Publish the verified pin at $script:PinRoot"
+            "Register local marketplace hve-core-$script:DefaultSha at $script:PinRoot"
+            "Install qualified plugin hve-core@hve-core-$script:DefaultSha"
+        )
+        $script:ApplicationCalls | Should -HaveCount 0
+        Test-Path -LiteralPath $script:PinRoot | Should -BeFalse
+    }
+
+    It 'Rejects an abbreviated SHA before discovering applications or mutating state' {
+        { Invoke-HveCorePluginInstall -CommitSha '0c14eea' -InstallRoot $script:InstallRoot } |
+            Should -Throw '*full 40-character*'
+        Should -Invoke Get-RequiredApplication -Times 0 -Exactly
+        Should -Invoke Invoke-ExternalApplication -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
## Description

This PR added a cross-platform PowerShell installer for adopting HVE Core through a SHA-specific local Copilot marketplace instead of a moving branch.

* Added exact 40-character commit validation, fixed-origin Git fetch, detached checkout, canonical path and metadata checks, atomic staging and promotion, immutable pin reuse, and qualified Copilot plugin installation.
* Defaulted the installer to commit `0c14eea959a5ff355871205acf14807c7fa7d4a7` and stored pins under `$HOME/.hve-core/copilot-plugin-pins`.
* Added a non-mutating `-WhatIf` preview that reports acquisition, publication, marketplace registration, and qualified installation in order.
* Added isolated Pester coverage for validation, generated marketplace content, failure atomicity, command ordering, collision handling, recovery, and preview behavior.
* Updated maintainer and adopter guidance for Windows and macOS prerequisites, exact-commit installation, storage layout, recovery, release assurance, canonical source `.`, and generated source `./source`.

## Related Issue(s)

Closes #2826 

## Type of Change

Select all that apply:

**Code & Documentation:**

* [ ] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

<!-- If you checked any boxes under "AI Artifacts" above, provide a sample prompt showing how to use your contribution -->
<!-- Delete this section if not applicable -->

**User Request:**
<!-- What natural language request would trigger this agent/prompt/instruction? -->

**Execution Flow:**
<!-- Step-by-step: what happens when invoked? Include tool usage, decision points -->

**Output Artifacts:**
<!-- What files/content are created? Show first 10-20 lines as preview -->

**Success Indicators:**
<!-- How does user know it worked correctly? What validation should they perform? -->

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

The following validation completed during implementation and PR preparation:

* Focused Pester passed with 28 tests and no failures or skips.
* Configured PSScriptAnalyzer reported zero findings for the installer and its tests.
* Markdownlint, frontmatter validation, CSpell, and `git diff --check` passed.
* A missing-pin `-WhatIf` smoke reported four ordered actions, exited zero, and created no install root.
* A disposable real Git acquisition resolved exact `HEAD` `0c14eea959a5ff355871205acf14807c7fa7d4a7`, generated the expected marketplace and `./source` locator, validated successfully, and cleaned up without Copilot mutation.
* Security and sensitive-data diff analysis found no exposed secrets, customer data, dependency changes, privilege changes, or content-policy concerns.
* Manual Copilot marketplace installation and live macOS installation were not performed.

Required PR-template command results are added after the exact local checks complete.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [x] Local validation aggregate: `npm run validate:local`
* [x] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues (N/A - no dependencies changed)
* [ ] Security-related scripts follow the principle of least privilege (N/A - no security scripts changed)

## Additional Notes

* Native `microsoft/hve-core#<raw-SHA>` marketplace registration was not used because the observed Copilot CLI fetch path treated refs as branches. The installer fetched and verified the full object ID directly before registering a local marketplace.
* The implementation used platform-neutral PowerShell 7.4 and Git behavior. An authorized live macOS installation remains follow-up evidence before claiming observed macOS verification.
* Repository-wide copyright validation exceeded its earlier harness window; both new PowerShell files contain the required copyright and SPDX headers.
