### PR TITLE
fix(prompts): resolve cspell configuration precedence

### DIFF
--- a/.github/prompts/experimental/cspell-config.prompt.md
+++ b/.github/prompts/experimental/cspell-config.prompt.md
@@ -10,28 +10,42 @@ description: "Create or update the project cspell configuration with project wor
 * Goal: Add commonly used project-specific words to the cspell configuration, alphabetize the words list, and add useful `ignorePaths` aligned with the project's ignore files.
 * cspell supports multiple config formats and file names. The agent must detect which format the project uses rather than assuming any specific one.
 * Projects may also use custom dictionary files (`.txt` word lists) organized in a dedicated directory. The agent must discover and respect existing dictionary structure.
+* Configuration authority is invocation-bound, not a fixed ranking of file locations. The command that runs cspell determines the base configuration, cspell's own per-file lookup determines overlays, and a custom dictionary participates only when an effective configuration defines and enables it. File enumeration order never establishes authority.
 
 ## Required Steps
 
-### Step 1: Detect project context
+### Step 1: Detect project context and the authoritative command
 
 1. Identify the project's primary language and package manager by inspecting files at the workspace root (e.g., `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`, `pom.xml`, `Gemfile`).
 2. Determine how cspell is installed or available. Check for: a project dependency (npm, pip, or equivalent), a global install (`cspell --version`), or `npx`/`npx`-equivalent availability. If cspell is not available, ask the user for their preferred installation method.
-3. Check for an existing spell-check script in the project's task runner (e.g., `package.json` scripts, `Makefile` targets, `justfile` recipes, `pyproject.toml` scripts). Use the project command when one exists.
+3. Record the installed cspell version. Resolution details below describe cspell 10.x behavior; when the project pins a different major version, confirm the behavior against that version's documentation or observed output before relying on any ordering claim.
+4. Check for an existing spell-check script in the project's task runner (e.g., `package.json` scripts, `Makefile` targets, `justfile` recipes, `pyproject.toml` scripts). Use the project command when one exists; it is the authority for the rest of this workflow.
+5. From that command, capture the invocation working directory, the file globs it passes, any explicit `--config`, and any config-search controls (`--no-config-search`, `--config-search`, `--stop-config-search-at`, or an equivalent setting). These inputs determine which configuration the project actually uses.
 
-### Step 2: Detect cspell configuration
+### Step 2: Resolve the authoritative cspell configuration
 
-1. Search the workspace root for any cspell config file using a broad glob pattern (e.g., `cspell*`, `.cspell*`). cspell recognizes many naming variants including dotfiles (`.cspell.json`), plain names (`cspell.json`), JSONC (`cspell.jsonc`), JS modules (`cspell.config.{js,cjs,mjs}`), and YAML (`cspell.config.{yaml,yml}`). Also check `package.json` for a `cspell` configuration key.
-2. If multiple config files exist, use the first match and note the others for the user.
-3. If no config file exists, create `cspell.json` with a minimal scaffold (`version`, `language`, `ignorePaths`, `words`).
-4. Record the detected config path and format (JSON, YAML, or JS module) for subsequent steps.
+1. Inventory candidate config files across the workspace using a broad glob pattern (e.g., `cspell*`, `.cspell*`). cspell recognizes many naming variants including dotfiles (`.cspell.json`), plain names (`cspell.json`), JSONC (`cspell.jsonc`), JS modules (`cspell.config.{js,cjs,mjs}`), and YAML (`cspell.config.{yaml,yml}`). Also check `package.json` for a `cspell` configuration key. Treat this inventory as candidates only; enumeration order carries no authority.
+2. Identify the invocation-base config, which governs file discovery for the whole run:
+   * When the command passes `--config`, that file is the base.
+   * Otherwise the base is the config cspell finds from the invocation working directory.
+   * Because the base owns discovery, a file excluded by the base `ignorePaths` stays excluded no matter what a nested config says.
+3. Determine per-file overlays. Unless config search is turned off, cspell searches upward from each checked file for the nearest recognized config and merges it over the base settings. Only the nearest config applies; an intermediate ancestor between the file and the base participates only when the selected config imports it. In merged settings, nested scalar values win and mergeable arrays accumulate.
+4. Apply same-directory recognized-name order when one directory holds more than one representation. In cspell 10.x a `package.json` with an object-valued `cspell` key is selected before `.cspell.json`, then `cspell.json`, then the remaining recognized names. Sibling files are not merged automatically; a sibling participates only through an explicit `import` or an explicit invocation. Verify this ordering against the installed version rather than asserting it from memory.
+5. Note that `--config` alone does not disable the per-file search. `--no-config-search` and the `noConfigSearch: true` setting disable it; `--config-search` re-enables it; `--stop-config-search-at` bounds how far the upward search walks.
+6. Follow every `import` in the selected configs and record the imported files, since an import can supply the definitions and words a token would otherwise need.
+7. If no config file exists anywhere in the resolution chain, create `cspell.json` at the invocation root with a minimal scaffold (`version`, `language`, `ignorePaths`, `words`).
+8. Record the resolved base config path, the applicable local config path for the files you intend to change, the imported files, and each candidate you did not select, with the reason.
+9. If these inputs do not identify exactly one authoritative mutation target, stop and ask the user which config or dictionary to write to. Present the resolved command, the candidates, and why the choice is ambiguous. Do not guess.
 
