### PR TITLE
feat(evals): separate PR execution from baseline calibration

### DIFF
--- a/.github/workflows/baseline-calibration.yml
+++ b/.github/workflows/baseline-calibration.yml
@@ -1,0 +1,62 @@
+name: Baseline Calibration
+
+on:
+    workflow_dispatch:
+
+concurrency:
+    group: baseline-calibration-${{ github.ref }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+jobs:
+    calibrate:
+        name: RPI Baseline Calibration
+        runs-on: ubuntu-latest
+        timeout-minutes: 120
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+
+            - name: Setup Node.js
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: "24"
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Setup PowerShell modules
+              uses: ./.github/actions/setup-ps-modules
+
+            - name: Configure Copilot environment
+              shell: pwsh
+              run: |
+                  "COPILOT_HOME=$env:RUNNER_TEMP/copilot-calibration" >> $env:GITHUB_ENV
+                  Join-Path $env:GITHUB_WORKSPACE 'node_modules/.bin' >> $env:GITHUB_PATH
+
+            - name: Probe Copilot token
+              shell: pwsh
+              env:
+                  COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+              run: ./scripts/evals/Test-CopilotToken.ps1 -SmokeTest
+
+            - name: Run full calibration
+              env:
+                  COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+              run: npm run ci:eval:equivalence -- -Agent rpi-agent -Tier calibration
+
+            - name: Upload calibration summary
+              if: always()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: baseline-calibration-summary
+                  path: logs/baseline-equivalence-summary.json
+                  retention-days: 30
+                  if-no-files-found: ignore

--- a/.github/workflows/eval-validation.yml
+++ b/.github/workflows/eval-validation.yml
@@ -316,7 +316,7 @@ jobs:
   eval-execute:
     name: Eval Execute (${{ matrix.kind }})
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 30
     needs: [eval-validation, content-moderation]
     # Repository secrets are not exposed to fork PRs; clean-skip execution there.
     # Only run when eval-relevant paths changed (see eval-validation detect step).
@@ -415,7 +415,7 @@ jobs:
         if: env.EVAL_EXECUTE == 'true'
         shell: pwsh
         run: |
-          npm run ci:eval:execute -- -Kind ${{ matrix.kind }} -ChangedSpecManifestPath logs/changed-spec-stimuli.json -Model gpt-5.6-luna -SkipInputModeration -EnableBaselineEquivalence -EquivalenceTier calibration
+          npm run ci:eval:execute -- -Kind ${{ matrix.kind }} -ChangedSpecManifestPath logs/changed-spec-stimuli.json -Model gpt-5.6-luna -SkipInputModeration
           if ($LASTEXITCODE -ne 0) {
             'EVAL_EXECUTE_FAILED=true' >> $env:GITHUB_ENV
           }
@@ -435,7 +435,6 @@ jobs:
             logs/stimulus-presence.json
             logs/eval-summary.json
             logs/eval-results-*.json
-            logs/baseline-equivalence-*.json
           retention-days: 30
           if-no-files-found: ignore
 

--- a/docs/contributing/validation.md
+++ b/docs/contributing/validation.md
@@ -3,7 +3,7 @@ title: Validation Commands and CI-Owned Lanes
 description: Choose local-safe validation defaults and reproduce CI-owned documentation and evaluation lanes when their prerequisites are available
 sidebar_position: 12
 author: Microsoft
-ms.date: 2026-08-21
+ms.date: 2026-09-06
 ms.topic: how-to
 keywords:
   - validation
@@ -307,12 +307,32 @@ clean moderation result.
 | Agent matrix dry run | `npm run ci:eval:agent:matrix:dryrun`                           | No model invocation; writes a dry-run matrix summary                                                                    |
 | Changed-agent matrix | `npm run ci:eval:agent:changed`                                 | Requires a suitable git comparison base and model access                                                                |
 
-Devloop-tier equivalence results are advisory while CI-tier results are
-authoritative. These tiers name the baseline-equivalence exit policy and are
-distinct from the unchanged `pr` and `nightly` vocabulary of the separate
-agent-matrix commands above. Read the lane's generated JSON verdict and the
-hosted workflow status together. Do not infer a hosted CI policy from a direct
-local invocation.
+PR eval execution runs the changed-artifact checks without baseline calibration
+and has a 30-minute limit per shard. Full calibration is a separate, manually
+dispatched [Baseline Calibration workflow](../../.github/workflows/baseline-calibration.yml).
+Select a branch in GitHub Actions and run that workflow when a two-model
+baseline-versus-RPI comparison is needed. It requires the repository's
+`COPILOT_GITHUB_TOKEN` secret, has a two-hour job limit, and uploads only the
+aggregate summary, not raw trajectories or judge logs.
+
+To run the same calibration locally with model access already configured:
+
+```bash
+npm run ci:eval:equivalence -- -Agent rpi-agent -Tier calibration
+```
+
+Each comparison streams output and emits an elapsed-time heartbeat every 30
+seconds. Its default 30-minute deadline includes judge startup and cleanup;
+override it with `-ComparisonTimeoutSeconds <seconds>` when deliberately
+running a larger comparison. A timed-out comparison stops its process tree
+and records a run-health failure rather than passing without evidence.
+
+Devloop-tier execution is advisory. Calibration and CI tiers keep deterministic
+and structural failures authoritative, while comparative scores and divergence
+guards remain report-only. These tiers are distinct from the `pr` and `nightly`
+vocabulary of the separate agent-matrix commands above. Read the generated JSON
+verdict and workflow status together; a direct local invocation does not change
+hosted CI policy.
 
 ### Dashboards and reports
 

--- a/evals/baseline-equivalence/README.md
+++ b/evals/baseline-equivalence/README.md
@@ -2,7 +2,7 @@
 title: Baseline Equivalence Suite
 description: 'Pairs identical probes across baseline and customized environments to measure nominal behavior preservation'
 author: HVE Core Team
-ms.date: 2026-08-21
+ms.date: 2026-09-06
 ---
 
 ## Purpose
@@ -47,7 +47,7 @@ The contract is validated deterministically before any model-backed run. A missi
 The PowerShell driver at [scripts/evals/Invoke-BaselineEquivalence.ps1](../../scripts/evals/Invoke-BaselineEquivalence.ps1) is the single entry point. Invoke it through the npm wrapper:
 
 ```bash
-# devloop (default): single primary model, advisory verdict, always exits 0
+# devloop (default): single primary model, non-gating after summary generation
 npm run ci:eval:equivalence -- -Agent rpi-agent -Tier devloop
 
 # calibration: two-model sweep, report-only comparison, authoritative deterministic and structural evidence
@@ -60,9 +60,15 @@ npm run ci:eval:equivalence -- -Agent rpi-agent -Tier ci
 npm run ci:eval:equivalence -- -Agent rpi-agent -WhatIf
 ```
 
+PR eval execution does not invoke this suite. Use the manually dispatched
+[Baseline Calibration workflow](../../.github/workflows/baseline-calibration.yml)
+for hosted calibration on a selected branch. It requires the repository's
+`COPILOT_GITHUB_TOKEN` secret and uploads only the aggregate summary. Raw
+trajectories and judge logs are not published.
+
 The former `pr` and `nightly` tier names are rejected with a migration message rather than aliased, because they carried different exit policies and a silent alias would let a stale caller select the wrong one.
 
-`rpi-agent` is the only equivalence subject currently selected, because the customized launch target is fixed to that agent and the corpus guards encode that agent's contract. Other agents can be materialized by the driver, but they are not selected and are not meaningfully evaluated: scoring one against this corpus would fail for reasons unrelated to equivalence. Treat the shared-stimulus and scope-guard claims in this document as applying to `rpi-agent` only.
+`rpi-agent` is the only supported equivalence subject, because the customized launch target is fixed to that agent and the corpus guards encode that agent's contract. The driver rejects other agent slugs before execution. Treat the shared-stimulus and scope-guard claims in this document as applying to `rpi-agent` only.
 
 Corpus backlinks identify related artifacts for indexing; they do not select subjects. The corpus is excluded from generic tag-filtered dispatch, which previously produced partial and zero-stimulus
 runs that reported success without measuring anything. Extending coverage to the remaining agents requires per-subject conditional guards and is
@@ -70,7 +76,13 @@ deferred until one clean run under the restored comparison contract exists.
 
 The driver writes a machine-readable summary to `logs/baseline-equivalence-summary.json` and per-environment trajectories under `evals/results/`. The trajectory directories are gitignored. Both executable specs run three trials per stimulus. Three is a provisional inner-loop budget, not a calibrated power claim; the first valid post-launch run records dispersion and interval width before any future authoritative comparative policy is considered.
 
-Every stimulus also declares `constraints.max_agent_duration: 285s` beneath the 300-second hard timeout. Vally stops and aborts the active Copilot SDK request when that working-duration limit expires, while the outer CI shard stops after 240 minutes if process-level cleanup fails. A bounded trial may therefore report `agent_timeout`, but one unresolved request cannot hold the evaluation shard indefinitely.
+Every stimulus declares `constraints.max_agent_duration: 285s` beneath the
+300-second trial timeout. Each comparison has a separate 1800-second process
+deadline, configurable with `-ComparisonTimeoutSeconds`. The driver streams
+stdout and stderr to the console and the comparison log, and emits an
+elapsed-time heartbeat every 30 seconds even when Vally has no new output.
+A comparison timeout stops the process tree, returns status 124, and counts as
+a run-health failure. The standalone workflow also has a two-hour job limit.
 
 ### Driver output contract
 

--- a/scripts/evals/Invoke-BaselineEquivalence.ps1
+++ b/scripts/evals/Invoke-BaselineEquivalence.ps1
@@ -16,9 +16,9 @@
     to `logs/baseline-equivalence-summary.json`.
 
     Exit policy by tier:
-    - `devloop` always exits 0. Failing gates surface as `verdict: warn` in the
-      summary JSON. Advisory only.
-    - `ci` exits non-zero (1) when `verdict == fail`. Source of truth.
+        - `devloop` exits 0 after writing a summary, even when its verdict is fail.
+        - `calibration` and `ci` exit 1 when authoritative evidence fails.
+        - Startup and execution exceptions exit 3 in every tier.
 
     `-WhatIf` (dry-run) mode prints the planned `vally` command lines, emits a summary
     JSON populated with zeros and `verdict: dry-run`, and exits 0 without invoking any
@@ -29,8 +29,9 @@
     `.github/agents/`. Defaults to `rpi-agent`.
 
 .PARAMETER Tier
-    The harness mode. `devloop` runs a single primary model and stays advisory; `ci`
-    runs a model array for broader coverage and is authoritative. Defaults to `devloop`.
+    The harness mode. `devloop` runs one model and stays advisory. `calibration` and
+    `ci` run two models, with authoritative deterministic and structural checks and
+    report-only comparative scores. Defaults to `devloop`.
     The former `pr` and `nightly` names are rejected with a migration message rather
     than aliased, so a stale caller fails loudly instead of silently selecting a
     different exit policy.
@@ -38,11 +39,15 @@
 .PARAMETER Model
     Optional explicit model id for the `devloop` tier. When supplied it overrides the
     agent's frontmatter `model:` hint and the built-in default, letting callers pin a
-    cheaper model for advisory runs. Ignored for the `ci` tier, which always runs its
-    fixed model array of `gpt-5.6-luna` and `claude-sonnet-4.6`.
+    cheaper model for advisory runs. Ignored for `calibration` and `ci`, which run
+    the fixed pair of `gpt-5.6-luna` and `claude-sonnet-4.6`.
 
 .PARAMETER ComparisonJudgeModel
     Model used as the `vally compare` judge. Defaults to `claude-haiku-4.5`.
+
+.PARAMETER ComparisonTimeoutSeconds
+    Maximum duration of each comparison command, including judge startup and cleanup.
+    Defaults to 1800 seconds. Timeout stops the process tree and fails the run.
 
 .PARAMETER ComparisonSpecPath
     Repository-relative path to the comparison-judging contract passed to
@@ -102,6 +107,10 @@ param(
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$ComparisonJudgeModel = 'claude-haiku-4.5',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 86400)]
+    [int]$ComparisonTimeoutSeconds = 1800,
 
     # Comparison judging reads the stimulus rubric. Without this spec, vally falls back
     # to the rubric embedded in the baseline trajectory and then to a general-purpose
