### PR TITLE
fix(evals): replace Sonnet 4.6 with Sonnet 5 in baseline equivalence

### DIFF
--- a/docs/planning/adrs/0011-define-vally-baseline-equivalence-evaluation-policy.md
+++ b/docs/planning/adrs/0011-define-vally-baseline-equivalence-evaluation-policy.md
@@ -3,7 +3,7 @@ id: "0011"
 title: "Define the Vally baseline-equivalence evaluation policy"
 description: "Define launch-based agent invocation, authoritative evidence, report-only comparison calibration, model scope, and trial posture for the baseline-equivalence suite."
 author: "HVE Core Maintainers"
-ms.date: "2026-08-21"
+ms.date: "2026-09-11"
 ms.topic: "reference"
 status: "proposed"
 proposed_date: "2026-08-01"
@@ -123,7 +123,7 @@ Copying an agent file into a workspace is not invocation. Every customized `mode
 **3. Comparison is report-only calibration until valid post-launch evidence supports a non-inferiority policy.** The 35 stimuli all carry the `equivalent` policy. Signed scores, mean, standard deviation, 95% confidence bounds, and per-stimulus dispersion are computed separately for each model. Complete-delivery evidence resolved the boundary-stimulus decision by showing that five removed guards measured lifecycle phase behavior rather than nominal model non-degradation.
 Tie ratio and Vally's all-policy aggregate fields remain diagnostics. No comparative pass or fail state exists until a later human-owned decision defines score direction, hypotheses, numeric degradation margin, confidence level, boundary inequality, missing-bound behavior, and a rule forbidding pass-seeking recalibration. Historical values from before launch-based invocation are not comparable to the first valid calibration.
 
-**4. Tiers separate local iteration from two-model calibration while preserving authoritative evidence.** `devloop` runs one selected model and remains advisory. `calibration` and `ci` run the fixed pair `gpt-5.6-luna` and `claude-sonnet-4.6`. Comparison and persona-bleed guards are report-only at every current tier.
+**4. Tiers separate local iteration from two-model calibration while preserving authoritative evidence.** `devloop` runs one selected model and remains advisory. `calibration` and `ci` run the fixed pair `gpt-5.6-luna` and `claude-sonnet-5`. Comparison and persona-bleed guards are report-only at every current tier.
 Deterministic invariants, successful agent invocation, run health, and structural data quality remain authoritative in `calibration` and `ci`; structural failures fail closed even in `devloop`.
 The former `pr` and `nightly` names remain rejected rather than aliased.
 

--- a/evals/baseline-equivalence/README.md
+++ b/evals/baseline-equivalence/README.md
@@ -2,7 +2,7 @@
 title: Baseline Equivalence Suite
 description: 'Pairs identical probes across baseline and customized environments to measure nominal behavior preservation'
 author: HVE Core Team
-ms.date: 2026-08-21
+ms.date: 2026-09-11
 ---
 
 ## Purpose
@@ -84,7 +84,7 @@ The compare invocation deliberately omits `--fail-on-regression`. Comparison is 
 | `schemaVersion`                                                      | string       | Reporting contract version. `2.1.0` is the current contract; consumers fail loudly on an unsupported major                                                                                      |
 | `agent`                                                              | string       | Agent slug under test (matches `-Agent`)                                                                                                                                                        |
 | `tier`                                                               | string       | `devloop` (one-model advisory), `calibration` (two-model report-only comparison), or `ci`; deterministic and structural evidence remains authoritative outside devloop                          |
-| `model`                                                              | string       | Primary model for the run: `devloop` resolves one model; `calibration` and `ci` run the fixed `gpt-5.6-luna` and `claude-sonnet-4.6` pair                                                       |
+| `model`                                                              | string       | Primary model for the run: `devloop` resolves one model; `calibration` and `ci` run the fixed `gpt-5.6-luna` and `claude-sonnet-5` pair                                                         |
 | `runs`                                                               | int          | Total non-errored comparison trials parsed across all `--output` JSONL files                                                                                                                    |
 | `ties`                                                               | int          | Trials with `winner: "tie"`; neither environment showed a clear preference                                                                                                                      |
 | `baselineWins`                                                       | int          | Trials with `winner: "baseline"`; the customization underperformed                                                                                                                              |

--- a/scripts/evals/Invoke-BaselineEquivalence.ps1
+++ b/scripts/evals/Invoke-BaselineEquivalence.ps1
@@ -29,8 +29,9 @@
     `.github/agents/`. Defaults to `rpi-agent`.
 
 .PARAMETER Tier
-    The harness mode. `devloop` runs a single primary model and stays advisory; `ci`
-    runs a model array for broader coverage and is authoritative. Defaults to `devloop`.
+    The harness mode. `devloop` runs a single primary model and stays advisory;
+    `calibration` and `ci` run a fixed model pair with authoritative deterministic
+    and structural evidence. Defaults to `devloop`.
     The former `pr` and `nightly` names are rejected with a migration message rather
     than aliased, so a stale caller fails loudly instead of silently selecting a
     different exit policy.
@@ -38,8 +39,8 @@
 .PARAMETER Model
     Optional explicit model id for the `devloop` tier. When supplied it overrides the
     agent's frontmatter `model:` hint and the built-in default, letting callers pin a
-    cheaper model for advisory runs. Ignored for the `ci` tier, which always runs its
-    fixed model array of `gpt-5.6-luna` and `claude-sonnet-4.6`.
+    cheaper model for advisory runs. Ignored for the `calibration` and `ci` tiers,
+    which always run the fixed pair `gpt-5.6-luna` and `claude-sonnet-5`.
 
 .PARAMETER ComparisonJudgeModel
     Model used as the `vally compare` judge. Defaults to `claude-haiku-4.5`.
@@ -207,11 +208,9 @@ function Resolve-ModelList {
     )
 
     if ($Tier -in @('calibration', 'ci')) {
-        # Two standard-tier models rather than a premium sweep. `gpt-5.5` carried a
-        # 7.5x cost multiplier for no measured gain in cross-vendor signal, and
-        # `claude-sonnet-latest` produced no trajectories at all, so a floating alias
-        # is pinned to an explicit version that the suite has actually executed.
-        return @('gpt-5.6-luna', 'claude-sonnet-4.6')
+        # Keep cross-vendor coverage pinned to explicit model IDs rather than floating
+        # aliases. Hints and overrides apply only to advisory devloop runs.
+        return @('gpt-5.6-luna', 'claude-sonnet-5')
     }
 
     if ($ModelOverride) { return @($ModelOverride) }

--- a/scripts/tests/evals/Invoke-BaselineEquivalence.Tests.ps1
+++ b/scripts/tests/evals/Invoke-BaselineEquivalence.Tests.ps1
@@ -165,10 +165,10 @@ Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
             # did not build, so the comparison would not be attributable to the model.
             $customized = @($script:Summary.plannedCommands | Where-Object { $_ -match 'customized/eval\.yaml' })
             $customized.Count | Should -Be 2
-            foreach ($model in @('gpt-5.6-luna', 'claude-sonnet-4.6')) {
+            foreach ($model in @('gpt-5.6-luna', 'claude-sonnet-5')) {
                 $line = @($customized | Where-Object { $_ -match "--model $([regex]::Escape($model)) " })
                 $line.Count | Should -Be 1
-                $line[0] | Should -Match "--skill-dir [^ ]*$([regex]::Escape($model))[\\/][^ ]*customized-skill-dir"
+                $line[0] | Should -Match ('--skill-dir "[^"]*[/\\]' + [regex]::Escape($model) + '[/\\][^"/\\]+[/\\]customized-skill-dir"')
             }
         }
 
@@ -215,8 +215,10 @@ Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
         It 'Plans the fixed two-model population' {
             $script:Summary.tier | Should -Be 'calibration'
             $script:Summary.plannedCommands.Count | Should -Be 6
-            ($script:Summary.plannedCommands -join "`n") | Should -Match 'gpt-5\.6-luna'
-            ($script:Summary.plannedCommands -join "`n") | Should -Match 'claude-sonnet-4\.6'
+            $evalModels = @($script:Summary.plannedCommands |
+                    Where-Object { $_ -match '^vally eval ' } |
+                    ForEach-Object { [regex]::Match($_, '--model (\S+) ').Groups[1].Value })
+            ($evalModels -join ',') | Should -BeExactly 'gpt-5.6-luna,gpt-5.6-luna,claude-sonnet-5,claude-sonnet-5'
         }
     }
 