-### Step 3: Detect custom dictionaries
+### Step 3: Resolve custom dictionaries
 
-1. Search for a `.cspell/` directory or any path referenced in the config's `dictionaryDefinitions` field.
+1. Collect every `dictionaryDefinitions` entry from the resolved configs and their imports, and search for a `.cspell/` directory or any other referenced dictionary location.
 2. Catalog existing custom dictionary text files (`.txt` word lists) and note their names, paths, and apparent categories.
-3. Check the `dictionaries` field for enabled built-in dictionaries (e.g., `k8s`, `docker`, `rust`, `aws`, `terraform`, `python`, `csharp`).
-4. When adding new words later, route each token to either the inline `words` array or an existing custom dictionary file based on category fit. If no custom dictionaries exist, add all tokens to the inline `words` array.
+3. Treat a dictionary as active only when a definition supplies its name and an effective `dictionaries` list (or an applicable override or language setting) enables that name. A definition alone does not load the file, and a dictionary file that no config references has no effect.
+4. Resolve relative dictionary paths from the config that defines them, not from the process working directory.
+5. When the same dictionary name is defined more than once among active definitions, the later effective definition replaces the earlier one. Record which definition wins before writing to any file.
+6. Check the `dictionaries` field for enabled built-in dictionaries (e.g., `k8s`, `docker`, `rust`, `aws`, `terraform`, `python`, `csharp`).
+7. When adding new words later, route each token to the inline `words` array of the authoritative config or to an active custom dictionary file whose category fits. Never write to an inactive dictionary. If no active custom dictionaries exist, add all tokens to the inline `words` array.
 
 ### Step 4: Run initial spell check
 
@@ -50,27 +64,31 @@ description: "Create or update the project cspell configuration with project wor
 
 ### Step 6: Update configuration and dictionaries
 
-1. Add curated tokens to the `words` array or the appropriate custom dictionary file. Preserve original casing and avoid introducing duplicates.
+1. Write curated tokens only to the targets resolved in Steps 2 and 3: the inline `words` array of the authoritative config, or an active custom dictionary file. Preserve original casing and avoid introducing duplicates.
 2. Sort the `words` array alphabetically (case-insensitive sort, preserve original case).
 3. Sort custom dictionary text files alphabetically with one word per line if they follow that convention.
-4. Add or refine `ignorePaths` entries to align with the project's ignore files (`.gitignore`, `.dockerignore`, etc.), but do not ignore source folders containing meaningful code and documentation.
+4. Add or refine `ignorePaths` entries to align with the project's ignore files (`.gitignore`, `.dockerignore`, etc.), but do not ignore source folders containing meaningful code and documentation. Add an `ignorePaths` entry to the config that governs discovery for the affected files; an entry placed in a nested config cannot exclude a file the invocation base already enumerated, and cannot re-include a file the base excluded.
 5. Preserve the existing config format and style conventions (indentation, trailing commas, module export structure).
 
 ### Step 7: Validate and report
 
-1. Re-run cspell using the same command from Step 4.
+1. Re-run cspell using the same command from Step 4, from the same working directory and with the same config and search flags, so the before and after runs are comparable.
 2. Report the final counts: files checked, issues found, files with issues.
-3. If the issue count has not meaningfully decreased from baseline (target: ≥80% reduction), provide a short rationale and suggest next actions (add more words, fix typos, or add more ignore paths).
-4. List any typos identified in Step 5 that should be fixed in source.
+3. Report the resolution basis for the changes: the command used, the invocation-base config, the applicable local config, each file or dictionary written, and the candidates you did not select with the reason.
+4. If the issue count has not meaningfully decreased from baseline (target: ≥80% reduction), provide a short rationale and suggest next actions (add more words, fix typos, or add more ignore paths). When tokens you added are still reported, treat it as a resolution problem: confirm the config you edited is the one the command loads and that any dictionary you wrote to is enabled.
+5. List any typos identified in Step 5 that should be fixed in source.
 
 ## Acceptance criteria
 
