### PR TITLE
docs(dataops): document synthetic-data preflight

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -3,7 +3,7 @@ title: Reference
 description: Generated reference documentation for HVE Core GenAI assets.
 sidebar_position: 0
 author: Microsoft
-ms.date: 2026-09-09
+ms.date: 2026-09-11
 ms.topic: overview
 keywords:
   - reference
@@ -18,5 +18,5 @@ This page lists the generated reference documentation, grouped by asset kind.
 | [Agents](agents/README.md)             | 60     |
 | [Instructions](instructions/README.md) | 60     |
 | [Prompts](prompts/README.md)           | 48     |
-| [Skills](skills/README.md)             | 78     |
+| [Skills](skills/README.md)             | 79     |
 <!-- END AUTO-GENERATED: index -->

--- a/docs/reference/prompts/data-science-engineering/synth-data-generate.md
+++ b/docs/reference/prompts/data-science-engineering/synth-data-generate.md
@@ -28,11 +28,21 @@ Generate synthetic data for any subject with realistic patterns and relationship
 
 ## When to use it
 
-Use this prompt when you need a notebook that produces realistic fictional data for development, demonstrations, or data-science experiments. Use approved source data instead when the work requires actual observed records.
+Use this prompt when you need a notebook that produces realistic fictional data for development, demonstrations, or data-science experiments. Use approved source data instead when the work requires actual observed records. For either mode, the `dataops` synthetic-data operation contract is the preflight authority.
 
 ## How to use it
 
-Describe the subject and optionally provide an example schema or sample structure. Confirm before generating PII-like fields, keep values fictional, and review any proposed update to an existing data source.
+Describe the subject and optionally provide an example schema or sample structure. Before
+project setup, package installation, notebook creation, source access, or generation,
+provide or create the applicable `SYNTHETIC_DATA_OPERATION_V1` preflight and run the
+`dataops` `validate` command. The preflight must contain current approved qualified-owner
+decisions; this prompt does not decide whether data or fields are sensitive. If validation
+is blocked, it stops and reports stable reason categories without reading source values.
+
+New output is the default. For `replace-local`, use one approved regular local file and
+expected SHA-256 digest, generate one candidate, and route the separately confirmed
+replacement through the `dataops` `commit-local` command so a recoverable predecessor is
+created and the original is not written by notebook code.
 
 ## Example usage
 

--- a/docs/reference/skills/data-science-engineering/dataops.md
+++ b/docs/reference/skills/data-science-engineering/dataops.md
@@ -34,6 +34,7 @@ Reach for this skill when the work touches data movement, transformation, or the
 * Deciding where schema and quality validation belongs relative to a Bronze-to-Silver boundary, and why replayability constrains that placement.
 * Writing or reviewing pytest suites for data-science and MLOps code, including which outside calls to mock and which to leave real.
 * Distinguishing a data-validation failure from model or data drift, and routing each to its own remediation path.
+* Guarding synthetic-data generation or an authorized local replacement. Read the [synthetic-data-operation-contract.md](https://github.com/microsoft/hve-core/blob/main/.github/skills/data-science-engineering/dataops/references/synthetic-data-operation-contract.md), require a current approved `SYNTHETIC_DATA_OPERATION_V1` preflight, and run its `validate` command before project setup, package installation, source access, or writes.
 
 Choose a different asset when:
 
@@ -53,3 +54,13 @@ and what does that imply for replay?
 The skill grounds the answer in its reference pack: validation runs at the Bronze-to-Silver boundary so Bronze retains the raw landed record, which preserves two distinct replay paths (replaying to exercise changed validation logic, and replaying to recover from a transformation defect).
 
 It also flags the notebook-extraction trigger when transformation logic outgrows an interactive cell, and separates transformation code from data-access code so the transformation is unit-testable without mocking storage.
+
+For synthetic-data work, validate the preflight record before any source access or write:
+
+```text
+python .github/skills/data-science-engineering/dataops/scripts/synthetic_data_operation.py validate --preflight preflight.json
+```
+
+Use `new-output` by default. For an authorized `replace-local` operation, create one
+candidate and result record, recheck the approved source digest, and route the final
+replacement through `commit-local`; do not overwrite the original from notebook code.


### PR DESCRIPTION
## Description

Synchronize the published DataOps and synthetic-data generator reference pages with the current synthetic-data operation contract.

- Document the `SYNTHETIC_DATA_OPERATION_V1` preflight and `validate` gate before setup, source access, or writes.
- Document the `new-output` default and guarded `replace-local` flow through `commit-local`.
- Link the canonical synthetic-data operation contract and refresh the generated reference index.

## Related Issue

Closes #2887

## Validation

- `npm run docs:generate` — 0 created, 1 updated, 252 unchanged.
- `npm run docs:generate:check` — passed with 0 drift.
- `npm run lint:asset-docs` — 0 errors; existing authored-content warnings only.
- `npm run validate:docs` — passed (84 Jest tests and 11 Mermaid accessibility checks).
- Targeted Markdown lint, table formatting, spell-check, changed-file link check, and `git diff --check` — passed.
- Repository-wide Markdown/frontmatter lint was locally affected only by the pre-existing untracked `AGENTS.md`, which is not part of this branch.

## Scope

Documentation-only; no runtime behavior or dependency manifests changed.