@@ -329,12 +338,13 @@ function Test-CustomizationCollapse {
 
 function Invoke-VallyCommand {
     [CmdletBinding()]
+    [OutputType([int])]
     param(
         [Parameter(Mandatory)]
         [string[]]$Arguments
     )
 
-    & vally @Arguments
+    & vally @Arguments | ForEach-Object { Write-Host $_ }
     return $LASTEXITCODE
 }
 
@@ -344,31 +354,104 @@ function Invoke-VallyCommandWithCapture {
     param(
         [Parameter(Mandatory)]
         [string[]]$Arguments,
-        [string]$LogPath
+        [string]$LogPath,
+        [ValidateRange(1, 86400)]
+        [int]$TimeoutSeconds = 1800,
+        [ValidateRange(1, 3600)]
+        [int]$HeartbeatSeconds = 30
     )
 
-    $prev = [Console]::OutputEncoding
+    $command = Get-Command vally -ErrorAction Stop
+    if ($command -is [System.Management.Automation.AliasInfo]) {
+        $command = $command.ResolvedCommand
+    }
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $startInfo.StandardErrorEncoding = [System.Text.Encoding]::UTF8
+    $startInfo.WorkingDirectory = (Get-Location).ProviderPath
+    if ($command.CommandType -eq 'ExternalScript') {
+        $startInfo.FileName = (Get-Process -Id $PID).Path
+        foreach ($argument in @('-NoProfile', '-File', $command.Source)) {
+            $startInfo.ArgumentList.Add($argument)
+        }
+    }
+    else {
+        $startInfo.FileName = $command.Source
+    }
+    foreach ($argument in $Arguments) { $startInfo.ArgumentList.Add($argument) }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $writer = $null
+    $timedOut = $false
+    $started = $false
     try {
-        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-        $raw = & vally @Arguments 2>&1
-        $code = $LASTEXITCODE
+        if ($LogPath) {
+            $fullLogPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($LogPath)
+            [System.IO.Directory]::CreateDirectory((Split-Path -Parent $fullLogPath)) | Out-Null
+            $writer = [System.IO.StreamWriter]::new($fullLogPath, $false, [System.Text.UTF8Encoding]::new($false))
+            $writer.AutoFlush = $true
+        }
+        Write-Host "Vally $($Arguments[0]) started (timeout: ${TimeoutSeconds}s)."
+        $started = $process.Start()
+        $clock = [System.Diagnostics.Stopwatch]::StartNew()
+        $nextHeartbeat = $HeartbeatSeconds
+        $readers = @{
+            stdout = $process.StandardOutput
+            stderr = $process.StandardError
+        }
+        $pending = @{
+            stdout = $readers.stdout.ReadLineAsync()
+            stderr = $readers.stderr.ReadLineAsync()
+        }
+        while ($pending.Count -gt 0 -or -not $process.HasExited) {
+            if ($clock.Elapsed.TotalSeconds -ge $TimeoutSeconds) {
+                $timedOut = $true
+                if (-not $process.HasExited) { $process.Kill($true) }
+                $message = "Vally $($Arguments[0]) timed out after ${TimeoutSeconds}s; stopped the process tree."
+                Write-Host $message
+                $lines.Add($message)
+                if ($writer) { $writer.WriteLine($message) }
+                break
+            }
+            foreach ($stream in @($pending.Keys)) {
+                if (-not $pending[$stream].IsCompleted) { continue }
+                $line = $pending[$stream].GetAwaiter().GetResult()
+                if ($null -eq $line) {
+                    $pending.Remove($stream)
+                    continue
+                }
+                $lines.Add($line)
+                if ($writer) { $writer.WriteLine($line) }
+                Write-Host $line
+                $pending[$stream] = $readers[$stream].ReadLineAsync()
+            }
+            if ($clock.Elapsed.TotalSeconds -ge $nextHeartbeat) {
+                Write-Host "Vally $($Arguments[0]) still running ($([int]$clock.Elapsed.TotalSeconds)s elapsed; limit ${TimeoutSeconds}s)."
+                $nextHeartbeat += $HeartbeatSeconds
+            }
+            if ($pending.Count -gt 0) {
+                [System.Threading.Tasks.Task]::WaitAny([System.Threading.Tasks.Task[]]@($pending.Values), 200) | Out-Null
+            }
+            elseif (-not $process.HasExited) {
+                $process.WaitForExit(200) | Out-Null
+            }
+        }
+        if ($timedOut) { $process.WaitForExit(5000) | Out-Null }
+        $code = if ($timedOut) { 124 } else { $process.ExitCode }
     }
     finally {
-        [Console]::OutputEncoding = $prev
+        if ($started -and -not $process.HasExited) { $process.Kill($true) }
+        $process.Dispose()
+        if ($writer) { $writer.Dispose() }
     }
 
-    $lines = @($raw | ForEach-Object { $_.ToString() })
-    foreach ($line in $lines) { Write-Host $line }
-
-    if ($LogPath) {
-        $dir = Split-Path -Parent $LogPath
-        if ($dir -and -not (Test-Path -LiteralPath $dir)) {
-            New-Item -ItemType Directory -Path $dir -Force | Out-Null
-        }
-        Set-Content -LiteralPath $LogPath -Value $lines -Encoding utf8NoBOM
-    }
-
-    return @{ ExitCode = $code; Lines = $lines }
+    return @{ ExitCode = $code; Lines = $lines.ToArray(); TimedOut = $timedOut }
 }
 
 function Get-CanonicalStimulusPolicy {
@@ -912,7 +995,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             # The customization-boundary guards assert that the customized run does not
             # claim it performed a prohibited write. They are declared inline per
             # stimulus and need no per-agent parameter. Resolve-AgentScopePattern is
-            # retained for the stage 2 subject-aware guard work rather than invoked here,
+            # retained for subject-aware guard work rather than invoked here,
             # because a parameter no spec consumes would report a guard that never ran.
             $evalBaseline = @(
                 'eval',
@@ -1130,7 +1213,8 @@ if ($MyInvocation.InvocationName -ne '.') {
                     '--output', $compareJsonlPath
                 )
                 $compareLog = Join-Path $resolvedRoot "logs/vally-compare-$model-$runId.log"
-                $resultC = Invoke-VallyCommandWithCapture -Arguments $compareArgs -LogPath $compareLog
+                Write-Host "Comparing baseline and customized responses for $model with judge $ComparisonJudgeModel."
+                $resultC = Invoke-VallyCommandWithCapture -Arguments $compareArgs -LogPath $compareLog -TimeoutSeconds $ComparisonTimeoutSeconds
                 $compareFailed = $resultC.ExitCode -ne 0
                 if ($compareFailed) { $runHealthFailures++ }
                 $compareLogs.Add($compareLog)

--- a/scripts/evals/Invoke-VallyEvals.ps1
+++ b/scripts/evals/Invoke-VallyEvals.ps1
@@ -67,15 +67,14 @@
     Defaults to `devloop`. `calibration` runs the fixed two-model set while keeping
     comparison and divergence evidence report-only; deterministic and structural
     failures remain authoritative.
-    Applies only when `-EnableBaselineEquivalence` is set. Per DD-01, `devloop`
-    equivalence dispatch is advisory: failures surface in summary JSON but do
-    not increment `failedSpecs` or change exit code. This ValidateSet must stay in
-    step with the driver's accepted tiers, which reject the retired `pr` and
-    `nightly` names outright rather than aliasing them.
+    Applies only when `-EnableBaselineEquivalence` is set. Devloop verdicts are
+    advisory; a missing or incompatible summary still fails. Keep the accepted
+    values aligned with the driver, which rejects retired `pr` and `nightly` names.
 
 .PARAMETER EnableBaselineEquivalence
-    Enables Tier 2 baseline-equivalence dispatch for changed or affected agents.
-    Disabled by default for PR-time eval execution.
+    Enables baseline-equivalence dispatch for supported changed or affected agents.
+    Disabled by default and not enabled by PR validation; hosted calibration uses
+    the separate manually dispatched Baseline Calibration workflow.
 
 .PARAMETER FailFast
     Stop after the first spec invocation that returns a non-zero exit code or
@@ -778,16 +777,7 @@ foreach ($runKey in $uniqueSpecRuns.Keys) {
         }
     }
     else {
-        # Per DD-01, baseline-equivalence is advisory at PR tier: equivalence
-        # signal surfaces in the run summary but never gates merge. Its stimuli
-        # corpus is tag-resolved into this authoritative path and runs at a
-        # perfect-score threshold (1.0) against a small model, so a single grader
-        # miss on a file-reading prompt would otherwise hard-fail the spec and
-        # block the build. Treat any baseline-equivalence spec as advisory so the
-        # tag-resolved path honors the same advisory posture as the dedicated
-        # equivalence dispatch.
-        $specIsEquivalence = $specRel -match '(^|/)baseline-equivalence/'
-        $isAdvisory = (Test-SpecIsAdvisory -SpecPath $specAbs) -or $specIsEquivalence
+        $isAdvisory = Test-SpecIsAdvisory -SpecPath $specAbs
         $result['isAdvisory'] = $isAdvisory
 
         # A zero vally exit means the spec met its aggregate threshold (the author's
@@ -905,8 +895,6 @@ if ($EnableBaselineEquivalence -and $shardOwnsEquivalence) {
     }
 }
 
-# Equivalence dispatch (Tier 2 baseline-equivalence). Per DD-01, PR-tier failures
-# are advisory: they surface in summary but do not increment $failedSpecs.
 # Only the agent-owning shard dispatches equivalence so cross-kind promotions are
 # not duplicated across parallel per-kind shards.
 $equivalenceResults = [System.Collections.Generic.List[object]]::new()

--- a/scripts/tests/evals/Invoke-BaselineEquivalence.Tests.ps1
+++ b/scripts/tests/evals/Invoke-BaselineEquivalence.Tests.ps1
@@ -7,6 +7,77 @@ BeforeAll {
     $script:RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '../../..') | Select-Object -ExpandProperty Path
 }
 
+Describe 'Invoke-VallyCommand exit status' -Tag 'Unit' {
+    BeforeAll {
+        . $script:ScriptPath
+    }
+
+    It 'Returns only exit code <ExitCode> when Vally writes stdout' -ForEach @(
+        @{ ExitCode = 0 }
+        @{ ExitCode = 7 }
+    ) {
+        $script:VallyExitCode = $ExitCode
+        Mock vally {
+            Write-Output 'ordinary CLI output'
+            $global:LASTEXITCODE = $script:VallyExitCode
+        }
+        Mock Write-Host {}
+
+        $result = Invoke-VallyCommand -Arguments @('eval')
+
+        $result | Should -BeOfType [int]
+        $result | Should -Be $ExitCode
+        Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+            $Object -eq 'ordinary CLI output'
+        }
+    }
+}
+
+Describe 'Invoke-VallyCommandWithCapture process bounds' -Tag 'Unit' {
+    BeforeAll {
+        . $script:ScriptPath
+    }
+
+    BeforeEach {
+        $script:SavedCompareMode = $env:STUB_VALLY_COMPARE_MODE
+        Set-Alias -Name vally -Value (Join-Path $PSScriptRoot 'fixtures/stub-vally.ps1')
+        $script:CompareLog = Join-Path $TestDrive 'compare.log'
+        $script:CompareOutput = Join-Path $TestDrive 'compare.json'
+        Mock Write-Host {}
+    }
+
+    AfterEach {
+        Remove-Item Alias:vally -Force -ErrorAction SilentlyContinue
+        $env:STUB_VALLY_COMPARE_MODE = $script:SavedCompareMode
+    }
+
+    It 'Streams and saves both output streams while preserving the exit code' {
+        $env:STUB_VALLY_COMPARE_MODE = 'stream'
+
+        $result = Invoke-VallyCommandWithCapture -Arguments @('compare', '--output', $script:CompareOutput) -LogPath $script:CompareLog
+
+        $result.ExitCode | Should -Be 7
+        $result.TimedOut | Should -BeFalse
+        $result.Lines | Should -Contain 'stub comparison stdout'
+        $result.Lines | Should -Contain 'stub comparison stderr'
+        Get-Content -LiteralPath $script:CompareLog | Should -HaveCount 2
+        Should -Invoke Write-Host -ParameterFilter { $Object -eq 'stub comparison stdout' } -Times 1 -Exactly
+    }
+
+    It 'Reports progress and stops a stalled process at the deadline' {
+        $env:STUB_VALLY_COMPARE_MODE = 'wait'
+
+        $result = Invoke-VallyCommandWithCapture -Arguments @('compare', '--output', $script:CompareOutput) -LogPath $script:CompareLog -TimeoutSeconds 3 -HeartbeatSeconds 1
+
+        $result.ExitCode | Should -Be 124
+        $result.TimedOut | Should -BeTrue
+        Get-Content -LiteralPath $script:CompareLog -Raw | Should -Match 'timed out'
+        Should -Invoke Write-Host -ParameterFilter { $Object -like '*still running*' }
+        $childId = [int](Get-Content -LiteralPath $script:CompareOutput -Raw)
+        Get-Process -Id $childId -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+    }
+}
+
 Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
     BeforeEach {
         $script:OutputPath = Join-Path $TestDrive "summary-$([Guid]::NewGuid()).json"
@@ -66,7 +137,7 @@ Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
             $script:Summary.tier | Should -Be 'devloop'
         }
 