+* Every configuration or dictionary change is written to a target the project's own cspell command actually loads, and the report names the command, base config, local config, and unselected candidates.
 * The cspell configuration includes a comprehensive `ignorePaths` array that excludes generated and vendored folders.
 * The `words` array and any custom dictionary files contain the most common project-specific tokens, alphabetized and deduplicated.
 * A final cspell run shows a meaningful reduction from the baseline (target ≥80%, or the agent documents the remaining categories with rationale).
 
 ## Notes and best practices
 
+* Prefer observed command behavior over any remembered ordering rule. When resolution is unclear, run the project command with increased verbosity and let its output identify the configuration in effect.
+* Do not reimplement cspell's resolver. Use the tool's own output to confirm which settings applied.
 * Preserve original casing for tokens (do not normalize to uppercase or lowercase).
 * Prefer adding tokens for environment variables, infrastructure outputs, and technology names rather than silencing real typos.
 * When in doubt about a token that appears only once in generated files, prefer ignoring the generated file path instead of adding the token.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -3,7 +3,7 @@ title: Reference
 description: Generated reference documentation for HVE Core GenAI assets.
 sidebar_position: 0
 author: Microsoft
-ms.date: 2026-09-09
+ms.date: 2026-09-11
 ms.topic: overview
 keywords:
   - reference
@@ -18,5 +18,5 @@ This page lists the generated reference documentation, grouped by asset kind.
 | [Agents](agents/README.md)             | 60     |
 | [Instructions](instructions/README.md) | 60     |
 | [Prompts](prompts/README.md)           | 48     |
-| [Skills](skills/README.md)             | 78     |
+| [Skills](skills/README.md)             | 79     |
 <!-- END AUTO-GENERATED: index -->

--- a/evals/behavior-conformance/prompts.eval.yaml
+++ b/evals/behavior-conformance/prompts.eval.yaml
@@ -85,8 +85,23 @@ stimuli:
 
   - name: prompt-cspell-config-conformance
     prompt: |
-      Invoke the `cspell-config` prompt with minimal arguments and explain how it
-      coordinates the workflow.
+      Invoke the `cspell-config` prompt against the two synthetic workspaces
+      below. For each one, state the configuration or dictionary you would write
+      to and why, before proposing any edit.
+
+      Workspace A resolves from evidence. Its `package.json` declares the script
+      `spell-check` as `cspell "**/*.md" --config config/base.cspell.json`. The
+      workspace also contains a root `.cspell.json`, a `docs/.cspell.json`, and a
+      word list at `.cspell/terms.txt`. Only `config/base.cspell.json` declares a
+      `dictionaryDefinitions` entry named `terms`, and its `dictionaries` list
+      does not include that name. Explain which configuration the command loads,
+      which configuration applies to a file under `docs/`, whether the word list
+      at `.cspell/terms.txt` participates, which candidates you did not select,
+      and how you confirm the result.
+
+      Workspace B does not resolve. It has `cspell.json` and `.cspell.json`
+      beside each other at the root and no spell-check entry in any task runner.
+      State what you do in that case.
     tags:
       category: behavior-conformance
       prompt: cspell-config
@@ -97,9 +112,25 @@ stimuli:
         config:
           pattern: "(?i)cspell|spell"
       - type: output-matches
-        name: scope-language
+        name: command-and-search-resolution
         config:
-          pattern: "(?i)cspell|dictionary|word|spelling|config"
+          pattern: "(?i)no-config-search|config-search|nearest\\s+config|invocation\\s+(root|base|working)|project\\s+command|--config"
+      - type: output-matches
+        name: selected-and-unselected-candidates
+        config:
+          pattern: "(?i)not\\s+select|unselected|did\\s+not\\s+apply|rather\\s+than|instead\\s+of|candidate"
+      - type: output-matches
+        name: dictionary-activation
+        config:
+          pattern: "(?i)dictionaryDefinitions|dictionaries|not\\s+enabled|never\\s+loads|activated|activation"
+      - type: output-matches
+        name: same-command-validation
+        config:
+          pattern: "(?i)same\\s+command|re-?run|spell-check|validat"
+      - type: output-matches
+        name: ambiguity-handling
+        config:
+          pattern: "(?i)ambiguous|ambiguity|cannot\\s+determine|ask\\s+(the\\s+)?user|which\\s+config|stop\\b|clarif"
 
   - name: prompt-dt-canonical-deck-conformance
     prompt: |

