### PR TITLE
docs(customization): sync devcontainer example with devcontainer.json

### DIFF
--- a/docs/customization/environment.md
+++ b/docs/customization/environment.md
@@ -43,10 +43,12 @@ To add tools or adjust versions, modify `.devcontainer/devcontainer.json`. The
 {
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
+      "version": "24",
+      "pnpmVersion": "none"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.11"
+      "version": "3.11",
+      "installTools": false
     },
     "ghcr.io/devcontainers/features/powershell:1": {}
   }


### PR DESCRIPTION
**Description**

The "Customizing for Your Team" example omitted `"pnpmVersion": "none"` and `"installTools": false`, which #2874 added to the real `.devcontainer/devcontainer.json` to stop network handshake failures on unused optional downloads. Copying the snippet reintroduced what that change fixed. The example now matches the real file for the `node:1` and `python:1` features.

**Related Issue(s)**

Closes #2881

**Type of Change**

* [x] Documentation update

**Testing**

`npm run lint:md`: 492 files, 0 issues. `npm run spell-check`: 799 files, 0 issues. Both repo-wide, exit 0.

**Checklist**

**Required Checks**

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)

**Required Local Checks**

* [x] Spell checking: `npm run spell-check`
* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [ ] Link validation: `npm run lint:md-links`

The unchecked commands need `pwsh`, absent on this machine, so they were not run.

**Security Considerations**

* [x] This PR does not contain any sensitive or NDA information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