@@ -275,10 +277,13 @@ Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
             ($summary.plannedCommands -join "`n") | Should -Match 'gpt-5-mini'
         }
 
-        It 'Ignores the override for the ci tier' {
+        It 'Ignores the override for the <SelectedTier> tier' -ForEach @(
+            @{ SelectedTier = 'calibration' }
+            @{ SelectedTier = 'ci' }
+        ) {
             & $script:ScriptPath `
                 -Agent 'rpi-agent' `
-                -Tier 'ci' `
+                -Tier $SelectedTier `
                 -Model 'gpt-5-mini' `
                 -RepoRoot $script:RepoRoot `
                 -OutputPath $script:OutputPath `
@@ -286,6 +291,11 @@ Describe 'Invoke-BaselineEquivalence.ps1 (dry-run)' -Tag 'Unit' {
 
             $summary = Get-Content -LiteralPath $script:OutputPath -Raw | ConvertFrom-Json
             $summary.model | Should -Be 'gpt-5.6-luna'
+            $summary.plannedCommands.Count | Should -Be 6
+            $evalModels = @($summary.plannedCommands |
+                    Where-Object { $_ -match '^vally eval ' } |
+                    ForEach-Object { [regex]::Match($_, '--model (\S+) ').Groups[1].Value })
+            ($evalModels -join ',') | Should -BeExactly 'gpt-5.6-luna,gpt-5.6-luna,claude-sonnet-5,claude-sonnet-5'
         }
     }
 
@@ -382,6 +392,30 @@ Describe 'Resolve-ModelList' -Tag 'Unit' {
         $models = Resolve-ModelList -Tier 'devloop' -Hint '' -ModelOverride ''
 
         $models | Should -Be @('gpt-5.6-luna')
+    }
+
+    It 'Selects the fixed pair for <SelectedTier> despite a hint and override' -ForEach @(
+        @{ SelectedTier = 'calibration' }
+        @{ SelectedTier = 'ci' }
+    ) {
+        $models = @(Resolve-ModelList -Tier $SelectedTier -Hint 'hint-model' -ModelOverride 'override-model')
+
+        $models | Should -HaveCount 2
+        ($models -join ',') | Should -BeExactly 'gpt-5.6-luna,claude-sonnet-5'
+    }
+
+    It 'Uses the hint when devloop has no override' {
+        $models = @(Resolve-ModelList -Tier 'devloop' -Hint 'hint-model' -ModelOverride '')
+
+        $models | Should -HaveCount 1
+        $models[0] | Should -BeExactly 'hint-model'
+    }
+
+    It 'Prefers the devloop override over the hint' {
+        $models = @(Resolve-ModelList -Tier 'devloop' -Hint 'hint-model' -ModelOverride 'override-model')
+
+        $models | Should -HaveCount 1
+        $models[0] | Should -BeExactly 'override-model'
     }
 }
 
@@ -519,18 +553,29 @@ defaults:
         Remove-Item Env:STUB_VALLY_COMPARE_MODE, Env:STUB_VALLY_BASELINE_MODE, Env:STUB_VALLY_CUSTOMIZED_MODES, Env:STUB_VALLY_CUSTOMIZED_COUNT_PATH, Env:STUB_VALLY_CALL_LOG -ErrorAction SilentlyContinue
     }
 
-    It 'Counts each failed empty compare once across ci models' {
+    It 'Counts each failed empty compare once across <SelectedTier> models' -ForEach @(
+        @{ SelectedTier = 'calibration' }
+        @{ SelectedTier = 'ci' }
+    ) {
+        $env:STUB_VALLY_CALL_LOG = Join-Path $TestDrive "model-calls-$SelectedTier.jsonl"
+
         & $script:ScriptPath `
             -Agent 'rpi-agent' `
-            -Tier 'ci' `
+            -Tier $SelectedTier `
             -RepoRoot $script:StubRepoRoot `
-            -OutputPath $script:StubOutputPath *> $null
+            -OutputPath $script:StubOutputPath `
+            -NoBaselineCache *> $null
 
         $summary = Get-Content -LiteralPath $script:StubOutputPath -Raw | ConvertFrom-Json
         $summary.runHealthFailures | Should -Be 2
         $summary.runs | Should -Be 0
         $summary.verdict | Should -Be 'fail'
         $LASTEXITCODE | Should -Be 1
+
+        $calls = @(Get-Content -LiteralPath $env:STUB_VALLY_CALL_LOG | ForEach-Object { , ($_ | ConvertFrom-Json) })
+        $evalModels = @($calls | Where-Object { $_[0] -eq 'eval' } |
+                ForEach-Object { $_[([Array]::IndexOf([object[]]$_, '--model') + 1)] })
+        ($evalModels -join ',') | Should -BeExactly 'gpt-5.6-luna,gpt-5.6-luna,claude-sonnet-5,claude-sonnet-5'
     }
 
     It 'Materializes the customization surface where the spec reads it' {


### PR DESCRIPTION
# Pull Request

## Description
Replace `claude-sonnet-4.6` with `claude-sonnet-5` in baseline-equivalence calibration and CI, retaining `gpt-5.6-luna` and cross-model coverage. The previous Sonnet ID failed session creation in an isolated CI smoke; Sonnet 5 completed the same smoke with the repository's current Vally and Copilot SDK versions.

* Update the fixed pair in `Resolve-ModelList` and clarify that both `calibration` and `ci` ignore `-Model` overrides.
* Strengthen tests for the exact model pair, baseline/customized invocations, both fixed tiers, devloop override/hint precedence, and model-specific quoted paths containing spaces. Retain the failed-comparison exit checks.
* Update the suite README and proposed ADR 0011's active model reference and review date. Preserve historical results, ADR status, lineage, and its unchecked human-review requirement.

The model ID is the only executable driver change. The comparison judge, retry policy, cache logic, invariants, execution-health checks, evidence-completeness checks, and tier-specific gates are unchanged. No workflow, dependency, eval-stimulus, or RPI customization changes are included.

## Related Issue(s)
closes #2899 

## Type of Change

Select all that apply:

**Code & Documentation:**

* [x] Bug fix (non-breaking change fixing an issue)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature causing existing functionality to change)
* [x] Documentation update

**Infrastructure & Configuration:**

* [ ] GitHub Actions workflow
* [ ] Linting configuration (markdown, PowerShell, etc.)
* [ ] Security configuration
* [ ] DevContainer configuration
* [ ] Dependency update

**AI Artifacts:**

* [ ] Reviewed contribution with `hve-builder` and addressed all actionable findings
* [ ] Copilot instructions (`.github/instructions/*.instructions.md`)
* [ ] Copilot prompt (`.github/prompts/*.prompt.md`)
* [ ] Copilot agent (`.github/agents/*.agent.md`)
* [ ] Copilot skill (`.github/skills/*/SKILL.md`)
* [ ] Copilot hook (`.github/hooks/*/*.json`)
* [ ] Eval spec added/updated for changed AI artifacts (`evals/`)

> Note for AI Artifact Contributors:
>
> * Agents: Research, indexing/referencing other project (using standard VS Code GitHub Copilot/MCP tools), planning, and general implementation agents likely already exist. Review `.github/agents/` before creating new ones.
> * Skills: Must include both bash and PowerShell scripts. See [Skills](../docs/contributing/skills.md).
> * Model Versions: Contributions **MUST** target models listed in the model catalog (`scripts/linting/model-catalog.json`) whose provider appears in `providerAllowlist` and whose status is `ga` or `preview`. Run `npm run lint:models` to validate references.
> * See [Agents Not Accepted](../docs/contributing/custom-agents.md#agents-not-accepted) and [Model Version Requirements](../docs/contributing/ai-artifacts-common.md#model-version-requirements).

**Other:**

* [x] Script/automation (`.ps1`, `.sh`, `.py`)
* [ ] Other (please describe):

## Testing
Targeted local tests passed for the source changes committed in `a019935be9fcc12c160dfbc24d1810f226105fb7`:

| Command | Result |
|---|---|
| `npm.cmd run test:ps -- -TestPath scripts/tests/evals/Invoke-BaselineEquivalence.Tests.ps1 -Tag Unit` | 65 passed |
| `npm.cmd run test:ps -- -TestPath scripts/tests/evals/EquivalenceParsing.Tests.ps1 -Tag Unit` | 171 passed |
| `npm.cmd run test:ps -- -TestPath scripts/tests/evals/Invoke-VallyEvals.Tests.ps1 -Tag Unit` | 52 passed; 31 non-selected tests not run |

Total: **288 passing unit tests**. These use dry-run or stubbed execution, not live model calls. Before changing the selector, the strengthened driver tests produced eight expected failures for the old model ID; all 65 driver tests passed after the change.

Additional checks passed:

* `Invoke-ScriptAnalyzer` with `scripts/linting/PSScriptAnalyzer.psd1` for both changed PowerShell files: zero findings, refreshed during PR preparation.
* `Validate-MarkdownFrontmatter.ps1 -Files ... -EnableSchemaValidation -WarningsAsErrors` for both changed Markdown files: zero errors or warnings, refreshed during PR preparation.
* `python .github/skills/project-planning/adr-author/scripts/scan_sensitive_content.py --public` against the candidate ADR text on stdin before its write: completed with zero findings.
* PowerShell parser/token comparison: the model ID is the only executable driver change.
* Exact documentation comparison: only the active model ID, dates, and retained table padding changed; ADR approval and lineage fields are preserved.
* Editor diagnostics and committed-diff `git diff --check`: no errors.

### Prior isolated CI evidence

These separate diagnostic runs support model availability; they are not full calibration of this PR:

* [Sonnet 4.6 smoke](https://github.com/microsoft/hve-core/actions/runs/34641849901): all four cells reported the target absent from the catalog and failed session creation with `model-unavailable`.
* [Sonnet 5 smoke](https://github.com/microsoft/hve-core/actions/runs/34644305911): all four cells found the target, completed the expected response, requested no tool permissions, and cleaned up successfully.
* [Diagnostic model-only change](https://github.com/microsoft/hve-core/commit/fb40bccbc517b512cca117c191c885596079ad00): changed only the requested model ID.

The matrix covered Vally `0.14.0`/`0.15.0` and Copilot SDK `1.0.9`/`1.0.11`, holding CLI `1.0.80` fixed. Recorded per-cell lock and CLI fingerprints matched across the two model tests. This includes the current Vally `0.15.0` and SDK `1.0.9` combination without a dependency upgrade.

## Checklist

### Required Checks

* [x] Documentation is updated (if applicable)
* [x] Files follow existing naming conventions
* [ ] Changes are backwards compatible (if applicable)
* [x] Tests added for new functionality (if applicable)

### AI Artifact Contributions
<!-- If contributing an agent, prompt, instruction, or skill, complete these checks -->
* [ ] Used `hve-builder` review mode to review contribution
* [ ] Addressed all actionable findings from the `hve-builder` review
* [ ] Verified contribution follows common standards and type-specific requirements

### Required Local Checks

The following local-safe validation commands must pass before merging:

* [x] Local validation aggregate: `npm run validate:local`
* [x] Documentation validation (if docs changed): `npm run validate:docs`
* [x] Spell checking: `npm run spell-check`
* [x] Link validation: `npm run lint:md-links`

## Security Considerations
<!-- ⚠️ WARNING: Do not commit sensitive information such as API keys, passwords, or personal data -->
* [x] This PR does not contain any sensitive or NDA information
* [ ] Any new dependencies have been reviewed for security issues
* [ ] Security-related scripts follow the principle of least privilege

## Additional Notes
<!-- Any additional information that reviewers should know -->