--- a/scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1
+++ b/scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1
@@ -1,0 +1,342 @@
+#Requires -Modules Pester
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+    $script:CSpellBin = Join-Path $script:RepoRoot 'node_modules/cspell/bin.mjs'
+    $script:NodeAvailable = $null -ne (Get-Command node -ErrorAction SilentlyContinue)
+
+    function New-FixtureFile {
+        param(
+            [Parameter(Mandatory)][string]$Path,
+            [Parameter(Mandatory)][string]$Content
+        )
+
+        $parent = Split-Path -Parent $Path
+        if (-not (Test-Path -LiteralPath $parent)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8
+    }
+
+    function New-FixtureConfig {
+        param(
+            [Parameter(Mandatory)][string]$Path,
+            [Parameter(Mandatory)][hashtable]$Settings
+        )
+
+        New-FixtureFile -Path $Path -Content (ConvertTo-Json -InputObject $Settings -Depth 10)
+    }
+
+    function New-FixtureRoot {
+        New-Item -ItemType Directory -Path (Join-Path $TestDrive ([Guid]::NewGuid().ToString('N'))) -Force |
+            Select-Object -ExpandProperty FullName
+    }
+
+    # Runs the repository-pinned cspell CLI against a disposable fixture and parses its observables.
+    function Invoke-FixtureCSpell {
+        param(
+            [Parameter(Mandatory)][string]$Root,
+            [string[]]$CSpellArgs = @('**/*.md')
+        )
+
+        if (-not $script:NodeAvailable) {
+            throw 'node was not found on PATH. The CSpell precedence oracle requires Node to invoke the pinned CLI.'
+        }
+        if (-not (Test-Path -LiteralPath $script:CSpellBin)) {
+            throw "The repository-pinned cspell CLI was not found at '$script:CSpellBin'. Run 'npm ci' at the repository root first."
+        }
+
+        Push-Location -LiteralPath $Root
+        try {
+            $raw = & node $script:CSpellBin lint @CSpellArgs --no-progress --no-color 2>&1
+        }
+        finally {
+            Pop-Location
+        }
+
+        $lines = @($raw | ForEach-Object { $_.ToString() })
+
+        $issues = @(
+            foreach ($line in $lines) {
+                if ($line -match '^(?<path>.+?):(?<line>\d+):(?<col>\d+)\s+-\s+Unknown word \((?<word>[^)]+)\)') {
+                    [pscustomobject]@{ Path = $Matches.path; Word = $Matches.word }
+                }
+            }
+        )
+
+        $filesChecked = -1
+        $issuesFound = -1
+        foreach ($line in $lines) {
+            if ($line -match 'Files checked:\s*(?<checked>\d+),\s*Issues found:\s*(?<issues>\d+)') {
+                $filesChecked = [int]$Matches.checked
+                $issuesFound = [int]$Matches.issues
+            }
+        }
+
+        [pscustomobject]@{
+            Issues       = $issues
+            UnknownWords = @($issues | ForEach-Object { $_.Word })
+            FilesChecked = $filesChecked
+            IssuesFound  = $issuesFound
+            Output       = $lines
+        }
+    }
+
+    # Unknown words reported for one fixture-relative file, using the forward-slash paths cspell emits.
+    function Get-FixtureUnknownWord {
+        param(
+            [Parameter(Mandatory)][psobject]$Result,
+            [Parameter(Mandatory)][string]$RelativePath
+        )
+
+        @($Result.Issues | Where-Object { $_.Path.Replace('\\', '/') -eq $RelativePath } | ForEach-Object { $_.Word })
+    }
+}
+
+Describe 'CSpell configuration precedence oracle' -Tag 'Unit' {
+
+    Context 'Test prerequisites' {
+        It 'Resolves Node and the repository-pinned cspell CLI' {
+            $script:NodeAvailable | Should -BeTrue -Because 'the oracle invokes the pinned cspell CLI through Node'
+            Test-Path -LiteralPath $script:CSpellBin | Should -BeTrue -Because "npm ci must install cspell at '$script:CSpellBin'"
+        }
+    }
+
+    Context 'Scenario 1: root-only configuration' {
+        It 'Loads root inline words and an enabled root dictionary' {
+            $root = New-FixtureRoot
+            New-FixtureFile -Path (Join-Path $root 'dicts/base.txt') -Content 'zzdictword'
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version               = '0.2'
+                language              = 'en'
+                words                 = @('zzrootword')
+                ignorePaths           = @()
+                dictionaryDefinitions = @(@{ name = 'zzbasedict'; path = './dicts/base.txt' })
+                dictionaries          = @('zzbasedict')
+            }
+            New-FixtureFile -Path (Join-Path $root 'doc.md') -Content 'zzrootword zzdictword zzcontrolword'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $result.FilesChecked | Should -Be 1
+            $result.UnknownWords | Should -Contain 'zzcontrolword'
+            $result.UnknownWords | Should -Not -Contain 'zzrootword'
+            $result.UnknownWords | Should -Not -Contain 'zzdictword'
+        }
+    }
+
+    Context 'Scenario 2: root plus nested standalone configuration' {
+        It 'Accumulates word arrays, lets the nested scalar win, and keeps discovery with the root' {
+            $root = New-FixtureRoot
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version            = '0.2'
+                language           = 'en'
+                words              = @('zzrootword', 'zzalpha', 'zzbeta')
+                allowCompoundWords = $true
+                ignorePaths        = @('**/skipped/**')
+            }
+            New-FixtureConfig -Path (Join-Path $root 'pkg/.cspell.json') -Settings @{
+                version            = '0.2'
+                words              = @('zznestedword')
+                allowCompoundWords = $false
+            }
+            New-FixtureFile -Path (Join-Path $root 'top.md') -Content 'zzrootword zzalphazzbeta'
+            New-FixtureFile -Path (Join-Path $root 'pkg/doc.md') -Content 'zzrootword zznestedword zzalphazzbeta'
+            New-FixtureFile -Path (Join-Path $root 'pkg/skipped/ignored.md') -Content 'zzignoredword'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $result.FilesChecked | Should -Be 2 -Because 'the invocation-base ignorePaths governs discovery for nested directories'
+            $result.UnknownWords | Should -Not -Contain 'zzignoredword'
+            $result.UnknownWords | Should -Not -Contain 'zzrootword' -Because 'root settings still apply beneath a nested config'
+            $result.UnknownWords | Should -Not -Contain 'zznestedword' -Because 'the nested word array accumulates onto the root array'
+            (Get-FixtureUnknownWord -Result $result -RelativePath 'pkg/doc.md') | Should -Contain 'zzalphazzbeta' -Because 'the nested scalar overrides the root scalar'
+            (Get-FixtureUnknownWord -Result $result -RelativePath 'top.md') | Should -Not -Contain 'zzalphazzbeta' -Because 'the same compound still passes above the nested config'
+        }
+    }
+
+    Context 'Scenario 3: embedded versus sibling configuration in one directory' {
+        It 'Selects package.json#cspell over a sibling .cspell.json without merging the sibling' {
+            $root = New-FixtureRoot
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version     = '0.2'
+                language    = 'en'
+                words       = @('zzrootword')
+                ignorePaths = @()
+            }
+            New-FixtureConfig -Path (Join-Path $root 'pkg/package.json') -Settings @{
+                name    = 'zz-fixture-pkg'
+                version = '1.0.0'
+                cspell  = @{ words = @('zzembedded') }
+            }
+            New-FixtureConfig -Path (Join-Path $root 'pkg/.cspell.json') -Settings @{
+                version = '0.2'
+                words   = @('zzsibling')
+            }
+            New-FixtureFile -Path (Join-Path $root 'pkg/doc.md') -Content 'zzrootword zzembedded zzsibling'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $result.UnknownWords | Should -Not -Contain 'zzembedded' -Because 'package.json#cspell precedes .cspell.json in the same directory'
+            $result.UnknownWords | Should -Contain 'zzsibling' -Because 'an unselected sibling participates only through an explicit import'
+            $result.UnknownWords | Should -Not -Contain 'zzrootword'
+        }
+    }
+
+    Context 'Scenario 4: nearest configuration skips an intermediate ancestor' {
+        It 'Applies the base and the nearest config but not an unimported intermediate ancestor' {
+            $root = New-FixtureRoot
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version     = '0.2'
+                language    = 'en'
+                words       = @('zzrootword')
+                ignorePaths = @()
+            }
+            New-FixtureConfig -Path (Join-Path $root 'a/.cspell.json') -Settings @{
+                version = '0.2'
+                words   = @('zzparentword')
+            }
+            New-FixtureConfig -Path (Join-Path $root 'a/b/.cspell.json') -Settings @{
+                version = '0.2'
+                words   = @('zzchildword')
+            }
+            New-FixtureFile -Path (Join-Path $root 'a/b/doc.md') -Content 'zzrootword zzparentword zzchildword'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $result.UnknownWords | Should -Not -Contain 'zzrootword' -Because 'the invocation base always participates'
+            $result.UnknownWords | Should -Not -Contain 'zzchildword' -Because 'the nearest config overlays the base'
+            $result.UnknownWords | Should -Contain 'zzparentword' -Because 'only the nearest ancestor config is applied'
+        }
+    }
+
+    Context 'Scenario 5: explicit config and config-search controls' {
+        BeforeEach {
+            $script:SearchRoot = New-FixtureRoot
+            New-FixtureConfig -Path (Join-Path $script:SearchRoot 'base.cspell.json') -Settings @{
+                version     = '0.2'
+                language    = 'en'
+                words       = @('zzbaseword')
+                ignorePaths = @()
+            }
+            New-FixtureConfig -Path (Join-Path $script:SearchRoot 'base-nosearch.cspell.json') -Settings @{
+                version        = '0.2'
+                language       = 'en'
+                words          = @('zzbaseword')
+                ignorePaths    = @()
+                noConfigSearch = $true
+            }
+            New-FixtureConfig -Path (Join-Path $script:SearchRoot 'pkg/.cspell.json') -Settings @{
+                version = '0.2'
+                words   = @('zznestedword')
+            }
+            New-FixtureFile -Path (Join-Path $script:SearchRoot 'pkg/doc.md') -Content 'zzbaseword zznestedword zzcontrolword'
+        }
+
+        It 'Keeps per-file search enabled when only --config is supplied' {
+            $result = Invoke-FixtureCSpell -Root $script:SearchRoot -CSpellArgs @('**/*.md', '--config', 'base.cspell.json')
+
+            $result.UnknownWords | Should -Not -Contain 'zzbaseword'
+            $result.UnknownWords | Should -Not -Contain 'zznestedword' -Because '--config alone does not disable the nearest-config search'
+            $result.UnknownWords | Should -Contain 'zzcontrolword'
+        }
+
+        It 'Suppresses the nested config when --no-config-search is supplied' {
+            $result = Invoke-FixtureCSpell -Root $script:SearchRoot -CSpellArgs @('**/*.md', '--config', 'base.cspell.json', '--no-config-search')
+
+            $result.UnknownWords | Should -Not -Contain 'zzbaseword' -Because 'the explicit base stays active'
+            $result.UnknownWords | Should -Contain 'zznestedword'
+            $result.UnknownWords | Should -Contain 'zzcontrolword'
+        }
+
+        It 'Suppresses the nested config when the base sets noConfigSearch' {
+            $result = Invoke-FixtureCSpell -Root $script:SearchRoot -CSpellArgs @('**/*.md', '--config', 'base-nosearch.cspell.json')
+
+            $result.UnknownWords | Should -Not -Contain 'zzbaseword'
+            $result.UnknownWords | Should -Contain 'zznestedword'
+        }
+
+        It 'Restores the nested config when --config-search overrides the base setting' {
+            $result = Invoke-FixtureCSpell -Root $script:SearchRoot -CSpellArgs @('**/*.md', '--config', 'base-nosearch.cspell.json', '--config-search')
+
+            $result.UnknownWords | Should -Not -Contain 'zzbaseword'
+            $result.UnknownWords | Should -Not -Contain 'zznestedword' -Because 'the CLI flag overrides the base noConfigSearch setting'
+            $result.UnknownWords | Should -Contain 'zzcontrolword'
+        }
+    }
+
+    Context 'Scenario 6: import order' {
+        It 'Accumulates imported and local arrays while the importing config supplies the winning scalar' {
+            $root = New-FixtureRoot
+            New-FixtureConfig -Path (Join-Path $root 'shared.cspell.json') -Settings @{
+                version            = '0.2'
+                words              = @('zzimportword', 'zzcompa', 'zzcompb')
+                allowCompoundWords = $true
+            }
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version            = '0.2'
+                language           = 'en'
+                import             = @('./shared.cspell.json')
+                words              = @('zzlocalword')
+                allowCompoundWords = $false
+                ignorePaths        = @()
+            }
+            New-FixtureFile -Path (Join-Path $root 'doc.md') -Content 'zzimportword zzlocalword zzcompazzcompb'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $result.UnknownWords | Should -Not -Contain 'zzimportword' -Because 'imported word arrays accumulate'
+            $result.UnknownWords | Should -Not -Contain 'zzlocalword'
+            $result.UnknownWords | Should -Contain 'zzcompazzcompb' -Because 'the importing config scalar wins over the imported scalar'
+        }
+    }
+
+    Context 'Scenario 7: dictionary collision, activation, and path relativity' {
+        It 'Uses the later same-name definition, accumulates distinct names, and ignores unenabled definitions' {
+            $root = New-FixtureRoot
+            New-FixtureFile -Path (Join-Path $root 'dicts/root-shared.txt') -Content 'zzrootshared'
+            New-FixtureFile -Path (Join-Path $root 'dicts/root-only.txt') -Content 'zzrootonlyword'
+            New-FixtureFile -Path (Join-Path $root 'dicts/unused.txt') -Content 'zzunusedword'
+            New-FixtureFile -Path (Join-Path $root 'pkg/dicts/pkg-shared.txt') -Content 'zzpkgshared'
+            New-FixtureFile -Path (Join-Path $root 'pkg/dicts/pkg-only.txt') -Content 'zzpkgonlyword'
+
+            New-FixtureConfig -Path (Join-Path $root '.cspell.json') -Settings @{
+                version               = '0.2'
+                language              = 'en'
+                ignorePaths           = @()
+                dictionaryDefinitions = @(
+                    @{ name = 'zzshareddict'; path = './dicts/root-shared.txt' }
+                    @{ name = 'zzrootonlydict'; path = './dicts/root-only.txt' }
+                    @{ name = 'zzunuseddict'; path = './dicts/unused.txt' }
+                )
+                dictionaries          = @('zzshareddict', 'zzrootonlydict')
+            }
+            New-FixtureConfig -Path (Join-Path $root 'pkg/.cspell.json') -Settings @{
+                version               = '0.2'
+                dictionaryDefinitions = @(
+                    @{ name = 'zzshareddict'; path = './dicts/pkg-shared.txt' }
+                    @{ name = 'zzpkgonlydict'; path = './dicts/pkg-only.txt' }
+                )
+                dictionaries          = @('zzshareddict', 'zzpkgonlydict')
+            }
+            New-FixtureFile -Path (Join-Path $root 'pkg/doc.md') -Content 'zzrootshared zzpkgshared zzrootonlyword zzpkgonlyword zzunusedword'
+            New-FixtureFile -Path (Join-Path $root 'top.md') -Content 'zzrootshared zzpkgshared'
+
+            $result = Invoke-FixtureCSpell -Root $root
+
+            $nested = Get-FixtureUnknownWord -Result $result -RelativePath 'pkg/doc.md'
+            $top = Get-FixtureUnknownWord -Result $result -RelativePath 'top.md'
+
+            $nested | Should -Contain 'zzunusedword' -Because 'a defined but unenabled dictionary never loads'
+            $nested | Should -Not -Contain 'zzpkgshared' -Because 'the later same-name definition replaces the earlier one and its path resolves from the defining config'
+            $nested | Should -Not -Contain 'zzrootonlyword' -Because 'distinct enabled dictionary names accumulate across the merge'
+            $nested | Should -Not -Contain 'zzpkgonlyword'
+            $nested | Should -Contain 'zzrootshared' -Because 'the replaced same-name definition no longer supplies its words beneath the nested config'
+
+            $top | Should -Not -Contain 'zzrootshared' -Because 'the root definition still applies where no nested config overrides it'
+            $top | Should -Contain 'zzpkgshared' -Because 'the nested dictionary does not apply above the config that defines it'
+        }
+    }
+}