-        It 'Selects exactly one PR-tier model' {
+        It 'Selects exactly one devloop model' {
             $script:Summary.model | Should -Not -BeNullOrEmpty
             $script:Summary.plannedCommands.Count | Should -Be 3
         }
@@ -444,7 +515,7 @@ Describe 'Test-CustomizationCollapse' -Tag 'Unit' {
     }
 }
 
-Describe 'Invoke-BaselineEquivalence.ps1 (stubbed nightly run)' -Tag 'Unit' {
+Describe 'Invoke-BaselineEquivalence.ps1 (stubbed execution)' -Tag 'Unit' {
     BeforeEach {
         $script:StubRepoRoot = Join-Path $TestDrive 'repo'
         $baselineRoot = Join-Path $script:StubRepoRoot 'evals/baseline-equivalence'

--- a/scripts/tests/evals/fixtures/stub-vally.ps1
+++ b/scripts/tests/evals/fixtures/stub-vally.ps1
@@ -56,6 +56,16 @@ if ($args[0] -eq 'compare') {
         exit 65
     }
 
+    if ($env:STUB_VALLY_COMPARE_MODE -in @('stream', 'wait')) {
+        [Console]::Out.WriteLine('stub comparison stdout')
+        [Console]::Error.WriteLine('stub comparison stderr')
+        if ($env:STUB_VALLY_COMPARE_MODE -eq 'wait') {
+            Set-Content -LiteralPath $outputPath -Value $PID
+            [Console]::In.ReadLine() | Out-Null
+        }
+        exit 7
+    }
+
     if ($env:STUB_VALLY_COMPARE_MODE -eq 'fail-empty') {
         [System.IO.File]::WriteAllText($outputPath, '')
         exit 1


### PR DESCRIPTION
<!-- markdownlint-disable-file -->
# Pull Request

## Description
<!-- Provide a clear description of the changes in this PR -->

Separate PR eval execution from full baseline calibration so PR shards run changed-artifact checks within a 30-minute limit, while two-model calibration runs through a dedicated manual workflow.

* Add a manually dispatched Baseline Calibration workflow for `rpi-agent`, with a two-hour job limit and aggregate-summary-only artifact upload.
* Remove baseline calibration dispatch from PR eval execution and remove the blanket advisory override for baseline-equivalence paths in the generic runner.
* Stream comparison stdout and stderr to the console and log, emit progress heartbeats, and enforce a configurable 30-minute comparison deadline. Timeouts stop the process tree and count as run-health failures.
* Preserve numeric exit codes when Vally emits stdout, add regression tests for output capture and stalled processes, and document calibration invocation and exit policies.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses using "Fixes #123" or "Closes #123" -->

None identified in the branch or commit history.

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [x] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing
<!-- Describe how you tested these changes -->

* Passed `git diff --check 8aa6b214461e06df5b304ee48027fc49dfb5fd6f..HEAD`
* Completed dependency bootstrap with `npm ci`
* Passed `npm run test:ps -- -TestPath scripts/tests/evals/`: 716 passed, 0 failed, 1 skipped, 47 not run
* Passed `npm run lint:ps -- -ChangedFilesOnly -BaseBranch origin/main`: all four changed PowerShell files
* Passed `actionlint .github/workflows/baseline-calibration.yml .github/workflows/eval-validation.yml`
* Passed `npm exec -- markdownlint-cli2 docs/contributing/validation.md evals/baseline-equivalence/README.md`
* Passed `pwsh -NoProfile -File scripts/evals/Build-AgentBehaviorSpec.ps1 -WhatIf`
* Passed `npm exec -- vally lint --eval-spec evals/`
* Passed `pwsh -NoProfile -File scripts/evals/Test-EvalSpec.ps1`
* Passed `pwsh -NoProfile -File scripts/evals/Test-EvalSpecText.ps1` with advisory warnings
* Passed `pwsh -NoProfile -File scripts/evals/Test-VallyTestSafety.ps1 -OutputPath logs/vally-test-safety.json`

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [ ] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

The calibration workflow uses read-only repository permissions, disables checkout credential persistence, and requires the existing `COPILOT_GITHUB_TOKEN` secret. It uploads the aggregate summary, not raw trajectories or judge logs.

## Additional Notes
<!-- Any additional information that reviewers should know -->

Hosted CI and credential-dependent eval execution, moderation, and full calibration remain pending. Broad validation and documentation aggregates, browser suites, repository-wide spell and link checks, and security scans were not run during targeted preflight. No repair commits were needed.