--- a/scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1
+++ b/scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1
@@ -48,15 +48,28 @@ BeforeAll {
             throw "The repository-pinned cspell CLI was not found at '$script:CSpellBin'. Run 'npm ci' at the repository root first."
         }
 
-        Push-Location -LiteralPath $Root
-        try {
-            $raw = & node $script:CSpellBin lint @CSpellArgs --no-progress --no-color 2>&1
-        }
-        finally {
-            Pop-Location
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = 'node'
+        $startInfo.WorkingDirectory = $Root
+        $startInfo.UseShellExecute = $false
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+
+        @($script:CSpellBin, 'lint') + $CSpellArgs + @('--no-progress', '--no-color') |
+            ForEach-Object { $null = $startInfo.ArgumentList.Add($_) }
+
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        if ($null -eq $process) {
+            throw 'Failed to start the repository-pinned cspell CLI through Node.'
         }
 
-        $lines = @($raw | ForEach-Object { $_.ToString() })
+        $standardOutput = $process.StandardOutput.ReadToEndAsync()
+        $standardError = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $raw = @($standardOutput.Result, $standardError.Result) -join [Environment]::NewLine
+        $process.Dispose()
+
+        $lines = @($raw -split '\r?\n' | Where-Object { $_ })
 
         $issues = @(
             foreach ($line in $lines) {


### PR DESCRIPTION
# Pull Request

## Description

Replace the CSpell prompt's arbitrary first-match configuration rule with invocation-bound resolution, and add deterministic and advisory coverage for configuration precedence and dictionary activation.

The prompt now starts from the project command, distinguishes the invocation base from per-file overlays, follows imports and search controls, and asks the user when evidence does not identify one authoritative mutation target. A hermetic Pester oracle covers seven resolver scenarios against the repository-pinned CSpell version, while the existing advisory stimulus now checks the corresponding agent decisions.

## Related Issue(s)

None.

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [x] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [x] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Sample Prompts (for AI Artifact Contributions)

**User Request:**

Update this project's CSpell configuration with its recurring project terms without changing an unused config or inactive dictionary.

**Execution Flow:**

The prompt identifies the installed CSpell version and project command, resolves its base and per-file configurations, follows imports and enabled dictionary references, and asks for direction when the write target remains ambiguous. It then validates with the same command, working directory, and search flags.

**Output Artifacts:**

The invoked prompt updates only the configuration or active dictionary selected by the project's effective CSpell settings and reports the selected and unselected candidates.

**Success Indicators:**

The same project command reports a meaningful issue reduction, and the response identifies the invocation-base config, applicable local config, written target, and unselected candidates.

For detailed contribution requirements, see:

* Common Standards: [docs/contributing/ai-artifacts-common.md](../docs/contributing/ai-artifacts-common.md) - Shared standards for XML blocks, markdown quality, RFC 2119, validation, and testing
* Agents: [docs/contributing/custom-agents.md](../docs/contributing/custom-agents.md) - Agent configurations with tools and behavior patterns
* Prompts: [docs/contributing/prompts.md](../docs/contributing/prompts.md) - Workflow-specific guidance with template variables
* Instructions: [docs/contributing/instructions.md](../docs/contributing/instructions.md) - Technology-specific standards with glob patterns
* Skills: [docs/contributing/skills.md](../docs/contributing/skills.md) - Task execution utilities with cross-platform scripts

## Testing

* `npm run test:ps -- -TestPath scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1`: passed, 11 tests
* `wsl.exe -e sh -lc 'cd /mnt/c/Users/wberry/src/hve-core && npm run test:ps -- -TestPath scripts/tests/evals/CSpellConfigPrecedence.Tests.ps1'`: passed, 11 tests after preserving literal CSpell arguments across the PowerShell process boundary
* `npm run lint:md`: passed
* `npm run lint:frontmatter`: passed
* `npm run lint:yaml`: passed
* `npm run spell-check`: passed, 820 files and 0 issues
* `npm run docs:generate:check`: passed
* `npm run lint:asset-docs`: passed
* `npm run plugin:validate`: passed
* `npm run validate:copyright`: passed, 687 files compliant
* `pwsh -NoProfile -File scripts/evals/Build-AgentBehaviorSpec.ps1 -WhatIf`: passed, no drift
* `npm exec -- vally lint --eval-spec evals/`: passed with 35 pre-existing warnings outside the changed stimulus
* `pwsh -NoProfile -File scripts/evals/Test-VallyTestSafety.ps1 -OutputPath logs/vally-test-safety.json`: passed, 108 files and 0 matches
* `pwsh -NoProfile -File scripts/evals/Test-EvalSpecText.ps1 -CorpusGlob '.github/prompts/experimental/**/*.md' -OutputPath logs/cspell-pr-text.json`: passed with 0 errors and 2 pre-existing warnings
* Changed-test PSScriptAnalyzer result: passed before the broader repository scan stalled
* Eval schema: previously passed during implementation; the PR preflight rerun stalled without diagnostics and remains pending in hosted CI

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [x] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions

* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [ ] Local validation aggregate: `npm run validate:local`
* [ ] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [ ] Link validation: `npm run lint:md-links`

## Security Considerations

* [ ] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes

The generated reference index was already stale at 78 skills; the required generator refreshed it to the current 79-skill count. The first hosted PowerShell test run exposed Linux wildcard preprocessing in the new oracle helper; repair commit `31745608b` passes all 11 scenarios on Windows and WSL Linux. Model-backed behavior evaluation and content moderation require hosted prerequisites and remain pending CI. Qualified human RAI review remains pending and is not represented as agent-completed.